### PR TITLE
Update UnitsOfMeasureOntology.ttl

### DIFF
--- a/src/cco-modules/UnitsOfMeasureOntology.ttl
+++ b/src/cco-modules/UnitsOfMeasureOntology.ttl
@@ -1,5 +1,6 @@
 @prefix : <http://www.ontologyrepository.com/CommonCoreOntologies/> .
 @prefix cco: <http://www.ontologyrepository.com/CommonCoreOntologies/> .
+@prefix dc: <http://purl.org/dc/terms/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .


### PR DESCRIPTION
Introduces the prefix "@prefix dc: <http://purl.org/dc/terms/> ." to allow for dc:contributor