### PR TITLE
corrected def of is temporal region of per #262

### DIFF
--- a/src/cco-modules/ExtendedRelationOntology.ttl
+++ b/src/cco-modules/ExtendedRelationOntology.ttl
@@ -613,7 +613,7 @@ cco:is_temporal_region_of rdf:type owl:ObjectProperty ;
                                                      obo:BFO_0000035
                                                    )
                                      ] ;
-                          cco:definition "x is_temporal_region_of y iff y is an instance of a process or process boundary and x is an instance of a temporal region, such that the duration of x temporally projects on y."@en ;
+                          cco:definition "t is temporal region of p = def p occupies temporal region t."@en ;
                           cco:is_curated_in_ontology "http://www.ontologyrepository.com/CommonCoreOntologies/Mid/ExtendedRelationOntology"^^xsd:anyURI ;
                           rdfs:label "is temporal region of"@en ;
                           skos:editorialNote "Leaving this is in ERO for now since BFO2020 has no inverse of occupies-temporal-region yet."@en .


### PR DESCRIPTION
as @alanruttenberg has pointed out under this issue #262 , we should standardize how we write object property definitions including the inverses--maybe we can accomplish that under 2.1.