### PR TITLE
Erasing comment on describes from InformationEntityOntology.ttl

### DIFF
--- a/InformationEntityOntology.ttl
+++ b/InformationEntityOntology.ttl
@@ -51,7 +51,6 @@ cco:describes rdf:type owl:ObjectProperty ;
                                    "the content of a visitor's log describes some facility visit" ,
                                    "the content of an accident report describes some accident" ;
               cco:is_curated_in_ontology "http://www.ontologyrepository.com/CommonCoreOntologies/Mid/InformationEntityOntology"^^xsd:anyURI ;
-              rdfs:comment "It is possible that this relation should be a functional property, that is for all x, y, z if x describes y and x describes z then y = z. For example, if a financial report x describes the quarterly results of a company y and that same financial report describes the quarterly results of a company z, then it should be inferred that companies y and z are the same. We refrained from classifying the relation as a functional property on the concern that descriptions are multifaceted and so consequently it may be that the same report would contain descriptions of multiple entities."@en ;
               rdfs:label "describes"@en .
 
 


### PR DESCRIPTION
The original comment that cco:describes might ought to be functional also acknowledges that some descriptions are about multiple things. It follows that since these cases of description are not functional, the comment can be removed without sacrificing any of the property's semantics.

 Still, functional descriptions could allow for useful automated reasoning. It may be worth considering the topic in a discussion thread where others share more use cases.