### PR TITLE
Issue #176 Fix

### DIFF
--- a/EventOntology.ttl
+++ b/EventOntology.ttl
@@ -741,7 +741,7 @@ cco:ActOfPilgrimage rdf:type owl:Class ;
 ###  http://www.ontologyrepository.com/CommonCoreOntologies/ActOfPlanning
 cco:ActOfPlanning rdf:type owl:Class ;
                   rdfs:subClassOf cco:IntentionalAct ;
-                  cco:definition "A Planned Act that involves making a Plan to achieve some specified Objective."@en ;
+                  cco:definition "A Directed Act that involves making a Plan to achieve some specified Objective."@en ;
                   cco:is_curated_in_ontology "http://www.ontologyrepository.com/CommonCoreOntologies/Mid/EventOntology"^^xsd:anyURI ;
                   rdfs:label "Act of Planning"@en .
 

--- a/EventOntology.ttl
+++ b/EventOntology.ttl
@@ -1952,10 +1952,10 @@ cco:InstantMessaging rdf:type owl:Class ;
 ###  http://www.ontologyrepository.com/CommonCoreOntologies/IntentionalAct
 cco:IntentionalAct rdf:type owl:Class ;
                    rdfs:subClassOf cco:Act ;
-                   cco:alternative_label "Intentional Act"@en ;
+                   cco:alternative_label "Intended Act"@en ;
                    cco:definition "An Act in which at least one Agent plays a causative role and which is prescribed by some Directive Information Content Entity held by at least one of the Agents."@en ;
                    cco:is_curated_in_ontology "http://www.ontologyrepository.com/CommonCoreOntologies/Mid/EventOntology"^^xsd:anyURI ;
-                   rdfs:label "Planned Act"@en .
+                   rdfs:label "Directed Act"@en .
 
 
 ###  http://www.ontologyrepository.com/CommonCoreOntologies/InverseSawtoothWaveform


### PR DESCRIPTION
I changed the rdfs label of 'Planned Act' to 'Directed Act' and changed the alt label to 'Intended Act'. I also changed the def of 'Act of planning' such that the genus is 'Directed Act'.

If these changes are accepted, more changes will need to be made since all the subclasses of 'Directed Act' would be defined in terms of 'Planned Act'. However, these changes are outside the scope of this issue. Nor are they obvious since some of them may still need to be planned acts, thus requiring the addition of a 'planned act' class.