### PR TITLE
repair cco superclass query

### DIFF
--- a/.github/deployment/sparql/CCO_classes_have_BFO_superclass.sparql
+++ b/.github/deployment/sparql/CCO_classes_have_BFO_superclass.sparql
@@ -13,7 +13,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 SELECT DISTINCT ?class ?label
 WHERE {
 ?class a owl:Class .
-FILTER contains(str(?class),"http://www.ontologyrepository.com/CommonCoreOntologies/")
+FILTER (regex(str(?class),"http://www.ontologyrepository.com/CommonCoreOntologies/"))
 FILTER NOT EXISTS {?class rdfs:subClassOf+ <http://purl.obolibrary.org/obo/BFO_0000001> }
 OPTIONAL {?class rdfs:label ?label}
 }


### PR DESCRIPTION
Query requiring CCO classes fall under BFO was returning >100 false positives. Tried to test in protege, but 'contains' not supported. Replaced 'contains' with 'regex' and  tested. No false positives in protege. 

Let's see if false positives are generated in the build after this update. 