### PR TITLE
fixes #306 term request

### DIFF
--- a/src/cco-modules/InformationEntityOntology.ttl
+++ b/src/cco-modules/InformationEntityOntology.ttl
@@ -1023,8 +1023,8 @@ cco:ModePointEstimateInformationContentEntity rdf:type owl:Class ;
                                               rdfs:label "Mode Point Estimate Information Content Entity"@en .
 
 
-###  http://www.ontologyrepository.com/CommonCoreOntologies/NautralLanguage
-cco:NautralLanguage rdf:type owl:Class ;
+###  http://www.ontologyrepository.com/CommonCoreOntologies/NaturalLanguage
+cco:NaturalLanguage rdf:type owl:Class ;
                     rdfs:subClassOf cco:Language ;
                     cco:definition "A Language that is developed and evolves through use and repetition, rather than through conscious planning or premeditation."@en ;
                     cco:definition_source "https://en.wikipedia.org/w/index.php?title=Natural_language&oldid=1060890461"^^xsd:anyURI ;

--- a/src/cco-modules/UnitsOfMeasureOntology.ttl
+++ b/src/cco-modules/UnitsOfMeasureOntology.ttl
@@ -477,6 +477,23 @@ cco:DecibelMeasurementUnit rdf:type owl:NamedIndividual ,
                            rdfs:label "Decibel Measurement Unit"@en .
 
 
+###  http://www.ontologyrepository.com/CommonCoreOntologies/DecibelIsotropicMeasurementUnit
+cco:DecibelIsotropicMeasurementUnit rdf:type owl:NamedIndividual ,
+                                    cco:MeasurementUnitOfPower ;
+                           cco:SI_unit_symbol "dBi" ;
+                           rdfs:label "Decibel Isotropic Measurement Unit"@en ;
+                           cco:alternative_label "Decibels Relative to Isotrope" ;
+                           cco:alternative_label "Decibels Relative to Isotropic Radiator" ;
+                           cco:alternative_label "Decibels Over Isotropic" ;
+                           cco:alternative_label "Decibels Over Isotropic Antenna" ;
+                           cco:alternative_label "Decibels Relative to an Isotropic Reference Antenna" ;
+                           cco:definition_source "https://www.techtarget.com/whatis/definition/decibels-relative-to-isotropic-radiator-dBi"^^xsd:anyURI ;
+                           cco:definition_source "https://shopdelta.eu/dbi-power-gain-of-isotropic-antenna_l2_aid836.html"^^xsd:anyURI ;
+                           cco:is_curated_in_ontology "http://www.ontologyrepository.com/CommonCoreOntologies/Mid/UnitsOfMeasureOntology"^^xsd:anyURI ;
+                           dc:contributor "Donna Jones"
+                           dc:contributor "Olivia Hobai" .
+
+
 ###  http://www.ontologyrepository.com/CommonCoreOntologies/DecigramMeasurementUnit
 cco:DecigramMeasurementUnit rdf:type owl:NamedIndividual ,
                                      cco:MeasurementUnitOfMass ;


### PR DESCRIPTION
Added a new Named Individual to CCO's Unit of Measure Ontology for dBi, a Decibel Isotropic Measurement Unit originally suggested by @Donna-Jones.
Fixed a minor spelling error in the IRI for CCO's Information Entity Ontology class for Natural Language. Before, it read "Nautral". 