### PR TITLE
Artifact part list typo

### DIFF
--- a/ArtifactOntology.ttl
+++ b/ArtifactOntology.ttl
@@ -2924,7 +2924,7 @@ cco:PartRole rdf:type owl:Class ;
 ###  http://www.ontologyrepository.com/CommonCoreOntologies/PartsList
 cco:PartsList rdf:type owl:Class ;
               rdfs:subClassOf cco:QualitySpecification ;
-              cco:definition "A Quality Specification that prescribes the Amount of some type of Artifact that are part of or located on anotther Artifact."@en ;
+              cco:definition "A Quality Specification that prescribes the Amount of some type of Artifact that are part of or located on another Artifact."@en ;
               cco:is_curated_in_ontology "http://www.ontologyrepository.com/CommonCoreOntologies/Mid/ArtifactOntology"^^xsd:anyURI ;
               rdfs:label "Parts List"@en .
 

--- a/cco-merged/MergedAllCoreOntology-v1.4-2023-04-07.ttl
+++ b/cco-merged/MergedAllCoreOntology-v1.4-2023-04-07.ttl
@@ -13079,7 +13079,7 @@ cco:PartRole rdf:type owl:Class ;
 ###  http://www.ontologyrepository.com/CommonCoreOntologies/PartsList
 cco:PartsList rdf:type owl:Class ;
               rdfs:subClassOf cco:QualitySpecification ;
-              cco:definition "A Quality Specification that prescribes the Amount of some type of Artifact that are part of or located on anotther Artifact."@en ;
+              cco:definition "A Quality Specification that prescribes the Amount of some type of Artifact that are part of or located on another Artifact."@en ;
               cco:is_curated_in_ontology "http://www.ontologyrepository.com/CommonCoreOntologies/Mid/ArtifactOntology"^^xsd:anyURI ;
               rdfs:label "Parts List"@en .
 


### PR DESCRIPTION
@mark-jensen @johnbeve 
Fixed typo in definition of part list in both the artifact ontology and merged file