### PR TITLE
Direct Build to Local Files Since IRIs Not Resolving

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ $(ROBOT_FILE): setup
 reason-individual: $(ROBOT_FILE)
 	for file in $(DEV_FILES); do \
 		echo "Reasoning on $$file..."; \
-		java -jar $(ROBOT_FILE) reason --input $$file --reasoner HermiT; \
+		java -jar $(ROBOT_FILE) reason --input $$file --catalog src/cco-modules/catalog-v001.xml --reasoner HermiT; \
 	done
 
 # Test individual files
@@ -104,7 +104,7 @@ build-combined: $(combined-file)
 
 .PHONY: reason-combined test-combined
 reason-combined: $(combined-file) | $(ROBOT_FILE)
-	java -jar $(ROBOT_FILE) reason --input $(combined-file) --reasoner HermiT
+	java -jar $(ROBOT_FILE) reason --input $(combined-file) --catalog src/cco-modules/catalog-v001.xml --reasoner HermiT
 
 test-combined: $(combined-file) | $(ROBOT_FILE)
 	java -jar $(ROBOT_FILE) verify --input $(combined-file) --output-dir $(config.REPORTS_DIR) --queries $(QUERIES) --fail-on-violation false || true

--- a/src/cco-modules/AgentOntology.ttl
+++ b/src/cco-modules/AgentOntology.ttl
@@ -25,8 +25,6 @@
 
 ###  http://purl.org/dc/terms/bibliographicCitation
 dcterms:bibliographicCitation rdf:type owl:AnnotationProperty .
-dcterms:bibliographicCitation rdf:type owl:AnnotationProperty .
-
 
 ###  http://purl.org/dc/terms/created
 dcterms:created rdf:type owl:AnnotationProperty .

--- a/src/cco-modules/AgentOntology.ttl
+++ b/src/cco-modules/AgentOntology.ttl
@@ -25,6 +25,7 @@
 
 ###  http://purl.org/dc/terms/bibliographicCitation
 dcterms:bibliographicCitation rdf:type owl:AnnotationProperty .
+dcterms:bibliographicCitation rdf:type owl:AnnotationProperty .
 
 
 ###  http://purl.org/dc/terms/created


### PR DESCRIPTION
Reasoning using ROBOT default relies on resolvable IRIs; the IRIs in the 2.0 release don't resolve. Consequently, builds were failing.

I tested a fix on this branch, directing the reasoning to local ontology files by adding "-catalog src/cco-modules/catalog-v001.xml" to lines 86 and 107 of the Makefile. The build completed on this branch with this update. 

I'm now pushing the Makefile update to develop.  