### PR TITLE
updated agent and agent capability def and axioms per #186

### DIFF
--- a/src/cco-modules/AgentOntology.ttl
+++ b/src/cco-modules/AgentOntology.ttl
@@ -1165,6 +1165,7 @@ cco:Agent rdf:type owl:Class ;
                               ] ;
           rdfs:subClassOf obo:BFO_0000040 ;
           cco:definition "A Material Entity that bears an Agent Capability."@en ;
+          cco:definition_source "Schlosser, Markus, \"Agency\", The Stanford Encyclopedia of Philosophy (Winter 2019 Edition), Edward N. Zalta (ed.), available at: https://plato.stanford.edu/archives/win2019/entries/agency/"@en ;
           cco:is_curated_in_ontology "http://www.ontologyrepository.com/CommonCoreOntologies/Mid/AgentOntology"^^xsd:anyURI ;
           rdfs:label "Agent"@en .
 
@@ -1173,6 +1174,7 @@ cco:Agent rdf:type owl:Class ;
 cco:AgentCapability rdf:type owl:Class ;
                     rdfs:subClassOf obo:BFO_0000017 ;
                     cco:definition "A Realizable Entity that inheres in a Material Entity to the extent of that Material Entity's capacity to realize it in Planned Acts of a certain type."@en ;
+                    cco:definition_source "Schlosser, Markus, \"Agency\", The Stanford Encyclopedia of Philosophy (Winter 2019 Edition), Edward N. Zalta (ed.), available at: https://plato.stanford.edu/archives/win2019/entries/agency/"@en ;
                     cco:is_curated_in_ontology "http://www.ontologyrepository.com/CommonCoreOntologies/Mid/AgentOntology"^^xsd:anyURI ;
                     rdfs:label "Agent Capability"@en .
 

--- a/src/cco-modules/AgentOntology.ttl
+++ b/src/cco-modules/AgentOntology.ttl
@@ -1157,14 +1157,14 @@ cco:Affordance rdf:type owl:Class ;
 cco:Agent rdf:type owl:Class ;
           owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000040
                                                      [ rdf:type owl:Restriction ;
-                                                       owl:onProperty cco:agent_in ;
-                                                       owl:someValuesFrom obo:BFO_0000015
+                                                       owl:onProperty obo:BFO_0000196 ;
+                                                       owl:someValuesFrom cco:AgentCapability
                                                      ]
                                                    ) ;
                                 rdf:type owl:Class
                               ] ;
           rdfs:subClassOf obo:BFO_0000040 ;
-          cco:definition "A Material Entity that is capable of performing Planned Acts"@en ;
+          cco:definition "A Material Entity that bears an Agent Capability."@en ;
           cco:is_curated_in_ontology "http://www.ontologyrepository.com/CommonCoreOntologies/Mid/AgentOntology"^^xsd:anyURI ;
           rdfs:label "Agent"@en .
 
@@ -1172,7 +1172,7 @@ cco:Agent rdf:type owl:Class ;
 ###  http://www.ontologyrepository.com/CommonCoreOntologies/AgentCapability
 cco:AgentCapability rdf:type owl:Class ;
                     rdfs:subClassOf obo:BFO_0000017 ;
-                    cco:definition "A Realizable Entity that inheres in an Agent to the extent of that Agent's capacity to realize it in Intentional Acts of a certain type."@en ;
+                    cco:definition "A Realizable Entity that inheres in a Material Entity to the extent of that Material Entity's capacity to realize it in Planned Acts of a certain type."@en ;
                     cco:is_curated_in_ontology "http://www.ontologyrepository.com/CommonCoreOntologies/Mid/AgentOntology"^^xsd:anyURI ;
                     rdfs:label "Agent Capability"@en .
 


### PR DESCRIPTION
I can adjust or revert any of the changes in this pr, but now 'Intentional Act' is no longer referenced and 'Agent' is not referred to in the definition of Agent Capability. I also added a definition source, but I can remove or change that.