### PR TITLE
Update UnitsOfMeasureOntology.ttl

### DIFF
--- a/src/cco-modules/UnitsOfMeasureOntology.ttl
+++ b/src/cco-modules/UnitsOfMeasureOntology.ttl
@@ -490,8 +490,6 @@ cco:DecibelIsotropicMeasurementUnit rdf:type owl:NamedIndividual ,
                            cco:definition_source "https://www.techtarget.com/whatis/definition/decibels-relative-to-isotropic-radiator-dBi"^^xsd:anyURI ;
                            cco:definition_source "https://shopdelta.eu/dbi-power-gain-of-isotropic-antenna_l2_aid836.html"^^xsd:anyURI ;
                            cco:is_curated_in_ontology "http://www.ontologyrepository.com/CommonCoreOntologies/Mid/UnitsOfMeasureOntology"^^xsd:anyURI ;
-                           dc:contributor "Donna Jones"
-                           dc:contributor "Olivia Hobai" .
 
 
 ###  http://www.ontologyrepository.com/CommonCoreOntologies/DecigramMeasurementUnit


### PR DESCRIPTION
dc:contributor was used without declaration of dc in the prefixes, which causes this file to not open on its own. 