### PR TITLE
remove datatype range per #432

### DIFF
--- a/src/cco-modules/InformationEntityOntology.ttl
+++ b/src/cco-modules/InformationEntityOntology.ttl
@@ -453,11 +453,6 @@ cco:has_integer_value rdf:type owl:DatatypeProperty ;
 ###  http://www.ontologyrepository.com/CommonCoreOntologies/has_text_value
 cco:has_text_value rdf:type owl:DatatypeProperty ;
                    rdfs:domain cco:InformationBearingEntity ;
-                   rdfs:range [ rdf:type rdfs:Datatype ;
-                                owl:unionOf ( rdf:langString
-                                              xsd:string
-                                            )
-                              ] ;
                    cco:definition "A data property that has as its range a string value."@en ;
                    cco:is_curated_in_ontology "http://www.ontologyrepository.com/CommonCoreOntologies/Mid/InformationEntityOntology"^^xsd:anyURI ;
                    rdfs:label "has text value"@en .


### PR DESCRIPTION
removes a datatype range that causes an error in Protege 5.5