### PR TITLE
Modified Makefile to download robot.jar selectively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,8 @@ setup:
 # Download ROBOT JAR
 ROBOT_FILE := $(config.LIBRARY_DIR)/robot.jar
 $(ROBOT_FILE): setup
-	curl -L -o $@ https://github.com/ontodev/robot/releases/download/v1.8.4/robot.jar
-	chmod +x $@
+	if [ ! -f $@ ] ; then echo Downloading $@ ; curl -L -o $@ https://github.com/ontodev/robot/releases/download/v1.8.4/robot.jar ; fi
+	if [ ! -x $@ ] ; then chmod +x $@ ; fi
 
 # Reason individual files
 .PHONY: reason-individual

--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,9 @@ setup:
 
 # Download ROBOT JAR
 ROBOT_FILE := $(config.LIBRARY_DIR)/robot.jar
-$(ROBOT_FILE): setup
-	if [ ! -f $@ ] ; then echo Downloading $@ ; curl -L -o $@ https://github.com/ontodev/robot/releases/download/v1.8.4/robot.jar ; fi
-	if [ ! -x $@ ] ; then chmod +x $@ ; fi
+$(ROBOT_FILE): | $(config.LIBRARY_DIR)
+	curl -L -o $@ https://github.com/ontodev/robot/releases/download/v1.8.4/robot.jar
+	chmod +x $@
 
 # Reason individual files
 .PHONY: reason-individual


### PR DESCRIPTION
The Makefile tests whether build/lib/robot.jar already exists, and skips downloading if it does.