### PR TITLE
Update Makefile for 2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 # ----------------------------------------
 # Project essentials
 config.ONTOLOGY_PREFIX := CCO
-config.BASE_IRI := http://www.ontologyrepository.com/CommonCoreOntologies/Mid/
+config.BASE_IRI := https://www.commoncoreontologies.org/
 config.DEV_IRI := $(config.BASE_IRI)/dev
 config.MODULES_IRI := $(config.DEV_IRI)/modules
 


### PR DESCRIPTION
The config.BASE_IRI has changed in 2.0 from: 
- http://www.ontologyrepository.com/CommonCoreOntologies/Mid/
to 
- https://www.commoncoreontologies.org/
The Makefile must be updated to run actions. 