### PR TITLE
#584 - Relabels Directive ICE as Prescriptive ICE. Changes Designativ…

### DIFF
--- a/src/cco-modules/InformationEntityOntology.ttl
+++ b/src/cco-modules/InformationEntityOntology.ttl
@@ -1,24 +1,24 @@
 @prefix : <https://www.commoncoreontologies.org/InformationEntityOntology/> .
+@prefix cco: <https://www.commoncoreontologies.org/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix cco: <https://www.commoncoreontologies.org/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@base <https://www.commoncoreontologies.org/InformationEntityOntology> .
+@base <https://www.commoncoreontologies.org/InformationEntityOntology/> .
 
 <https://www.commoncoreontologies.org/InformationEntityOntology> rdf:type owl:Ontology ;
-                                                                                        owl:versionIRI <https://www.commoncoreontologies.org/2024-11-06/InformationEntityOntology> ;
-                                                                                        owl:imports <https://www.commoncoreontologies.org/GeospatialOntology> ,
-                                                                                                    <https://www.commoncoreontologies.org/TimeOntology> ;
-                                                                                        dcterms:license "BSD 3-Clause: https://github.com/CommonCoreOntology/CommonCoreOntologies/blob/master/LICENSE"@en ;
-                                                                                        dcterms:rights "CUBRC Inc., see full license."@en ;
-                                                                                        rdfs:comment "This ontology is designed to represent generic types of information as well as the relationships between information and other entities."@en ;
-                                                                                        rdfs:label "Information Entity Ontology"@en ;
-                                                                                        owl:versionInfo "Version 2.0"@en .
+                                                                  owl:versionIRI <https://www.commoncoreontologies.org/2024-11-06/InformationEntityOntology> ;
+                                                                  owl:imports cco:GeospatialOntology ,
+                                                                              cco:TimeOntology ;
+                                                                  dcterms:license "BSD 3-Clause: https://github.com/CommonCoreOntology/CommonCoreOntologies/blob/master/LICENSE"@en ;
+                                                                  dcterms:rights "CUBRC Inc., see full license."@en ;
+                                                                  rdfs:comment "This ontology is designed to represent generic types of information as well as the relationships between information and other entities."@en ;
+                                                                  rdfs:label "Information Entity Ontology"@en ;
+                                                                  owl:versionInfo "Version 2.0"@en .
 
 #################################################################
 #    Annotation properties
@@ -46,362 +46,362 @@ cco:ont00001760 rdf:type owl:AnnotationProperty .
 
 ###  https://www.commoncoreontologies.org/ont00001801
 cco:ont00001801 rdf:type owl:ObjectProperty ;
-                 owl:inverseOf cco:ont00001808 ;
-                 rdfs:range cco:ont00000958 ;
-                 rdfs:label "is subject of"@en ;
-                 skos:definition "A primitive relationship between an instance of an Entity and an instance of an Information Content Entity."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                owl:inverseOf cco:ont00001808 ;
+                rdfs:range cco:ont00000958 ;
+                rdfs:label "is subject of"@en ;
+                skos:definition "A primitive relationship between an instance of an Entity and an instance of an Information Content Entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001808
 cco:ont00001808 rdf:type owl:ObjectProperty ;
-                 rdfs:domain cco:ont00000958 ;
-                 rdfs:range obo:BFO_0000001 ;
-                 rdfs:label "is about"@en ;
-                 skos:definition "A primitive relationship between an Information Content Entity and some Entity."@en ;
-                 cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000136" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:domain cco:ont00000958 ;
+                rdfs:range obo:BFO_0000001 ;
+                rdfs:label "is about"@en ;
+                skos:definition "A primitive relationship between an Information Content Entity and some Entity."@en ;
+                cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000136" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001811
 cco:ont00001811 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001966 ;
-                 owl:inverseOf cco:ont00001963 ;
-                 rdfs:domain cco:ont00001010 ;
-                 rdfs:label "is a ordinal measurement of"@en ;
-                 skos:definition "x is_a_ordinal_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale ordered by rank."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001966 ;
+                owl:inverseOf cco:ont00001963 ;
+                rdfs:domain cco:ont00001010 ;
+                rdfs:label "is a ordinal measurement of"@en ;
+                skos:definition "x is_a_ordinal_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale ordered by rank."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001824
 cco:ont00001824 rdf:type owl:ObjectProperty ;
-                 rdfs:domain cco:ont00000253 ;
-                 rdfs:range cco:ont00000253 ;
-                 rdfs:label "is excerpted from"@en ;
-                 skos:definition "An Information Bearing Entity b1 is excerpted from another Information Bearing Entity B2 iff b1 is part of some Information Bearing Entity B1 that is carrier of some Information Content Entity C1, B2 is carrier of some Information Content Entity C2, C1 is not identical with C2, b1 is carrier of some Information Content Entity c1, b2 is an Information Bearing Entity that is part of B2 and b2 is carrier of c1 (i.e. the same Information Content Entity as borne by b1)."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range cco:ont00000253 ;
+                rdfs:label "is excerpted from"@en ;
+                skos:definition "An Information Bearing Entity b1 is excerpted from another Information Bearing Entity B2 iff b1 is part of some Information Bearing Entity B1 that is carrier of some Information Content Entity C1, B2 is carrier of some Information Content Entity C2, C1 is not identical with C2, b1 is carrier of some Information Content Entity c1, b2 is an Information Bearing Entity that is part of B2 and b2 is carrier of c1 (i.e. the same Information Content Entity as borne by b1)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001837
 cco:ont00001837 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf obo:BFO_0000084 ;
-                 owl:inverseOf cco:ont00001908 ;
-                 rdfs:domain cco:ont00000829 ;
-                 rdfs:range cco:ont00000253 ;
-                 rdfs:label "time zone identifier used by"@en ;
-                 skos:definition "x time_zone_identifier_used_by y iff y is an instance of Information Bearing Entity and x is an instance of Time Zone Identifier, such that x designates the spatial region associated with the time zone mentioned in y."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf obo:BFO_0000084 ;
+                owl:inverseOf cco:ont00001908 ;
+                rdfs:domain cco:ont00000829 ;
+                rdfs:range cco:ont00000253 ;
+                rdfs:label "time zone identifier used by"@en ;
+                skos:definition "x time_zone_identifier_used_by y iff y is an instance of Information Bearing Entity and x is an instance of Time Zone Identifier, such that x designates the spatial region associated with the time zone mentioned in y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001863
 cco:ont00001863 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf obo:BFO_0000101 ;
-                 owl:inverseOf cco:ont00001961 ;
-                 rdfs:domain cco:ont00000253 ;
-                 rdfs:range cco:ont00000120 ;
-                 rdfs:label "uses measurement unit"@en ;
-                 skos:definition "y uses_measurement_unit x iff y is an instance of Information Bearing Entity and x is an instance of Measurement Unit, such that x describes the magnitude of measured physical quantity mentioned in y."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf obo:BFO_0000101 ;
+                owl:inverseOf cco:ont00001961 ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range cco:ont00000120 ;
+                rdfs:label "uses measurement unit"@en ;
+                skos:definition "y uses_measurement_unit x iff y is an instance of Information Bearing Entity and x is an instance of Measurement Unit, such that x describes the magnitude of measured physical quantity mentioned in y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001868
 cco:ont00001868 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001966 ;
-                 owl:inverseOf cco:ont00001914 ;
-                 rdfs:domain cco:ont00000293 ;
-                 rdfs:label "is a nominal measurement of"@en ;
-                 skos:definition "x is_a_nominal_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x classifies y relative to some set of shared, possibly arbitrary, characteristics."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001966 ;
+                owl:inverseOf cco:ont00001914 ;
+                rdfs:domain cco:ont00000293 ;
+                rdfs:label "is a nominal measurement of"@en ;
+                skos:definition "x is_a_nominal_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x classifies y relative to some set of shared, possibly arbitrary, characteristics."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001873
 cco:ont00001873 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001801 ;
-                 owl:inverseOf cco:ont00001938 ;
-                 rdfs:range cco:ont00001069 ;
-                 rdfs:comment "See notes for inverse property." ;
-                 rdfs:label "represented by"@en ;
-                 skos:definition "y represented_by x iff x is an instance of Information Content Entity, and y is an instance of Entity, and z is carrier of x, such that x is about y in virtue of there existing an isomorphism between characteristics of z and y."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001801 ;
+                owl:inverseOf cco:ont00001938 ;
+                rdfs:range cco:ont00001069 ;
+                rdfs:comment "See notes for inverse property." ;
+                rdfs:label "represented by"@en ;
+                skos:definition "y represented_by x iff x is an instance of Information Content Entity, and y is an instance of Entity, and z is carrier of x, such that x is about y in virtue of there existing an isomorphism between characteristics of z and y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001877
 cco:ont00001877 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001966 ;
-                 owl:inverseOf cco:ont00001964 ;
-                 rdfs:domain cco:ont00001364 ;
-                 rdfs:label "is a interval measurement of"@en ;
-                 skos:definition "x is_a_interval_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale which has uniform intervals but has a zero value that does not correspond to an absence of the attribute being measured."@en ;
-                 skos:example "a measurement of air temperature on the Celsius scale." ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001966 ;
+                owl:inverseOf cco:ont00001964 ;
+                rdfs:domain cco:ont00001364 ;
+                rdfs:label "is a interval measurement of"@en ;
+                skos:definition "x is_a_interval_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale which has uniform intervals but has a zero value that does not correspond to an absence of the attribute being measured."@en ;
+                skos:example "a measurement of air temperature on the Celsius scale." ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001878
 cco:ont00001878 rdf:type owl:ObjectProperty ;
-                 owl:inverseOf cco:ont00001919 ;
-                 rdfs:label "is mention of"@en ;
-                 skos:definition "x is_mention_of y iff x is an instance Information Bearing Entity and y is an instance Entity, such that x is used as a reference to y."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                owl:inverseOf cco:ont00001919 ;
+                rdfs:label "is mention of"@en ;
+                skos:definition "x is_mention_of y iff x is an instance Information Bearing Entity and y is an instance Entity, such that x is used as a reference to y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001879
 cco:ont00001879 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001801 ;
-                 owl:inverseOf cco:ont00001916 ;
-                 rdfs:range cco:ont00000686 ;
-                 rdfs:label "designated by"@en ;
-                 skos:definition "x designated_by y iff y is an instance of Information Content Entity and x is an instance of Entity, such that given some context, y uniquely distinguishes x from other entities."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001801 ;
+                owl:inverseOf cco:ont00001916 ;
+                rdfs:range cco:ont00000686 ;
+                rdfs:label "designated by"@en ;
+                skos:definition "x designated_by y iff y is an instance of Information Content Entity and x is an instance of Entity, such that given some context, y uniquely distinguishes x from other entities."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001884
 cco:ont00001884 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001801 ;
-                 owl:inverseOf cco:ont00001980 ;
-                 owl:propertyChainAxiom ( cco:ont00001917
-                                          obo:BFO_0000176
-                                        ) ;
-                 rdfs:label "condition described by"@en ;
-                 skos:definition "c condition_described_by p iff p is an instance of a Performance Specification, and p has part d, and d is an instance of a Descriptive Information Content Entity, and p prescribes an entity s, and d describes c, and c is an entity that is causally relevant to s existing as prescribed by p."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001801 ;
+                owl:inverseOf cco:ont00001980 ;
+                owl:propertyChainAxiom ( cco:ont00001917
+                                         obo:BFO_0000176
+                                       ) ;
+                rdfs:label "condition described by"@en ;
+                skos:definition "c condition_described_by p iff p is an instance of a Performance Specification, and p has part d, and d is an instance of a Descriptive Information Content Entity, and p prescribes an entity s, and d describes c, and c is an entity that is causally relevant to s existing as prescribed by p."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001899
 cco:ont00001899 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001942 ;
-                 owl:inverseOf cco:ont00001976 ;
-                 rdfs:domain cco:ont00001175 ;
-                 rdfs:range cco:ont00000253 ;
-                 rdfs:label "language used in"@en ;
-                 skos:definition "x language_used_by y iff y is an instance of Information Bearing Entity and x is an instance of Language, such that the literal value of y is a string that is encoded according to the syntax of x."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001942 ;
+                owl:inverseOf cco:ont00001976 ;
+                rdfs:domain cco:ont00001175 ;
+                rdfs:range cco:ont00000253 ;
+                rdfs:label "language used in"@en ;
+                skos:definition "x language_used_by y iff y is an instance of Information Bearing Entity and x is an instance of Language, such that the literal value of y is a string that is encoded according to the syntax of x."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001900
 cco:ont00001900 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001997 ;
-                 owl:inverseOf cco:ont00001913 ;
-                 rdfs:domain cco:ont00000469 ;
-                 rdfs:range cco:ont00000253 ;
-                 rdfs:label "is geospatial coordinate reference system of"@en ;
-                 skos:definition "x is_geospatial_coordinate_reference_system_of y iff y is an instance of Information Bearing Entity and x is an instance of Geospatial Coordinate Reference System, such that x describes the set of standards mentioned in y."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001997 ;
+                owl:inverseOf cco:ont00001913 ;
+                rdfs:domain cco:ont00000469 ;
+                rdfs:range cco:ont00000253 ;
+                rdfs:label "is geospatial coordinate reference system of"@en ;
+                skos:definition "x is_geospatial_coordinate_reference_system_of y iff y is an instance of Information Bearing Entity and x is an instance of Geospatial Coordinate Reference System, such that x describes the set of standards mentioned in y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001904
 cco:ont00001904 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001917 ;
-                 owl:inverseOf cco:ont00001966 ;
-                 rdfs:range cco:ont00001163 ;
-                 rdfs:label "is measured by"@en ;
-                 skos:definition "y is_measured_by x iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to some scale or classification scheme."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001917 ;
+                owl:inverseOf cco:ont00001966 ;
+                rdfs:range cco:ont00001163 ;
+                rdfs:label "is measured by"@en ;
+                skos:definition "y is_measured_by x iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to some scale or classification scheme."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001908
 cco:ont00001908 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf obo:BFO_0000101 ;
-                 rdfs:domain cco:ont00000253 ;
-                 rdfs:range cco:ont00000829 ;
-                 rdfs:label "uses time zone identifier"@en ;
-                 skos:definition "x uses_time_zone_identifier y iff x is an instance of Information Bearing Entity and y is an instance of Time Zone Identifier, such that y designates the spatial region associated with the time zone mentioned in x."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf obo:BFO_0000101 ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range cco:ont00000829 ;
+                rdfs:label "uses time zone identifier"@en ;
+                skos:definition "x uses_time_zone_identifier y iff x is an instance of Information Bearing Entity and y is an instance of Time Zone Identifier, such that y designates the spatial region associated with the time zone mentioned in x."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001912
 cco:ont00001912 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf obo:BFO_0000101 ;
-                 owl:inverseOf cco:ont00001997 ;
-                 rdfs:domain cco:ont00000253 ;
-                 rdfs:range cco:ont00000398 ;
-                 rdfs:label "uses reference system"@en ;
-                 skos:definition "y uses_reference_system x iff y is an instance of Information Bearing Entity and x is an instance of Reference System, such that x describes the set of standards mentioned in y."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf obo:BFO_0000101 ;
+                owl:inverseOf cco:ont00001997 ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range cco:ont00000398 ;
+                rdfs:label "uses reference system"@en ;
+                skos:definition "y uses_reference_system x iff y is an instance of Information Bearing Entity and x is an instance of Reference System, such that x describes the set of standards mentioned in y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001913
 cco:ont00001913 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001912 ;
-                 rdfs:domain cco:ont00000253 ;
-                 rdfs:range cco:ont00000469 ;
-                 rdfs:label "uses geospatial coordinate reference system"@en ;
-                 skos:definition "y uses_geospatial_coordinate_reference_system x iff y is an instance of Information Bearing Entity and x is an instance of Geospatial Coordinate Reference System, such that x describes the set of standards mentioned in y."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001912 ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range cco:ont00000469 ;
+                rdfs:label "uses geospatial coordinate reference system"@en ;
+                skos:definition "y uses_geospatial_coordinate_reference_system x iff y is an instance of Information Bearing Entity and x is an instance of Geospatial Coordinate Reference System, such that x describes the set of standards mentioned in y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001914
 cco:ont00001914 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001904 ;
-                 rdfs:range cco:ont00000293 ;
-                 rdfs:label "is measured by nominal"@en ;
-                 skos:definition "y is_measured_by_nominal x iff x is an instance of Information Content Entity and y is an instance of Entity, such that x classifies y relative to some set of shared, possibly arbitrary, characteristics."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001904 ;
+                rdfs:range cco:ont00000293 ;
+                rdfs:label "is measured by nominal"@en ;
+                skos:definition "y is_measured_by_nominal x iff x is an instance of Information Content Entity and y is an instance of Entity, such that x classifies y relative to some set of shared, possibly arbitrary, characteristics."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001916
 cco:ont00001916 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001808 ;
-                 rdfs:domain cco:ont00000686 ;
-                 rdfs:label "designates"@en ;
-                 skos:definition "x designates y iff x is an instance of an Information Content Entity, and y is an instance of an Entity, such that given some context, x uniquely distinguishes y from other entities."@en ;
-                 skos:example "a URL designates the location of a Web Page on the internet" ,
-                              "a person's name designates that person" ,
-                              "a vehicle identification number designates some vehicle" ;
-                 skos:scopeNote "Given a stronger temporal interpretation, this property may be functional. For more info please refer to https://github.com/BFO-ontology/BFO-2020/tree/master/src/owl/temporal%20extensions."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001808 ;
+                rdfs:domain cco:ont00000686 ;
+                rdfs:label "designates"@en ;
+                skos:definition "x designates y iff x is an instance of an Information Content Entity, and y is an instance of an Entity, such that given some context, x uniquely distinguishes y from other entities."@en ;
+                skos:example "a URL designates the location of a Web Page on the internet" ,
+                             "a person's name designates that person" ,
+                             "a vehicle identification number designates some vehicle" ;
+                skos:scopeNote "Given a stronger temporal interpretation, this property may be functional. For more info please refer to https://github.com/BFO-ontology/BFO-2020/tree/master/src/owl/temporal%20extensions."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001917
 cco:ont00001917 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001801 ;
-                 owl:inverseOf cco:ont00001982 ;
-                 rdfs:range cco:ont00000853 ;
-                 rdfs:label "described by"@en ;
-                 skos:definition "x described_by y iff y is an instance of Information Content Entity, and x is an instance of Entity, such that y is about the characteristics by which y can be recognized or visualized."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001801 ;
+                owl:inverseOf cco:ont00001982 ;
+                rdfs:range cco:ont00000853 ;
+                rdfs:label "described by"@en ;
+                skos:definition "x described_by y iff y is an instance of Information Content Entity, and x is an instance of Entity, such that y is about the characteristics by which y can be recognized or visualized."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001919
 cco:ont00001919 rdf:type owl:ObjectProperty ;
-                 rdfs:label "is mentioned by"@en ;
-                 skos:definition "y is_mention_by x iff x is an instance Information Bearing Entity and y is an instance Entity, such that x is used as a reference to y."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:label "is mentioned by"@en ;
+                skos:definition "y is_mention_by x iff x is an instance Information Bearing Entity and y is an instance Entity, such that x is used as a reference to y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001920
 cco:ont00001920 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001801 ;
-                 owl:inverseOf cco:ont00001942 ;
-                 rdfs:range cco:ont00000965 ;
-                 rdfs:label "prescribed by"@en ;
-                 skos:definition "x prescribed_by y iff y is an instance of Information Content Entity and x is an instance of Entity, such that y serves as a rule or guide for x if x is an Occurrent, or y serves as a model for x if x is a Continuant."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001801 ;
+                owl:inverseOf cco:ont00001942 ;
+                rdfs:range cco:ont00000965 ;
+                rdfs:label "prescribed by"@en ;
+                skos:definition "x prescribed_by y iff y is an instance of Information Content Entity and x is an instance of Entity, such that y serves as a rule or guide for x if x is an Occurrent, or y serves as a model for x if x is a Continuant."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001938
 cco:ont00001938 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001808 ;
-                 rdfs:domain cco:ont00001069 ;
-                 rdfs:comment "Isomorphism between the carrier of x and the represented entity can be via a direct similarity relation, e.g., grooves in a vinyl record corresponding to sound waves, or linguistic convention, e.g., a court stenographer's transcription of spoken words, as well as others, such as encoding processes for images."@en ;
-                 rdfs:label "represents"@en ;
-                 skos:definition "x represents y iff x is an instance of Information Content Entity, y is an instance of Entity, and z is carrier of x, such that x is about y in virtue of there existing an isomorphism between characteristics of z and y."@en ;
-                 skos:scopeNote "Given a stronger temporal interpretation, this property may be functional. For more info please refer to https://github.com/BFO-ontology/BFO-2020/tree/master/src/owl/temporal%20extensions."@en ,
-                                "The relationship that is being defined here is that between the content of a photographic image and its object, between the content of a video and its objects and events, between the content of an audio recording and the sounds or events generating those sounds, or between the content of a written transcript and the verbal event that it transcribes."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001808 ;
+                rdfs:domain cco:ont00001069 ;
+                rdfs:comment "Isomorphism between the carrier of x and the represented entity can be via a direct similarity relation, e.g., grooves in a vinyl record corresponding to sound waves, or linguistic convention, e.g., a court stenographer's transcription of spoken words, as well as others, such as encoding processes for images."@en ;
+                rdfs:label "represents"@en ;
+                skos:definition "x represents y iff x is an instance of Information Content Entity, y is an instance of Entity, and z is carrier of x, such that x is about y in virtue of there existing an isomorphism between characteristics of z and y."@en ;
+                skos:scopeNote "Given a stronger temporal interpretation, this property may be functional. For more info please refer to https://github.com/BFO-ontology/BFO-2020/tree/master/src/owl/temporal%20extensions."@en ,
+                               "The relationship that is being defined here is that between the content of a photographic image and its object, between the content of a video and its objects and events, between the content of an audio recording and the sounds or events generating those sounds, or between the content of a written transcript and the verbal event that it transcribes."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001942
 cco:ont00001942 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001808 ;
-                 rdfs:domain cco:ont00000965 ;
-                 rdfs:label "prescribes"@en ;
-                 skos:definition "x prescribes y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x serves as a rule or guide for y if y an Occurrent, or x serves as a model for y if y is a Continuant."@en ;
-                 skos:example "A blueprint prescribes some artifact or facility by being a model for it." ,
-                              "A professional code of conduct prescribes some realizations of a profession (role) by giving rules for how the bearer should act in those realizations." ,
-                              "An operations plan prescribes an operation by enumerating the tasks that need to be performed in order to achieve the objectives of the operation." ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001808 ;
+                rdfs:domain cco:ont00000965 ;
+                rdfs:label "prescribes"@en ;
+                skos:definition "x prescribes y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x serves as a rule or guide for y if y an Occurrent, or x serves as a model for y if y is a Continuant."@en ;
+                skos:example "A blueprint prescribes some artifact or facility by being a model for it." ,
+                             "A professional code of conduct prescribes some realizations of a profession (role) by giving rules for how the bearer should act in those realizations." ,
+                             "An operations plan prescribes an operation by enumerating the tasks that need to be performed in order to achieve the objectives of the operation." ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001961
 cco:ont00001961 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf obo:BFO_0000084 ;
-                 rdfs:domain cco:ont00000120 ;
-                 rdfs:range cco:ont00000253 ;
-                 rdfs:label "is measurement unit of"@en ;
-                 skos:definition "x is_measurement_unit_of y iff y is an instance of Information Bearing Entity and x is an instance of Measurement Unit, such that x describes the magnitude of measured physical quantity mentioned in y."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf obo:BFO_0000084 ;
+                rdfs:domain cco:ont00000120 ;
+                rdfs:range cco:ont00000253 ;
+                rdfs:label "is measurement unit of"@en ;
+                skos:definition "x is_measurement_unit_of y iff y is an instance of Information Bearing Entity and x is an instance of Measurement Unit, such that x describes the magnitude of measured physical quantity mentioned in y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001963
 cco:ont00001963 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001904 ;
-                 rdfs:range cco:ont00001010 ;
-                 rdfs:label "is measured by ordinal"@en ;
-                 skos:definition "y is_measured_by_ordinal x iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale ordered by rank."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001904 ;
+                rdfs:range cco:ont00001010 ;
+                rdfs:label "is measured by ordinal"@en ;
+                skos:definition "y is_measured_by_ordinal x iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale ordered by rank."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001964
 cco:ont00001964 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001904 ;
-                 rdfs:range cco:ont00001364 ;
-                 rdfs:label "is measured by interval"@en ;
-                 skos:definition "y is_measured_by_interval x iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale which has uniform intervals but has a zero value that does not correspond to an absence of the attribute being measured."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001904 ;
+                rdfs:range cco:ont00001364 ;
+                rdfs:label "is measured by interval"@en ;
+                skos:definition "y is_measured_by_interval x iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale which has uniform intervals but has a zero value that does not correspond to an absence of the attribute being measured."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001965
 cco:ont00001965 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001904 ;
-                 owl:inverseOf cco:ont00001983 ;
-                 rdfs:range cco:ont00001022 ;
-                 rdfs:label "is measured by ratio"@en ;
-                 skos:definition "y is_measured_by_ratio x iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale having equal unit values and a zero value that corresponds to the absence of the attribute being measured."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001904 ;
+                owl:inverseOf cco:ont00001983 ;
+                rdfs:range cco:ont00001022 ;
+                rdfs:label "is measured by ratio"@en ;
+                skos:definition "y is_measured_by_ratio x iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale having equal unit values and a zero value that corresponds to the absence of the attribute being measured."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001966
 cco:ont00001966 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001982 ;
-                 rdfs:domain cco:ont00001163 ;
-                 rdfs:comment "This object property, as well as all of its children are typified as functional properties. This means that for instances x, y, and z if x is a measurement of y and x is a measurement of z, then y = z."@en ;
-                 rdfs:label "is a measurement of"@en ;
-                 skos:definition "x is_a_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to some scale or classification scheme."@en ;
-                 skos:scopeNote "Given a stronger temporal interpretation, this property may be functional. For more info please refer to https://github.com/BFO-ontology/BFO-2020/tree/master/src/owl/temporal%20extensions."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001982 ;
+                rdfs:domain cco:ont00001163 ;
+                rdfs:comment "This object property, as well as all of its children are typified as functional properties. This means that for instances x, y, and z if x is a measurement of y and x is a measurement of z, then y = z."@en ;
+                rdfs:label "is a measurement of"@en ;
+                skos:definition "x is_a_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to some scale or classification scheme."@en ;
+                skos:scopeNote "Given a stronger temporal interpretation, this property may be functional. For more info please refer to https://github.com/BFO-ontology/BFO-2020/tree/master/src/owl/temporal%20extensions."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001976
 cco:ont00001976 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001920 ;
-                 rdfs:domain cco:ont00000253 ;
-                 rdfs:range cco:ont00001175 ;
-                 rdfs:label "uses language"@en ;
-                 skos:definition "x uses_language y iff x is an instance of an Information Bearing Entity and y is an instance of a Language such that the literal value of x is a string that is encoded according to the syntax of y."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001920 ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range cco:ont00001175 ;
+                rdfs:label "uses language"@en ;
+                skos:definition "x uses_language y iff x is an instance of an Information Bearing Entity and y is an instance of a Language such that the literal value of x is a string that is encoded according to the syntax of y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001980
 cco:ont00001980 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001808 ;
-                 owl:propertyChainAxiom ( obo:BFO_0000178
-                                          cco:ont00001982
-                                        ) ;
-                 rdfs:label "describes condition"@en ;
-                 skos:definition "p describes_condition c iff p is an instance of a Performance Specification, and p has part d, and d is an instance of a Descriptive Information Content Entity, and p prescribes an entity s, and d describes c, and c is an entity that is causally relevant to s existing as prescribed by p."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001808 ;
+                owl:propertyChainAxiom ( obo:BFO_0000178
+                                         cco:ont00001982
+                                       ) ;
+                rdfs:label "describes condition"@en ;
+                skos:definition "p describes_condition c iff p is an instance of a Performance Specification, and p has part d, and d is an instance of a Descriptive Information Content Entity, and p prescribes an entity s, and d describes c, and c is an entity that is causally relevant to s existing as prescribed by p."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001982
 cco:ont00001982 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001808 ;
-                 rdfs:domain cco:ont00000853 ;
-                 rdfs:comment "It is possible that this relation should be a functional property, that is for all x, y, z if x describes y and x describes z then y = z. For example, if a financial report x describes the quarterly results of a company y and that same financial report describes the quarterly results of a company z, then it should be inferred that companies y and z are the same. We refrained from classifying the relation as a functional property on the concern that descriptions are multifaceted and so consequently it may be that the same report would contain descriptions of multiple entities."@en ;
-                 rdfs:label "describes"@en ;
-                 skos:definition "x describes y iff x is an instance of Information Content Entity, and y is an instance of Entity, such that x is about the characteristics by which y can be recognized or visualized."@en ;
-                 skos:example "the content of a newspaper article describes some current event" ,
-                              "the content of a visitor's log describes some facility visit" ,
-                              "the content of an accident report describes some accident" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001808 ;
+                rdfs:domain cco:ont00000853 ;
+                rdfs:comment "It is possible that this relation should be a functional property, that is for all x, y, z if x describes y and x describes z then y = z. For example, if a financial report x describes the quarterly results of a company y and that same financial report describes the quarterly results of a company z, then it should be inferred that companies y and z are the same. We refrained from classifying the relation as a functional property on the concern that descriptions are multifaceted and so consequently it may be that the same report would contain descriptions of multiple entities."@en ;
+                rdfs:label "describes"@en ;
+                skos:definition "x describes y iff x is an instance of Information Content Entity, and y is an instance of Entity, such that x is about the characteristics by which y can be recognized or visualized."@en ;
+                skos:example "the content of a newspaper article describes some current event" ,
+                             "the content of a visitor's log describes some facility visit" ,
+                             "the content of an accident report describes some accident" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001983
 cco:ont00001983 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001966 ;
-                 rdfs:domain cco:ont00001022 ;
-                 rdfs:label "is a ratio measurement of"@en ;
-                 skos:definition "x is_a_ratio_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale having equal unit values and a zero value that corresponds to the absence of the attribute being measured."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf cco:ont00001966 ;
+                rdfs:domain cco:ont00001022 ;
+                rdfs:label "is a ratio measurement of"@en ;
+                skos:definition "x is_a_ratio_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale having equal unit values and a zero value that corresponds to the absence of the attribute being measured."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001997
 cco:ont00001997 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf obo:BFO_0000084 ;
-                 rdfs:domain cco:ont00000398 ;
-                 rdfs:range cco:ont00000253 ;
-                 rdfs:label "is reference system of"@en ;
-                 skos:definition "x is_reference_system_of y iff y is an instance of Information Bearing Entity and x is an instance of Reference System, such that x describes the set of standards mentioned in y."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subPropertyOf obo:BFO_0000084 ;
+                rdfs:domain cco:ont00000398 ;
+                rdfs:range cco:ont00000253 ;
+                rdfs:label "is reference system of"@en ;
+                skos:definition "x is_reference_system_of y iff y is an instance of Information Bearing Entity and x is an instance of Reference System, such that x describes the set of standards mentioned in y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 #################################################################
@@ -410,72 +410,72 @@ cco:ont00001997 rdf:type owl:ObjectProperty ;
 
 ###  https://www.commoncoreontologies.org/ont00001765
 cco:ont00001765 rdf:type owl:DatatypeProperty ;
-                 rdfs:domain cco:ont00000253 ;
-                 rdfs:label "has text value"@en ;
-                 skos:definition "A data property that has as its range a string value."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:domain cco:ont00000253 ;
+                rdfs:label "has text value"@en ;
+                skos:definition "A data property that has as its range a string value."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001767
 cco:ont00001767 rdf:type owl:DatatypeProperty ;
-                 rdfs:domain cco:ont00000253 ;
-                 rdfs:range xsd:dateTime ;
-                 rdfs:label "has datetime value"@en ;
-                 skos:definition "A data property that has as its value a datetime value."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range xsd:dateTime ;
+                rdfs:label "has datetime value"@en ;
+                skos:definition "A data property that has as its value a datetime value."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001768
 cco:ont00001768 rdf:type owl:DatatypeProperty ;
-                 rdfs:domain cco:ont00000253 ;
-                 rdfs:range xsd:anyURI ;
-                 rdfs:label "has URI value"@en ;
-                 skos:definition "A data property that has as its range a URI value."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range xsd:anyURI ;
+                rdfs:label "has URI value"@en ;
+                skos:definition "A data property that has as its range a URI value."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001769
 cco:ont00001769 rdf:type owl:DatatypeProperty ;
-                 rdfs:domain cco:ont00000253 ;
-                 rdfs:range xsd:decimal ;
-                 rdfs:label "has decimal value"@en ;
-                 skos:definition "A data property that has as its range a decimal value."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range xsd:decimal ;
+                rdfs:label "has decimal value"@en ;
+                skos:definition "A data property that has as its range a decimal value."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001770
 cco:ont00001770 rdf:type owl:DatatypeProperty ;
-                 rdfs:domain cco:ont00000253 ;
-                 rdfs:range xsd:double ;
-                 rdfs:label "has double value"@en ;
-                 skos:definition "A data property that has as its range a double value."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range xsd:double ;
+                rdfs:label "has double value"@en ;
+                skos:definition "A data property that has as its range a double value."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001771
 cco:ont00001771 rdf:type owl:DatatypeProperty ;
-                 rdfs:domain cco:ont00000253 ;
-                 rdfs:label "has date value"@en ;
-                 skos:definition "A data property that has as its range a date value."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:domain cco:ont00000253 ;
+                rdfs:label "has date value"@en ;
+                skos:definition "A data property that has as its range a date value."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001772
 cco:ont00001772 rdf:type owl:DatatypeProperty ;
-                 rdfs:domain cco:ont00000253 ;
-                 rdfs:range xsd:boolean ;
-                 rdfs:label "has boolean value"@en ;
-                 skos:definition "A data property that has as its range a boolean value."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range xsd:boolean ;
+                rdfs:label "has boolean value"@en ;
+                skos:definition "A data property that has as its range a boolean value."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001773
 cco:ont00001773 rdf:type owl:DatatypeProperty ;
-                 rdfs:domain cco:ont00000253 ;
-                 rdfs:range xsd:integer ;
-                 rdfs:label "has integer value"@en ;
-                 skos:definition "A data property that has as its range an integer value."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range xsd:integer ;
+                rdfs:label "has integer value"@en ;
+                skos:definition "A data property that has as its range an integer value."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 #################################################################
@@ -484,157 +484,157 @@ cco:ont00001773 rdf:type owl:DatatypeProperty ;
 
 ###  https://www.commoncoreontologies.org/ont00000003
 cco:ont00000003 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000686 ;
-                 owl:disjointWith cco:ont00000649 ;
-                 rdfs:label "Designative Name"@en ;
-                 skos:altLabel "Name"@en ;
-                 skos:definition "A Designative Information Content Entity that consists of a string of characters that designates an entity within a specified cultural or social namespace and which is typically a word or phrase in a natural language that has an accepted cultural or social significance."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000686 ;
+                owl:disjointWith cco:ont00000649 ;
+                rdfs:label "Designative Name"@en ;
+                skos:altLabel "Name"@en ;
+                skos:definition "A Designative Information Content Entity that consists of a string of characters that designates an entity within a specified cultural or social namespace and which is typically a word or phrase in a natural language that has an accepted cultural or social significance."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000029
 cco:ont00000029 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000745 ;
-                 rdfs:label "Median Point Estimate Information Content Entity"@en ;
-                 skos:altLabel "Median"@en ;
-                 skos:definition "A Point Estimate Information Content Entity that is a measurement of a set of values and is equal to either the middle value or the average of the two values which separate the set into two equally populated upper and lower sets."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000745 ;
+                rdfs:label "Median Point Estimate Information Content Entity"@en ;
+                skos:altLabel "Median"@en ;
+                skos:definition "A Point Estimate Information Content Entity that is a measurement of a set of values and is equal to either the middle value or the average of the two values which separate the set into two equally populated upper and lower sets."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000067
 cco:ont00000067 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001328 ;
-                 rdfs:comment "In traditional astronomical usage, civil time is mean solar time as calculated from midnight as the beginning of the Civil Day."@en ,
-                              "Note that Civil Time Reference System is more accurately represented as a Temporal Reference System that participates in an act of usage that is sanctioned by an appropriate civil authority. As such, it should be represented as a defined class."@en ;
-                 rdfs:label "Civil Time Reference System"@en ;
-                 skos:definition "A Temporal Reference System that is a statutory time scale as designated by civilian authorities to determine local time(s)."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001328 ;
+                rdfs:comment "In traditional astronomical usage, civil time is mean solar time as calculated from midnight as the beginning of the Civil Day."@en ,
+                             "Note that Civil Time Reference System is more accurately represented as a Temporal Reference System that participates in an act of usage that is sanctioned by an appropriate civil authority. As such, it should be represented as a defined class."@en ;
+                rdfs:label "Civil Time Reference System"@en ;
+                skos:definition "A Temporal Reference System that is a statutory time scale as designated by civilian authorities to determine local time(s)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000073
 cco:ont00000073 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00000399
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001916 ;
-                                                              owl:someValuesFrom obo:BFO_0000038
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00000399 ;
-                 rdfs:label "Temporal Interval Identifier"@en ;
-                 skos:altLabel "One-Dimensional Temporal Region Identifier"@en ;
-                 skos:definition "A Temporal Region Identifier that designates some Temporal Interval."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000399
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001916 ;
+                                                             owl:someValuesFrom obo:BFO_0000038
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000399 ;
+                rdfs:label "Temporal Interval Identifier"@en ;
+                skos:altLabel "One-Dimensional Temporal Region Identifier"@en ;
+                skos:definition "A Temporal Region Identifier that designates some Temporal Interval."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000077
 cco:ont00000077 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000649 ;
-                 owl:disjointWith cco:ont00000923 ;
-                 rdfs:label "Code Identifier"@en ;
-                 skos:altLabel "Code ID"@en ,
-                               "ID Code"@en ,
-                               "Identifier Code"@en ;
-                 skos:definition "A Non-Name Identifier that consists of a string of characters that was created and assigned according to an encoding system such that metadata can be derived from the identifier."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000649 ;
+                owl:disjointWith cco:ont00000923 ;
+                rdfs:label "Code Identifier"@en ;
+                skos:altLabel "Code ID"@en ,
+                              "ID Code"@en ,
+                              "Identifier Code"@en ;
+                skos:definition "A Non-Name Identifier that consists of a string of characters that was created and assigned according to an encoding system such that metadata can be derived from the identifier."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000080
 cco:ont00000080 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000827 ;
-                 rdfs:label "Standard Time of Day Identifier"@en ;
-                 skos:definition "A Time of Day Identifier that designates an approximate Temporal Instant that is part of some Day and is specified using the Hours, Minutes, and Seconds of the Day that preceded the Temporal Instant."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000827 ;
+                rdfs:label "Standard Time of Day Identifier"@en ;
+                skos:definition "A Time of Day Identifier that designates an approximate Temporal Instant that is part of some Day and is specified using the Hours, Minutes, and Seconds of the Day that preceded the Temporal Instant."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000087
 cco:ont00000087 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000894 ;
-                 rdfs:comment "An Ordinal Date Identifier may or may not also contain a number indicating a specific Year. If both numbers are included, the ISO 8601 ordinal date format stipulates that the two numbers be formatted as YYYY-DDD or YYYYDDD where [YYYY] indicates a year and [DDD] is the day of that year, from 001 through 365 (or 366 in leap years)."@en ;
-                 rdfs:label "Ordinal Date Identifier"@en ;
-                 skos:altLabel "Ordinal Date"@en ;
-                 skos:definition "A Decimal Date Identifier that designates some Day by using a number to indicate the sequential ordering of the Day since the beginning of the Year."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ordinal_date&oldid=1061989434"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000894 ;
+                rdfs:comment "An Ordinal Date Identifier may or may not also contain a number indicating a specific Year. If both numbers are included, the ISO 8601 ordinal date format stipulates that the two numbers be formatted as YYYY-DDD or YYYYDDD where [YYYY] indicates a year and [DDD] is the day of that year, from 001 through 365 (or 366 in leap years)."@en ;
+                rdfs:label "Ordinal Date Identifier"@en ;
+                skos:altLabel "Ordinal Date"@en ;
+                skos:definition "A Decimal Date Identifier that designates some Day by using a number to indicate the sequential ordering of the Day since the beginning of the Year."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ordinal_date&oldid=1061989434"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000120
 cco:ont00000120 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000853 ;
-                 rdfs:label "Measurement Unit"@en ;
-                 skos:definition "A Descriptive Information Content Entity that describes a definite magnitude of a physical quantity, defined and adopted by convention and/or by law, that is used as a standard for measurement of the same physical quantity."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Unit_of_measurement&oldid=1061038125"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000853 ;
+                rdfs:label "Measurement Unit"@en ;
+                skos:definition "A Descriptive Information Content Entity that describes a definite magnitude of a physical quantity, defined and adopted by convention and/or by law, that is used as a standard for measurement of the same physical quantity."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Unit_of_measurement&oldid=1061038125"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000124
 cco:ont00000124 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001328 ;
-                 rdfs:label "Solar Time Reference System"@en ;
-                 skos:definition "A Temporal Reference System that is based on the position of the Sun in the sky."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001328 ;
+                rdfs:label "Solar Time Reference System"@en ;
+                skos:definition "A Temporal Reference System that is based on the position of the Sun in the sky."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000127
 cco:ont00000127 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000965 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001980 ;
-                                   owl:someValuesFrom obo:BFO_0000001
-                                 ] ;
-                 rdfs:label "Performance Specification"@en ;
-                 skos:definition "A Directive Information Content Entity that prescribes some aspect of the behavior of a participant in a Process given one or more operating conditions."@en ;
-                 skos:example "Maximum Speed at high altitude; Rate of Ascent at 10 degrees celsius with nominal payload." ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000965 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty cco:ont00001980 ;
+                                  owl:someValuesFrom obo:BFO_0000001
+                                ] ;
+                rdfs:label "Performance Specification"@en ;
+                skos:definition "A Directive Information Content Entity that prescribes some aspect of the behavior of a participant in a Process given one or more operating conditions."@en ;
+                skos:example "Maximum Speed at high altitude; Rate of Ascent at 10 degrees celsius with nominal payload." ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000146
 cco:ont00000146 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001175 ;
-                 owl:disjointWith cco:ont00000496 ;
-                 rdfs:label "Artificial Language"@en ;
-                 skos:definition "A Language that is developed through conscious planning and premeditation, rather than one that was developed through use and repetition."@en ;
-                 skos:example "Esperanto" ,
-                              "Python Programming Language" ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Constructed_language&oldid=1062733589"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001175 ;
+                owl:disjointWith cco:ont00000496 ;
+                rdfs:label "Artificial Language"@en ;
+                skos:definition "A Language that is developed through conscious planning and premeditation, rather than one that was developed through use and repetition."@en ;
+                skos:example "Esperanto" ,
+                             "Python Programming Language" ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Constructed_language&oldid=1062733589"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000154
 cco:ont00000154 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000745 ;
-                 rdfs:comment "While there is always at least one Mode for every set of data, it is possible for any given set of data to have multiple Modes. The Mode is typically most useful when the members of the set are all Nominal Measurement Information Content Entities."@en ;
-                 rdfs:label "Mode Point Estimate Information Content Entity"@en ;
-                 skos:altLabel "Mode"@en ,
-                               "Statistical Mode"@en ;
-                 skos:definition "A Point Estimate Information Content Entity that is a measurement of a set of values and is equal to the value or values that occur most often in the set."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000745 ;
+                rdfs:comment "While there is always at least one Mode for every set of data, it is possible for any given set of data to have multiple Modes. The Mode is typically most useful when the members of the set are all Nominal Measurement Information Content Entities."@en ;
+                rdfs:label "Mode Point Estimate Information Content Entity"@en ;
+                skos:altLabel "Mode"@en ,
+                              "Statistical Mode"@en ;
+                skos:definition "A Point Estimate Information Content Entity that is a measurement of a set of values and is equal to the value or values that occur most often in the set."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000164
 cco:ont00000164 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001010 ;
-                 rdfs:label "Minimum Ordinal Measurement Information Content Entity"@en ;
-                 skos:definition "An Ordinal Measurement Information Content Entity that is a measurement of some entity in virtue of it being the smallest or having the least amount relative to a nominally described set of like entities."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001010 ;
+                rdfs:label "Minimum Ordinal Measurement Information Content Entity"@en ;
+                skos:definition "An Ordinal Measurement Information Content Entity that is a measurement of some entity in virtue of it being the smallest or having the least amount relative to a nominally described set of like entities."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000186
 cco:ont00000186 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001010 ;
-                 rdfs:label "Artifact Version Ordinality"@en ;
-                 skos:definition "An Ordinal Measurement Information Content Entity that is about the form of an Artifact which differs in some respects from previous or future forms of that Artifact."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001010 ;
+                rdfs:label "Artifact Version Ordinality"@en ;
+                skos:definition "An Ordinal Measurement Information Content Entity that is about the form of an Artifact which differs in some respects from previous or future forms of that Artifact."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000203
 cco:ont00000203 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000293 ;
-                 rdfs:label "Event Status Nominal Information Content Entity"@en ;
-                 skos:definition "A Nominal Measurement Information Content Entity that is a measurement of the current state of a process."@en ;
-                 skos:example "proposed, approved, planned, in progress, completed, failed, or successful" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000293 ;
+                rdfs:label "Event Status Nominal Information Content Entity"@en ;
+                skos:definition "A Nominal Measurement Information Content Entity that is a measurement of the current state of a process."@en ;
+                skos:example "proposed, approved, planned, in progress, completed, failed, or successful" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000223
@@ -643,90 +643,90 @@ cco:ont00000223 rdf:type owl:Class .
 
 ###  https://www.commoncoreontologies.org/ont00000253
 cco:ont00000253 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000030
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty obo:BFO_0000101 ;
-                                                              owl:someValuesFrom cco:ont00000958
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf obo:BFO_0000030 ;
-                 rdfs:label "Information Bearing Entity"@en ;
-                 skos:altLabel "IBE"@en ;
-                 skos:definition "An Object upon which an Information Content Entity generically depends."@en ;
-                 cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000178"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000030
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:BFO_0000101 ;
+                                                             owl:someValuesFrom cco:ont00000958
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:BFO_0000030 ;
+                rdfs:label "Information Bearing Entity"@en ;
+                skos:altLabel "IBE"@en ;
+                skos:definition "An Object upon which an Information Content Entity generically depends."@en ;
+                cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000178"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000263
 cco:ont00000263 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001328 ;
-                 rdfs:comment "A single Clock Time System does not provide a complete means for identifying or measuring times. Depending on the particular Clock Time System, it may be compatible for use with one or more other Temporal Reference Systems."@en ;
-                 rdfs:label "Clock Time System"@en ;
-                 skos:definition "A Temporal Reference System that is a convention for keeping and displaying the Time of Day."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001328 ;
+                rdfs:comment "A single Clock Time System does not provide a complete means for identifying or measuring times. Depending on the particular Clock Time System, it may be compatible for use with one or more other Temporal Reference Systems."@en ;
+                rdfs:label "Clock Time System"@en ;
+                skos:definition "A Temporal Reference System that is a convention for keeping and displaying the Time of Day."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000275
 cco:ont00000275 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000398 ;
-                 rdfs:comment "Note that, while reference systems and reference frames are treated as synonyms here, some people treat them as related but separate entities. See: http://www.ggos-portal.org/lang_en/GGOS-Portal/EN/Topics/GeodeticApplications/GeodeticReferenceSystemsAndFrames/GeodeticReferenceSystemsAndFrames.html"@en ;
-                 rdfs:label "Spatial Reference System"@en ;
-                 skos:altLabel "Coordinate System"@en ,
-                               "Spatial Coordinate System"@en ,
-                               "Spatial Reference Frame"@en ;
-                 skos:definition "A Reference System that describes a set of standards for uniquely identifying the position of an entity or the direction of a vector within a defined spatial region by means of measurements along one or more Coordinate System Axes."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Coordinate_system&oldid=1060461397"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000398 ;
+                rdfs:comment "Note that, while reference systems and reference frames are treated as synonyms here, some people treat them as related but separate entities. See: http://www.ggos-portal.org/lang_en/GGOS-Portal/EN/Topics/GeodeticApplications/GeodeticReferenceSystemsAndFrames/GeodeticReferenceSystemsAndFrames.html"@en ;
+                rdfs:label "Spatial Reference System"@en ;
+                skos:altLabel "Coordinate System"@en ,
+                              "Spatial Coordinate System"@en ,
+                              "Spatial Reference Frame"@en ;
+                skos:definition "A Reference System that describes a set of standards for uniquely identifying the position of an entity or the direction of a vector within a defined spatial region by means of measurements along one or more Coordinate System Axes."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Coordinate_system&oldid=1060461397"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000276
 cco:ont00000276 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000891 ;
-                 rdfs:label "Solar Calendar System"@en ;
-                 skos:definition "A Calendar System that is designed to organize and identify dates based on the cycles of an Astronomical Body's Orbit around the Sun."@en ;
-                 skos:scopeNote "Unless otherwise specified, a Solar Calendar System is assumed to be relative to the Orbit of the Earth around the Sun."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Solar_calendar&oldid=1058016588"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000891 ;
+                rdfs:label "Solar Calendar System"@en ;
+                skos:definition "A Calendar System that is designed to organize and identify dates based on the cycles of an Astronomical Body's Orbit around the Sun."@en ;
+                skos:scopeNote "Unless otherwise specified, a Solar Calendar System is assumed to be relative to the Orbit of the Earth around the Sun."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Solar_calendar&oldid=1058016588"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000293
 cco:ont00000293 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00001163
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001868 ;
-                                                              owl:someValuesFrom obo:BFO_0000001
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00001163 ;
-                 owl:disjointWith cco:ont00001010 ,
-                                  cco:ont00001022 ,
-                                  cco:ont00001364 ;
-                 rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en ;
-                 rdfs:label "Nominal Measurement Information Content Entity"@en ;
-                 skos:definition "A Measurement Information Content Entity that consists of a symbol that classifies Entities according to some shared, possibly arbitrary, characteristic."@en ;
-                 skos:example "The sentence \"January 20, 1985 was a cold day in Chicago, IL\" is the carrier of a nominal measurement."@en ,
-                              "a measurement that classifies automobiles as sedans, coupes, hatchbacks, or convertibles" ,
-                              "a measurement that classifies military intelligence as strategic, operational, or tactical" ,
-                              "a measurement that classifies rocks as igneous, sedimentary, or metamorphic" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00001163
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001868 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00001163 ;
+                owl:disjointWith cco:ont00001010 ,
+                                 cco:ont00001022 ,
+                                 cco:ont00001364 ;
+                rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en ;
+                rdfs:label "Nominal Measurement Information Content Entity"@en ;
+                skos:definition "A Measurement Information Content Entity that consists of a symbol that classifies Entities according to some shared, possibly arbitrary, characteristic."@en ;
+                skos:example "The sentence \"January 20, 1985 was a cold day in Chicago, IL\" is the carrier of a nominal measurement."@en ,
+                             "a measurement that classifies automobiles as sedans, coupes, hatchbacks, or convertibles" ,
+                             "a measurement that classifies military intelligence as strategic, operational, or tactical" ,
+                             "a measurement that classifies rocks as igneous, sedimentary, or metamorphic" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000314
 cco:ont00000314 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000019 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:BFO_0000197 ;
-                                   owl:someValuesFrom cco:ont00000253
-                                 ] ;
-                 rdfs:comment "Typically, an IQE will be a complex pattern made up of multiple qualities joined together spatially."@en ;
-                 rdfs:label "Information Quality Entity"@en ;
-                 skos:altLabel "IQE"@en ;
-                 skos:definition "A Quality that concretizes some Information Content Entity."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000019 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000197 ;
+                                  owl:someValuesFrom cco:ont00000253
+                                ] ;
+                rdfs:comment "Typically, an IQE will be a complex pattern made up of multiple qualities joined together spatially."@en ;
+                rdfs:label "Information Quality Entity"@en ;
+                skos:altLabel "IQE"@en ;
+                skos:definition "A Quality that concretizes some Information Content Entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000359
@@ -735,91 +735,91 @@ cco:ont00000359 rdf:type owl:Class .
 
 ###  https://www.commoncoreontologies.org/ont00000369
 cco:ont00000369 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001010 ;
-                 rdfs:label "Priority Measurement Information Content Entity"@en ;
-                 skos:altLabel "Criticality Measurement"@en ,
-                               "Importance Measurement"@en ,
-                               "Priority Measurement"@en ;
-                 skos:definition "An Ordinal Measurement Information Content Entity that is a measurement of the relative importance of an entity."@en ;
-                 skos:example "low, normal, high, urgent, or immediate priority" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001010 ;
+                rdfs:label "Priority Measurement Information Content Entity"@en ;
+                skos:altLabel "Criticality Measurement"@en ,
+                              "Importance Measurement"@en ,
+                              "Priority Measurement"@en ;
+                skos:definition "An Ordinal Measurement Information Content Entity that is a measurement of the relative importance of an entity."@en ;
+                skos:example "low, normal, high, urgent, or immediate priority" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000390
 cco:ont00000390 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00000686
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001916 ;
-                                                              owl:someValuesFrom obo:BFO_0000006
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00000686 ;
-                 rdfs:label "Spatial Region Identifier"@en ;
-                 skos:definition "A Designative Information Content Entity that designates some Spatial Region."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000686
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001916 ;
+                                                             owl:someValuesFrom obo:BFO_0000006
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000686 ;
+                rdfs:label "Spatial Region Identifier"@en ;
+                skos:definition "A Designative Information Content Entity that designates some Spatial Region."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000398
 cco:ont00000398 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000853 ;
-                 rdfs:label "Reference System"@en ;
-                 skos:definition "A Descriptive Information Content Entity that describes a set of standards for organizing and understanding data of the specified type or domain."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000853 ;
+                rdfs:label "Reference System"@en ;
+                skos:definition "A Descriptive Information Content Entity that describes a set of standards for organizing and understanding data of the specified type or domain."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000399
 cco:ont00000399 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00000686
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001916 ;
-                                                              owl:someValuesFrom obo:BFO_0000008
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00000686 ;
-                 rdfs:label "Temporal Region Identifier"@en ;
-                 skos:definition "A Designative Information Content Entity that designates some Temporal Region."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000686
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001916 ;
+                                                             owl:someValuesFrom obo:BFO_0000008
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000686 ;
+                rdfs:label "Temporal Region Identifier"@en ;
+                skos:definition "A Designative Information Content Entity that designates some Temporal Region."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000406
 cco:ont00000406 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000120 ;
-                 rdfs:label "Measurement Unit of Geocoordinate"@en ;
-                 skos:definition "A Measurement Unit specifying the geospatial coordinates of a location."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000120 ;
+                rdfs:label "Measurement Unit of Geocoordinate"@en ;
+                skos:definition "A Measurement Unit specifying the geospatial coordinates of a location."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000419
 cco:ont00000419 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000077 ;
-                 rdfs:label "Part Number"@en ;
-                 skos:definition "A Code Identifier that designates a type of part whose instances are designed to be part of some Artifact."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000077 ;
+                rdfs:label "Part Number"@en ;
+                skos:definition "A Code Identifier that designates a type of part whose instances are designed to be part of some Artifact."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000469
 cco:ont00000469 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000275 ;
-                 rdfs:label "Geospatial Coordinate Reference System"@en ;
-                 skos:altLabel "Geographic Coordinate System"@en ;
-                 skos:definition "A Spatial Reference System that is used to determine and identify the location of a point or object at or near the surface of the Earth."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000275 ;
+                rdfs:label "Geospatial Coordinate Reference System"@en ;
+                skos:altLabel "Geographic Coordinate System"@en ;
+                skos:definition "A Spatial Reference System that is used to determine and identify the location of a point or object at or near the surface of the Earth."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000496
 cco:ont00000496 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001175 ;
-                 rdfs:label "Natural Language"@en ;
-                 skos:definition "A Language that is developed and evolves through use and repetition, rather than through conscious planning or premeditation."@en ;
-                 skos:example "English" ,
-                              "Mandarin (Chinese)" ,
-                              "Spanish" ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Natural_language&oldid=1060890461"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001175 ;
+                rdfs:label "Natural Language"@en ;
+                skos:definition "A Language that is developed and evolves through use and repetition, rather than through conscious planning or premeditation."@en ;
+                skos:example "English" ,
+                             "Mandarin (Chinese)" ,
+                             "Spanish" ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Natural_language&oldid=1060890461"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000498
@@ -828,231 +828,231 @@ cco:ont00000498 rdf:type owl:Class .
 
 ###  https://www.commoncoreontologies.org/ont00000529
 cco:ont00000529 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00000073
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001916 ;
-                                                              owl:someValuesFrom cco:ont00000800
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00000073 ;
-                 rdfs:label "Date Identifier"@en ;
-                 skos:altLabel "Day Identifier"@en ;
-                 skos:definition "A Temporal Interval Identifier that designates some Day."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000073
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001916 ;
+                                                             owl:someValuesFrom cco:ont00000800
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000073 ;
+                rdfs:label "Date Identifier"@en ;
+                skos:altLabel "Day Identifier"@en ;
+                skos:definition "A Temporal Interval Identifier that designates some Day."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000539
 cco:ont00000539 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001022 ;
-                 rdfs:label "Count Measurement Information Content Entity"@en ;
-                 skos:definition "A Ratio Measurement Information Content Entity that is a measurement of the number of members of some aggregate."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001022 ;
+                rdfs:label "Count Measurement Information Content Entity"@en ;
+                skos:definition "A Ratio Measurement Information Content Entity that is a measurement of the number of members of some aggregate."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000540
 cco:ont00000540 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00000399
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001916 ;
-                                                              owl:someValuesFrom obo:BFO_0000203
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00000399 ;
-                 rdfs:label "Temporal Instant Identifier"@en ;
-                 skos:altLabel "Zero-Dimensional Temporal Region Identifier"@en ;
-                 skos:definition "A Temporal Region Identifier that designates some Temporal Instant."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000399
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001916 ;
+                                                             owl:someValuesFrom obo:BFO_0000203
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000399 ;
+                rdfs:label "Temporal Instant Identifier"@en ;
+                skos:altLabel "Zero-Dimensional Temporal Region Identifier"@en ;
+                skos:definition "A Temporal Region Identifier that designates some Temporal Instant."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000589
 cco:ont00000589 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000973 ;
-                 rdfs:label "Julian Date Fraction"@en ;
-                 skos:altLabel "Julian Date Time Identifier"@en ,
-                               "Julian Day Fraction"@en ;
-                 skos:definition "A Decimal Time of Day Identifier that designates an approximate Temporal Instant that is part of some Julian Day."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000973 ;
+                rdfs:label "Julian Date Fraction"@en ;
+                skos:altLabel "Julian Date Time Identifier"@en ,
+                              "Julian Day Fraction"@en ;
+                skos:definition "A Decimal Time of Day Identifier that designates an approximate Temporal Instant that is part of some Julian Day."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000592
 cco:ont00000592 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001163 ;
-                 rdfs:comment "'Deviation Measurement Information Content Entity' and 'Veracity Measurement Information Content Entity' are complementary notions. Deviation is a measure of whether reality conforms to an ICE (e.g., a plan or prediction), whereas Veracity is a measure of whether a Descriptive ICE conforms to reality."@en ,
-                              "Note, the term 'accuracy' is avoided due to its ambiguity between: correctness-of-performance (see: 'Reliability Measurement Information Content Entity'), correctness-of-information ('Veracity Measurement Information Content Entity'), and adherance-to-expectations (see: 'Deviation Measurement Information Content Entity')."@en ;
-                 rdfs:label "Veracity Measurement Information Content Entity"@en ;
-                 skos:altLabel "Accuracy of Information"@en ,
-                               "Trueness Measurement"@en ,
-                               "Veracity Measurement"@en ;
-                 skos:definition "A Measurement Information Content Entity that is a measurement of the extent to which a description conforms to the reality it describes."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001163 ;
+                rdfs:comment "'Deviation Measurement Information Content Entity' and 'Veracity Measurement Information Content Entity' are complementary notions. Deviation is a measure of whether reality conforms to an ICE (e.g., a plan or prediction), whereas Veracity is a measure of whether a Descriptive ICE conforms to reality."@en ,
+                             "Note, the term 'accuracy' is avoided due to its ambiguity between: correctness-of-performance (see: 'Reliability Measurement Information Content Entity'), correctness-of-information ('Veracity Measurement Information Content Entity'), and adherance-to-expectations (see: 'Deviation Measurement Information Content Entity')."@en ;
+                rdfs:label "Veracity Measurement Information Content Entity"@en ;
+                skos:altLabel "Accuracy of Information"@en ,
+                              "Trueness Measurement"@en ,
+                              "Veracity Measurement"@en ;
+                skos:definition "A Measurement Information Content Entity that is a measurement of the extent to which a description conforms to the reality it describes."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000604
 cco:ont00000604 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001010 ;
-                 rdfs:label "Maximum Ordinal Measurement Information Content Entity"@en ;
-                 skos:definition "An Ordinal Measurement Information Content Entity that is a measurement of some entity in virtue of it being the largest or having the greatest amount relative to a nominally described set of like entities."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001010 ;
+                rdfs:label "Maximum Ordinal Measurement Information Content Entity"@en ;
+                skos:definition "An Ordinal Measurement Information Content Entity that is a measurement of some entity in virtue of it being the largest or having the greatest amount relative to a nominally described set of like entities."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000605
 cco:ont00000605 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000003 ;
-                 rdfs:label "Abbreviated Name"@en ;
-                 skos:definition "A Designative Name that is a shortened form of a Proper Name."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000003 ;
+                rdfs:label "Abbreviated Name"@en ;
+                skos:definition "A Designative Name that is a shortened form of a Proper Name."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000626
 cco:ont00000626 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000853 ;
-                 rdfs:comment "Since predictions are inherently about not-yet-existant things, the Modal Relation Ontology term 'describes' (i.e. mro:describes) should be used (instead of the standard cco:describes) to relate instances of Predictive Information Content Entity to the entities they are about."@en ;
-                 rdfs:label "Predictive Information Content Entity"@en ;
-                 skos:altLabel "Prediction"@en ,
-                               "Prediction Information Content Entity"@en ;
-                 skos:definition "A Descriptive Information Content Entity that describes an uncertain future event."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000853 ;
+                rdfs:comment "Since predictions are inherently about not-yet-existant things, the Modal Relation Ontology term 'describes' (i.e. mro:describes) should be used (instead of the standard cco:describes) to relate instances of Predictive Information Content Entity to the entities they are about."@en ;
+                rdfs:label "Predictive Information Content Entity"@en ;
+                skos:altLabel "Prediction"@en ,
+                              "Prediction Information Content Entity"@en ;
+                skos:definition "A Descriptive Information Content Entity that describes an uncertain future event."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000630
 cco:ont00000630 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000124 ;
-                 rdfs:label "Universal Time Reference System"@en ;
-                 skos:definition "A Solar Time Reference System that is based on the average speed of the Earth's rotation and which uses the prime meridian at 0° longitude as a reference point."@en ;
-                 cco:ont00001753 "UT" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000124 ;
+                rdfs:label "Universal Time Reference System"@en ;
+                skos:definition "A Solar Time Reference System that is based on the average speed of the Earth's rotation and which uses the prime meridian at 0° longitude as a reference point."@en ;
+                cco:ont00001753 "UT" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000649
 cco:ont00000649 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000686 ;
-                 rdfs:label "Non-Name Identifier"@en ;
-                 skos:altLabel "ID"@en ,
-                               "Identifier"@en ;
-                 skos:definition "A Designative Information Content Entity that consists of a string of characters that designates an entity within a specified namespace or context, is not a Designative Name, may be automatically or randomly generated, and typically has no preexisting cultural or social significance."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000686 ;
+                rdfs:label "Non-Name Identifier"@en ;
+                skos:altLabel "ID"@en ,
+                              "Identifier"@en ;
+                skos:definition "A Designative Information Content Entity that consists of a string of characters that designates an entity within a specified namespace or context, is not a Designative Name, may be automatically or randomly generated, and typically has no preexisting cultural or social significance."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000653
 cco:ont00000653 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000965 ;
-                 rdfs:label "Algorithm"@en ;
-                 skos:definition "A Directive Information Content Entity that prescribes some Process and contains a finite sequence of unambiguous instructions in order to achieve some Objective."@en ;
-                 cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000064"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000965 ;
+                rdfs:label "Algorithm"@en ;
+                skos:definition "A Directive Information Content Entity that prescribes some Process and contains a finite sequence of unambiguous instructions in order to achieve some Objective."@en ;
+                cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000064"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000669
 cco:ont00000669 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001022 ;
-                 rdfs:label "Distance Measurement Information Content Entity"@en ;
-                 skos:definition "A Ratio Measurement Information Content Entity that is a measurement of a One-Dimensional Extent inhering in some Site that is externally connected to two Independent Continuants."@en ;
-                 skos:scopeNote "Displacement (vector) is the shortest possible distance (scalar) between two points. Further thought is needed to adequately handle measurements of distance traveled along a path, e.g., a circuitous path or an arc (such as the surface of a planet), versus the simple case of a direct, straight line between two points."@en ,
-                                "Distance is a measure between two reference points, which are located on or in, or in some manner part of, the two obejcts for which the length of the extent between is sought. For exmple, the center point of the indentation of a ball in the sand and the edge of the foul line, the forwardmost point on a car's bumper and the closest point on the 2-dimensional plane that serves as the fiat boundary of a crosswalk, the center of an antenna array and closest point on ground."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001022 ;
+                rdfs:label "Distance Measurement Information Content Entity"@en ;
+                skos:definition "A Ratio Measurement Information Content Entity that is a measurement of a One-Dimensional Extent inhering in some Site that is externally connected to two Independent Continuants."@en ;
+                skos:scopeNote "Displacement (vector) is the shortest possible distance (scalar) between two points. Further thought is needed to adequately handle measurements of distance traveled along a path, e.g., a circuitous path or an arc (such as the surface of a planet), versus the simple case of a direct, straight line between two points."@en ,
+                               "Distance is a measure between two reference points, which are located on or in, or in some manner part of, the two obejcts for which the length of the extent between is sought. For exmple, the center point of the indentation of a ball in the sand and the edge of the foul line, the forwardmost point on a car's bumper and the closest point on the 2-dimensional plane that serves as the fiat boundary of a crosswalk, the center of an antenna array and closest point on ground."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000683
 cco:ont00000683 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000605 ;
-                 rdfs:label "Diminutive Name"@en ;
-                 skos:definition "An Abbreviated Name that is a familiar form of a Proper Name."@en ;
-                 skos:example "Alex, Bob, Cathy" ;
-                 skos:scopeNote "\"Familiar form of a Proper Name\" means: that the name is (originally) a short, affectionate version of the fuller name, used (originally) by family or friends."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000605 ;
+                rdfs:label "Diminutive Name"@en ;
+                skos:definition "An Abbreviated Name that is a familiar form of a Proper Name."@en ;
+                skos:example "Alex, Bob, Cathy" ;
+                skos:scopeNote "\"Familiar form of a Proper Name\" means: that the name is (originally) a short, affectionate version of the fuller name, used (originally) by family or friends."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000686
 cco:ont00000686 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00000958
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001916 ;
-                                                              owl:someValuesFrom obo:BFO_0000001
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00000958 ;
-                 owl:disjointWith cco:ont00000853 ,
-                                  cco:ont00000965 ;
-                 rdfs:label "Designative Information Content Entity"@en ;
-                 skos:altLabel "Designative ICE"@en ;
-                 skos:definition "An Information Content Entity that consists of a set of symbols that denote some Entity."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000958
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001916 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000958 ;
+                owl:disjointWith cco:ont00000853 ,
+                                 cco:ont00000965 ;
+                rdfs:label "Designative Information Content Entity"@en ;
+                skos:altLabel "Designative ICE"@en ;
+                skos:definition "An Information Content Entity that consists of a set of symbols that designate some Entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000692
 cco:ont00000692 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001163 ;
-                 rdfs:comment "Every probability measurement is made within a particular context given certain background assumptions."@en ;
-                 rdfs:label "Probability Measurement Information Content Entity"@en ;
-                 skos:altLabel "Likelihood Measurement"@en ,
-                               "Probability Measurement"@en ;
-                 skos:definition "A Measurement Information Content Entity that is a measurement of the likelihood that a Process or Process Aggregate occurs."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Probability&oldid=1059657543"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001163 ;
+                rdfs:comment "Every probability measurement is made within a particular context given certain background assumptions."@en ;
+                rdfs:label "Probability Measurement Information Content Entity"@en ;
+                skos:altLabel "Likelihood Measurement"@en ,
+                              "Probability Measurement"@en ;
+                skos:definition "A Measurement Information Content Entity that is a measurement of the likelihood that a Process or Process Aggregate occurs."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Probability&oldid=1059657543"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000729
 cco:ont00000729 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000275 ;
-                 rdfs:label "Spherical Coordinate System"@en ;
-                 skos:definition "A Spatial Reference System for three-dimensional spatial regions that identifies each point using an ordered triple of numerical coordinates that consist of the radial distance of the point of interest from a fixed origin, its polar angle measured from a fixed zenith direction, and the azimuth angle of its orthogonal projection measured from a fixed direction on a reference plane that passes through the origin and is orthogonal to the zenith."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Spherical_coordinate_system&oldid=1061029174"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000275 ;
+                rdfs:label "Spherical Coordinate System"@en ;
+                skos:definition "A Spatial Reference System for three-dimensional spatial regions that identifies each point using an ordered triple of numerical coordinates that consist of the radial distance of the point of interest from a fixed origin, its polar angle measured from a fixed zenith direction, and the azimuth angle of its orthogonal projection measured from a fixed direction on a reference plane that passes through the origin and is orthogonal to the zenith."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Spherical_coordinate_system&oldid=1061029174"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000731
 cco:ont00000731 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001163 ;
-                 rdfs:comment "'Deviation Measurement Information Content Entity' and 'Veracity Measurement Information Content Entity' are complementary notions. Deviation is a measure of whether reality conforms to an ICE (e.g., a plan or prediction), whereas Veracity is a measure of whether a Descriptive ICE conforms to reality."@en ,
-                              "Note, the term 'accuracy' is avoided due to its ambiguity between: correctness-of-performance (see: 'Reliability Measurement Information Content Entity'), correctness-of-information (see: 'Veracity Measurement Information Content Entity'), and adherance-to-expectations ('Deviation Measurement Information Content Entity')."@en ;
-                 rdfs:label "Deviation Measurement Information Content Entity"@en ;
-                 skos:altLabel "Conformance Measurement"@en ,
-                               "Degree of Conformance"@en ,
-                               "Degree of Deviation"@en ,
-                               "Deviation Measurement"@en ;
-                 skos:definition "A Measurement Information Content Entity that is a measurement of the extent to which an entity conforms to how it is expected or supposed to be."@en ;
-                 skos:example "a missile impact deviates from its target location by 100 feet" ,
-                              "a satellite deviaties from its predicted orbital path by 5 kilometers" ,
-                              "an overweight piece of luggage deviates from an airline's maximum allowed weight by +10 pounds" ;
-                 skos:scopeNote "In order for a Deviation to exist, an entity must first be expected, represented, prescribed, or predicted as being a certain way. Then, at a future time, this value can be compared to its actual, reported, or measured value to determine the Deviation between these values."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001163 ;
+                rdfs:comment "'Deviation Measurement Information Content Entity' and 'Veracity Measurement Information Content Entity' are complementary notions. Deviation is a measure of whether reality conforms to an ICE (e.g., a plan or prediction), whereas Veracity is a measure of whether a Descriptive ICE conforms to reality."@en ,
+                             "Note, the term 'accuracy' is avoided due to its ambiguity between: correctness-of-performance (see: 'Reliability Measurement Information Content Entity'), correctness-of-information (see: 'Veracity Measurement Information Content Entity'), and adherance-to-expectations ('Deviation Measurement Information Content Entity')."@en ;
+                rdfs:label "Deviation Measurement Information Content Entity"@en ;
+                skos:altLabel "Conformance Measurement"@en ,
+                              "Degree of Conformance"@en ,
+                              "Degree of Deviation"@en ,
+                              "Deviation Measurement"@en ;
+                skos:definition "A Measurement Information Content Entity that is a measurement of the extent to which an entity conforms to how it is expected or supposed to be."@en ;
+                skos:example "a missile impact deviates from its target location by 100 feet" ,
+                             "a satellite deviaties from its predicted orbital path by 5 kilometers" ,
+                             "an overweight piece of luggage deviates from an airline's maximum allowed weight by +10 pounds" ;
+                skos:scopeNote "In order for a Deviation to exist, an entity must first be expected, represented, prescribed, or predicted as being a certain way. Then, at a future time, this value can be compared to its actual, reported, or measured value to determine the Deviation between these values."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000735
 cco:ont00000735 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000406 ;
-                 rdfs:label "Geospatial Region Bounding Box Identifier List"@en ;
-                 skos:definition "A Measurement Unit of Geocoordinate that is comprised of 4 pairs of coordinates, one for each of the 4 defining points (North, West, South, East) of a Geospatial Region Bounding Box."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000406 ;
+                rdfs:label "Geospatial Region Bounding Box Identifier List"@en ;
+                skos:definition "A Measurement Unit of Geocoordinate that is comprised of 4 pairs of coordinates, one for each of the 4 defining points (North, West, South, East) of a Geospatial Region Bounding Box."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000745
 cco:ont00000745 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001176 ;
-                 rdfs:label "Point Estimate Information Content Entity"@en ;
-                 skos:altLabel "Best Estimate"@en ,
-                               "Point Estimate"@en ,
-                               "Point Estimate Measurement Information Content Entity"@en ;
-                 skos:definition "An Estimate Information Content Entity that consists of a single value for the measured entity."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001176 ;
+                rdfs:label "Point Estimate Information Content Entity"@en ;
+                skos:altLabel "Best Estimate"@en ,
+                              "Point Estimate"@en ,
+                              "Point Estimate Measurement Information Content Entity"@en ;
+                skos:definition "An Estimate Information Content Entity that consists of a single value for the measured entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000749
 cco:ont00000749 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000894 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001916 ;
-                                   owl:someValuesFrom cco:ont00000498
-                                 ] ;
-                 rdfs:label "Julian Day Number"@en ;
-                 skos:definition "A Decimal Date Identifier that designates some Julian Day by using a number to indicate the sequential ordering of the Day since the Julian Date epoch."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000894 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty cco:ont00001916 ;
+                                  owl:someValuesFrom cco:ont00000498
+                                ] ;
+                rdfs:label "Julian Day Number"@en ;
+                skos:definition "A Decimal Date Identifier that designates some Julian Day by using a number to indicate the sequential ordering of the Day since the Julian Date epoch."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000800
@@ -1061,433 +1061,441 @@ cco:ont00000800 rdf:type owl:Class .
 
 ###  https://www.commoncoreontologies.org/ont00000827
 cco:ont00000827 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00000540
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001916 ;
-                                                              owl:someValuesFrom cco:ont00000223
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00000540 ;
-                 rdfs:label "Time of Day Identifier"@en ;
-                 skos:definition "A Temporal Instant Identifier that designates some Time of Day."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000540
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001916 ;
+                                                             owl:someValuesFrom cco:ont00000223
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000540 ;
+                rdfs:label "Time of Day Identifier"@en ;
+                skos:definition "A Temporal Instant Identifier that designates some Time of Day."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000829
 cco:ont00000829 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000390 ;
-                 rdfs:comment """Standards of date, time, and time zone data formats:
+                rdfs:subClassOf cco:ont00000390 ;
+                rdfs:comment """Standards of date, time, and time zone data formats:
 ISO/WD 8601-2 (http://www.loc.gov/standards/datetime/iso-tc154-wg5_n0039_iso_wd_8601-2_2016-02-16.pdf)
 W3C (https://www.w3.org/TR/NOTE-datetime)"""@en ,
-                              "There is no class 'Time Zone' (the region), only 'Time Zone Identifier' (the designator for some region). Instances of 'Time Zone Identifier' should be related to instances of 'Information Bearing Entity' by means of the object properites 'uses time zone identifier' and 'time zone identifier used by' as appropriate. This is supposed to be analogous to the way we represent the relationship between measurement values and measurement units, where the relevant instance of Information Bearing Entity 'uses measurement unit' some instance of Measurement Unit (i.e., an instance of Information Content Entity)."@en ;
-                 rdfs:label "Time Zone Identifier"@en ;
-                 skos:definition "A Spatial Region Identifier that designates the region associated with some uniform standard time for legal, commercial, or social purposes."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                             "There is no class 'Time Zone' (the region), only 'Time Zone Identifier' (the designator for some region). Instances of 'Time Zone Identifier' should be related to instances of 'Information Bearing Entity' by means of the object properites 'uses time zone identifier' and 'time zone identifier used by' as appropriate. This is supposed to be analogous to the way we represent the relationship between measurement values and measurement units, where the relevant instance of Information Bearing Entity 'uses measurement unit' some instance of Measurement Unit (i.e., an instance of Information Content Entity)."@en ;
+                rdfs:label "Time Zone Identifier"@en ;
+                skos:definition "A Spatial Region Identifier that designates the region associated with some uniform standard time for legal, commercial, or social purposes."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000833
 cco:ont00000833 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000973 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:BFO_0000178 ;
-                                   owl:someValuesFrom cco:ont00000589
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:BFO_0000178 ;
-                                   owl:someValuesFrom cco:ont00000749
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001916 ;
-                                   owl:someValuesFrom cco:ont00000359
-                                 ] ;
-                 rdfs:label "Julian Date Identifier"@en ;
-                 skos:definition "A Decimal Time of Day Identifier that designates a Julian Date and is composed of both a Julian Day Number and a Julian Date Fraction."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000973 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000178 ;
+                                  owl:someValuesFrom cco:ont00000589
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000178 ;
+                                  owl:someValuesFrom cco:ont00000749
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty cco:ont00001916 ;
+                                  owl:someValuesFrom cco:ont00000359
+                                ] ;
+                rdfs:label "Julian Date Identifier"@en ;
+                skos:definition "A Decimal Time of Day Identifier that designates a Julian Date and is composed of both a Julian Day Number and a Julian Date Fraction."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000845
 cco:ont00000845 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001022 ;
-                 rdfs:comment "A percentage is one way to express a proportional measure where the decimal expression of the proportion is multiplied by 100, thus giving the proportional value with respect to a whole of 100. E.g., the ratio of pigs to cows on a farm is 44 to 79 (44:79 or 44/79). The proportion of pigs to total animals is 44 to 123 or 44/123. The percentage of pigs is the decimal equivalent of the proportion (0.36) multiplied by a 100 (36%). The percentage can be expressed as a proportion where the numerator value is transformed for a denominator of 100, i.e., 36 of a 100 animals are pigs (36/100)."@en ,
-                              "We may want to add either a subclass for Percentage or a data property (has percentage value) that links the percentage expression for a proportion to the relevant IBE."@en ;
-                 rdfs:label "Proportional Ratio Measurement Information Content Entity"@en ;
-                 skos:definition "A Ratio Measurement Information Content Entity that is a measurement of a portion of a whole (described by the numerator) compared against that whole (described by the denominator) where the whole is a nominally described set of like entities."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001022 ;
+                rdfs:comment "A percentage is one way to express a proportional measure where the decimal expression of the proportion is multiplied by 100, thus giving the proportional value with respect to a whole of 100. E.g., the ratio of pigs to cows on a farm is 44 to 79 (44:79 or 44/79). The proportion of pigs to total animals is 44 to 123 or 44/123. The percentage of pigs is the decimal equivalent of the proportion (0.36) multiplied by a 100 (36%). The percentage can be expressed as a proportion where the numerator value is transformed for a denominator of 100, i.e., 36 of a 100 animals are pigs (36/100)."@en ,
+                             "We may want to add either a subclass for Percentage or a data property (has percentage value) that links the percentage expression for a proportion to the relevant IBE."@en ;
+                rdfs:label "Proportional Ratio Measurement Information Content Entity"@en ;
+                skos:definition "A Ratio Measurement Information Content Entity that is a measurement of a portion of a whole (described by the numerator) compared against that whole (described by the denominator) where the whole is a nominally described set of like entities."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000853
 cco:ont00000853 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000958 ;
-                 owl:disjointWith cco:ont00000965 ;
-                 rdfs:label "Descriptive Information Content Entity"@en ;
-                 skos:altLabel "Descriptive ICE"@en ;
-                 skos:definition "An Information Content Entity that consists of a set of propositions that describe some Entity."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000958
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001982 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000958 ;
+                owl:disjointWith cco:ont00000965 ;
+                rdfs:label "Descriptive Information Content Entity"@en ;
+                skos:altLabel "Descriptive ICE"@en ;
+                skos:definition "An Information Content Entity that consists of a set of propositions that describe some Entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000891
 cco:ont00000891 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001328 ;
-                 rdfs:label "Calendar System"@en ;
-                 skos:definition "A Temporal Reference System that is designed to organize and identify dates."@en ;
-                 skos:scopeNote "Calendars typically organize dates through the use of naming and temporal conventions based on Days, Weeks, Months, and Years."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001328 ;
+                rdfs:label "Calendar System"@en ;
+                skos:definition "A Temporal Reference System that is designed to organize and identify dates."@en ;
+                skos:scopeNote "Calendars typically organize dates through the use of naming and temporal conventions based on Days, Weeks, Months, and Years."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000894
 cco:ont00000894 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000529 ;
-                 rdfs:label "Decimal Date Identifier"@en ;
-                 skos:definition "A Date Identifier that designates some Day by using a number to indicate the sequential ordering of the Day since a specified Reference Time."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000529 ;
+                rdfs:label "Decimal Date Identifier"@en ;
+                skos:definition "A Date Identifier that designates some Day by using a number to indicate the sequential ordering of the Day since a specified Reference Time."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000896
 cco:ont00000896 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000745 ;
-                 rdfs:label "Mean Point Estimate Information Content Entity"@en ;
-                 skos:altLabel "Arithmetic Mean"@en ,
-                               "Average"@en ,
-                               "Mean"@en ;
-                 skos:definition "A Point Estimate Information Content Entity that is a measurement of a set of values and is equal to the sum of all the values in the set divided by the total number of values in the set."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000745 ;
+                rdfs:label "Mean Point Estimate Information Content Entity"@en ;
+                skos:altLabel "Arithmetic Mean"@en ,
+                              "Average"@en ,
+                              "Mean"@en ;
+                skos:definition "A Point Estimate Information Content Entity that is a measurement of a set of values and is equal to the sum of all the values in the set divided by the total number of values in the set."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000915
 cco:ont00000915 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000605 ;
-                 rdfs:label "Acronym"@en ;
-                 skos:definition "An Abbreviated Name that combines the initial letters of a Designative Name and which is pronounced as a word."@en ;
-                 skos:example "Wi-Fi, ASCII, OPSEC" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000605 ;
+                rdfs:label "Acronym"@en ;
+                skos:definition "An Abbreviated Name that combines the initial letters of a Designative Name and which is pronounced as a word."@en ;
+                skos:example "Wi-Fi, ASCII, OPSEC" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000916
 cco:ont00000916 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000891 ;
-                 rdfs:label "Lunar Calendar System"@en ;
-                 skos:definition "A Calendar System that is designed to organize and identify dates based on the cycles of the Moon's phases."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Lunar_calendar&oldid=1055396837"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000891 ;
+                rdfs:label "Lunar Calendar System"@en ;
+                skos:definition "A Calendar System that is designed to organize and identify dates based on the cycles of the Moon's phases."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Lunar_calendar&oldid=1055396837"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000923
 cco:ont00000923 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000649 ;
-                 rdfs:label "Arbitrary Identifier"@en ;
-                 skos:altLabel "Arbitrary ID"@en ;
-                 skos:definition "A Non-Name Identifier that consists of a string of characters that does not follow an encoding system."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000649 ;
+                rdfs:label "Arbitrary Identifier"@en ;
+                skos:altLabel "Arbitrary ID"@en ;
+                skos:definition "A Non-Name Identifier that consists of a string of characters that does not follow an encoding system."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000958
 cco:ont00000958 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000031
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001808 ;
-                                                              owl:someValuesFrom obo:BFO_0000001
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf obo:BFO_0000031 ;
-                 rdfs:label "Information Content Entity"@en ;
-                 skos:altLabel "ICE"@en ;
-                 skos:definition "A Generically Dependent Continuant that generically depends on some Information Bearing Entity and stands in relation of aboutness to some Entity."@en ;
-                 skos:scopeNote "Information Content Entity is here intended to be a class of Entities whose instances are the informational content of Information Bearing Entities. For example, three instances of information bearers -- such as a bar chart, color-coded map, and a written report -- each of which lists the GDP of Countries for the year 2010 are each different carriers of the same information content. It is this content that is generically dependent upon its carrier. This treatment of Informational Content Entity (cf. the Information Artifact Ontology) leads to a principle of subtyping based upon the relationship that ICE's have with the Entity they are about rather than characteristics such as format, language, measurement scale, or media. The latter are treated here as being Qualities of bearers."@en ;
-                 cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000030" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000031
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001808 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:BFO_0000031 ;
+                rdfs:label "Information Content Entity"@en ;
+                skos:altLabel "ICE"@en ;
+                skos:definition "A Generically Dependent Continuant that generically depends on some Information Bearing Entity and stands in relation of aboutness to some Entity."@en ;
+                skos:scopeNote "Information Content Entity is here intended to be a class of Entities whose instances are the informational content of Information Bearing Entities. For example, three instances of information bearers -- such as a bar chart, color-coded map, and a written report -- each of which lists the GDP of Countries for the year 2010 are each different carriers of the same information content. It is this content that is generically dependent upon its carrier. This treatment of Informational Content Entity (cf. the Information Artifact Ontology) leads to a principle of subtyping based upon the relationship that ICE's have with the Entity they are about rather than characteristics such as format, language, measurement scale, or media. The latter are treated here as being Qualities of bearers."@en ;
+                cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000030" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000965
 cco:ont00000965 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00000958
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001942 ;
-                                                              owl:someValuesFrom obo:BFO_0000001
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00000958 ;
-                 rdfs:label "Directive Information Content Entity"@en ;
-                 skos:altLabel "Directive ICE"@en ;
-                 skos:definition "An Information Content Entity that consists of a set of propositions or images (as in the case of a blueprint) that prescribe some Entity."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000958
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001942 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000958 ;
+                rdfs:label "Prescriptive Information Content Entity"@en ;
+                skos:altLabel "Directive ICE"@en ;
+                skos:definition "An Information Content Entity that consists of a set of propositions or images (as in the case of a blueprint) that prescribe some Entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000973
 cco:ont00000973 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000827 ;
-                 rdfs:label "Decimal Time of Day Identifier"@en ;
-                 skos:altLabel "Fractional Time of Day Identifier"@en ;
-                 skos:definition "A Time of Day Identifier that designates an approximate Temporal Instant that is part of some Day and is specified using a decimal value for the portion of the Day that preceded the Temporal Instant."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000827 ;
+                rdfs:label "Decimal Time of Day Identifier"@en ;
+                skos:altLabel "Fractional Time of Day Identifier"@en ;
+                skos:definition "A Time of Day Identifier that designates an approximate Temporal Instant that is part of some Day and is specified using a decimal value for the portion of the Day that preceded the Temporal Instant."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000990
 cco:ont00000990 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000003 ;
-                 rdfs:label "Nickname"@en ;
-                 skos:definition "A Designative Name that is a familiar or humorous substitute for an entity's Proper Name."@en ;
-                 skos:example "Ike, Chief, P-Fox" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000003 ;
+                rdfs:label "Nickname"@en ;
+                skos:definition "A Designative Name that is a familiar or humorous substitute for an entity's Proper Name."@en ;
+                skos:example "Ike, Chief, P-Fox" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001010
 cco:ont00001010 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00001163
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001811 ;
-                                                              owl:someValuesFrom obo:BFO_0000001
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00001163 ;
-                 owl:disjointWith cco:ont00001022 ,
-                                  cco:ont00001364 ;
-                 rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en ;
-                 rdfs:label "Ordinal Measurement Information Content Entity"@en ;
-                 skos:definition "A Measurement Information Content Entity that consists of a symbol that places an Entity into some rank order."@en ;
-                 skos:example "The sentence \"The coldest day in history in Chicago, IL. is January 20, 1985.\" is the carrier of an ordinal measurment."@en ,
-                              "a measurement that places Geospatial Regions into a rank order of small, medium, large" ,
-                              "a measurement that places military units onto a readiness rank order of red, yellow, green" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00001163
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001811 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00001163 ;
+                owl:disjointWith cco:ont00001022 ,
+                                 cco:ont00001364 ;
+                rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en ;
+                rdfs:label "Ordinal Measurement Information Content Entity"@en ;
+                skos:definition "A Measurement Information Content Entity that consists of a symbol that places an Entity into some rank order."@en ;
+                skos:example "The sentence \"The coldest day in history in Chicago, IL. is January 20, 1985.\" is the carrier of an ordinal measurment."@en ,
+                             "a measurement that places Geospatial Regions into a rank order of small, medium, large" ,
+                             "a measurement that places military units onto a readiness rank order of red, yellow, green" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001014
 cco:ont00001014 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000003 ;
-                 rdfs:label "Proper Name"@en ;
-                 skos:definition "A Designative Name that is an official name for a particular entity."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000003 ;
+                rdfs:label "Proper Name"@en ;
+                skos:definition "A Designative Name that is an official name for a particular entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001022
 cco:ont00001022 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00001163
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001983 ;
-                                                              owl:someValuesFrom obo:BFO_0000001
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00001163 ;
-                 owl:disjointWith cco:ont00001364 ;
-                 rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en ;
-                 rdfs:label "Ratio Measurement Information Content Entity"@en ;
-                 skos:definition "A Measurement Information Content Entity that consists of a symbol that places a Quality of an Entity onto an interval scale having a true zero value."@en ;
-                 skos:example "The sentence \"The temperature reached 240.372 degrees Kelvin on January 20, 1985 in Chicago, IL.\" is the carrier of a ratio measurement as 0 degrees on the Kelvin scale does describe absolute zero."@en ,
-                              "a measurement of the barometric pressure at 1,000 feet above sea level" ,
-                              "a measurement of the measure of air temperature on the Kelvin scale" ,
-                              "a measurement of the number of members in an Organization" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00001163
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001983 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00001163 ;
+                owl:disjointWith cco:ont00001364 ;
+                rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en ;
+                rdfs:label "Ratio Measurement Information Content Entity"@en ;
+                skos:definition "A Measurement Information Content Entity that consists of a symbol that places a Quality of an Entity onto an interval scale having a true zero value."@en ;
+                skos:example "The sentence \"The temperature reached 240.372 degrees Kelvin on January 20, 1985 in Chicago, IL.\" is the carrier of a ratio measurement as 0 degrees on the Kelvin scale does describe absolute zero."@en ,
+                             "a measurement of the barometric pressure at 1,000 feet above sea level" ,
+                             "a measurement of the measure of air temperature on the Kelvin scale" ,
+                             "a measurement of the number of members in an Organization" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001041
 cco:ont00001041 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001010 ;
-                 rdfs:label "Sequence Position Ordinality"@en ;
-                 skos:definition "An Ordinal Measurement Information Content Entity that is about the position of some entity in some ordered sequence."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001010 ;
+                rdfs:label "Sequence Position Ordinality"@en ;
+                skos:definition "An Ordinal Measurement Information Content Entity that is about the position of some entity in some ordered sequence."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001069
 cco:ont00001069 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00000958
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001938 ;
-                                                              owl:someValuesFrom obo:BFO_0000001
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00000958 ;
-                 owl:disjointWith cco:ont00001163 ;
-                 rdfs:label "Representational Information Content Entity"@en ;
-                 skos:definition "An Information Content Entity that represents some Entity."@en ;
-                 skos:example "the content of a court transcript represents a courtroom proceeding" ,
-                              "the content of a photograph of the Statue of Liberty represents the Statue of Liberty" ,
-                              "the content of a video of a sporting event represents that sporting event" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000958
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001938 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000958 ;
+                owl:disjointWith cco:ont00001163 ;
+                rdfs:label "Representational Information Content Entity"@en ;
+                skos:definition "An Information Content Entity that represents some Entity."@en ;
+                skos:example "the content of a court transcript represents a courtroom proceeding" ,
+                             "the content of a photograph of the Statue of Liberty represents the Statue of Liberty" ,
+                             "the content of a video of a sporting event represents that sporting event" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001101
 cco:ont00001101 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001176 ;
-                 rdfs:label "Interval Estimate Information Content Entity"@en ;
-                 skos:altLabel "Interval Estimate"@en ,
-                               "Interval Estimate Measurement Information Content Entity"@en ;
-                 skos:definition "An Estimate Information Content Entity that consists of an interval of possible (or probable) values for the measured entity."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001176 ;
+                rdfs:label "Interval Estimate Information Content Entity"@en ;
+                skos:altLabel "Interval Estimate"@en ,
+                              "Interval Estimate Measurement Information Content Entity"@en ;
+                skos:definition "An Estimate Information Content Entity that consists of an interval of possible (or probable) values for the measured entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001146
 cco:ont00001146 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001328 ;
-                 rdfs:comment "Sidereal Time is the angle measured from an observer's meridian along the celestial equator to the Great Circle that passes through the March equinox and both poles. This angle is usually expressed in Hours, Minutes, and Seconds."@en ;
-                 rdfs:label "Sidereal Time Reference System"@en ;
-                 skos:definition "A Temporal Reference System that is based on Earth's rate of rotation measured relative to one or more fixed Stars (rather than the Sun)."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001328 ;
+                rdfs:comment "Sidereal Time is the angle measured from an observer's meridian along the celestial equator to the Great Circle that passes through the March equinox and both poles. This angle is usually expressed in Hours, Minutes, and Seconds."@en ;
+                rdfs:label "Sidereal Time Reference System"@en ;
+                skos:definition "A Temporal Reference System that is based on Earth's rate of rotation measured relative to one or more fixed Stars (rather than the Sun)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001149
 cco:ont00001149 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001101 ;
-                 rdfs:label "Data Range Interval Estimate Information Content Entity"@en ;
-                 skos:definition "A Ratio Measurement Information Content Entity that is a measurement of a set of values and is equal to the absolute difference between the largest value and the smallest value in the set."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001101 ;
+                rdfs:label "Data Range Interval Estimate Information Content Entity"@en ;
+                skos:definition "A Ratio Measurement Information Content Entity that is a measurement of a set of values and is equal to the absolute difference between the largest value and the smallest value in the set."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001163
 cco:ont00001163 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00000853
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001966 ;
-                                                              owl:someValuesFrom obo:BFO_0000001
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00000853 ;
-                 rdfs:label "Measurement Information Content Entity"@en ;
-                 skos:altLabel "Measurement ICE"@en ;
-                 skos:definition "A Descriptive Information Content Entity that describes the extent, dimensions, quantity, or quality of an Entity relative to some standard."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000853
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001966 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000853 ;
+                rdfs:label "Measurement Information Content Entity"@en ;
+                skos:altLabel "Measurement ICE"@en ;
+                skos:definition "A Descriptive Information Content Entity that describes the extent, dimensions, quantity, or quality of an Entity relative to some standard."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001175
 cco:ont00001175 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000965 ;
-                 rdfs:label "Language"@en ;
-                 skos:definition "A Directive Information Content Entity that prescribes a canonical format for communication."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000965 ;
+                rdfs:label "Language"@en ;
+                skos:definition "A Directive Information Content Entity that prescribes a canonical format for communication."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001176
 cco:ont00001176 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001163 ;
-                 rdfs:label "Estimate Information Content Entity"@en ;
-                 skos:altLabel "Estimate"@en ,
-                               "Estimate Measurement Information Content Entity"@en ,
-                               "Estimated Value"@en ;
-                 skos:definition "A Measurement Information Content Entity that is a measurement of an entity based on partial information about that entity or an appropriately similar entity."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001163 ;
+                rdfs:label "Estimate Information Content Entity"@en ;
+                skos:altLabel "Estimate"@en ,
+                              "Estimate Measurement Information Content Entity"@en ,
+                              "Estimated Value"@en ;
+                skos:definition "A Measurement Information Content Entity that is a measurement of an entity based on partial information about that entity or an appropriately similar entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001205
 cco:ont00001205 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000398 ;
-                 rdfs:label "Priority Scale"@en ;
-                 skos:definition "A Reference System that is designed to be used to rank or identify the importance of entities of the specified type."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000398 ;
+                rdfs:label "Priority Scale"@en ;
+                skos:definition "A Reference System that is designed to be used to rank or identify the importance of entities of the specified type."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001235
 cco:ont00001235 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000829 ;
-                 rdfs:label "Military Time Zone Identifier"@en ;
-                 skos:definition "A Time Zone Identifier that designates a spatial region where the local time is calculated according to the specified offset from Zulu time, which has no offset from Coordinated Universal Time."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000829 ;
+                rdfs:label "Military Time Zone Identifier"@en ;
+                skos:definition "A Time Zone Identifier that designates a spatial region where the local time is calculated according to the specified offset from Zulu time, which has no offset from Coordinated Universal Time."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001238
 cco:ont00001238 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000605 ;
-                 rdfs:label "Initialism"@en ;
-                 skos:definition "An Abbreviated Name that consists of the initial letters of some words (or syllables) in a Designative Name, and in which each letter is pronounced separately."@en ;
-                 skos:example "USA, CPU, BBC" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000605 ;
+                rdfs:label "Initialism"@en ;
+                skos:definition "An Abbreviated Name that consists of the initial letters of some words (or syllables) in a Designative Name, and in which each letter is pronounced separately."@en ;
+                skos:example "USA, CPU, BBC" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001256
 cco:ont00001256 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001163 ;
-                 rdfs:comment "Note, the term 'accuracy' is avoided due to its ambiguity between: correctness-of-performance ('Reliability Measurement Information Content Entity'), correctness-of-information (see: 'Veracity Measurement Information Content Entity'), and adherance-to-expectations (see: 'Deviation Measurement Information Content Entity')."@en ;
-                 rdfs:label "Reliability Measurement Information Content Entity"@en ;
-                 skos:altLabel "Accuracy of Process"@en ,
-                               "Reliability Measurement"@en ;
-                 skos:definition "A Measurement Information Content Entity that is a measurement of the extent to which an entity can consistently produce an outcome."@en ;
-                 skos:scopeNote "Reliability concerns both a measure of past performance and the expectation that future performance will conform to the range of past performances."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Reliability_(statistics)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001163 ;
+                rdfs:comment "Note, the term 'accuracy' is avoided due to its ambiguity between: correctness-of-performance ('Reliability Measurement Information Content Entity'), correctness-of-information (see: 'Veracity Measurement Information Content Entity'), and adherance-to-expectations (see: 'Deviation Measurement Information Content Entity')."@en ;
+                rdfs:label "Reliability Measurement Information Content Entity"@en ;
+                skos:altLabel "Accuracy of Process"@en ,
+                              "Reliability Measurement"@en ;
+                skos:definition "A Measurement Information Content Entity that is a measurement of the extent to which an entity can consistently produce an outcome."@en ;
+                skos:scopeNote "Reliability concerns both a measure of past performance and the expectation that future performance will conform to the range of past performances."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Reliability_(statistics)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001309
 cco:ont00001309 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000077 ;
-                 rdfs:label "Lot Number"@en ;
-                 skos:definition "A Code Identifier that designates a particular quantity or lot of material from a single manufacturer."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Lot_number&oldid=1061846325"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000077 ;
+                rdfs:label "Lot Number"@en ;
+                skos:definition "A Code Identifier that designates a particular quantity or lot of material from a single manufacturer."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Lot_number&oldid=1061846325"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001328
 cco:ont00001328 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000398 ;
-                 rdfs:label "Temporal Reference System"@en ;
-                 skos:altLabel "Temporal Reference Frame"@en ,
-                               "Time Scale"@en ;
-                 skos:definition "A Reference System that describes a set of standards for measuring time as well as understanding the context of and organizing temporal data."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000398 ;
+                rdfs:label "Temporal Reference System"@en ;
+                skos:altLabel "Temporal Reference Frame"@en ,
+                              "Time Scale"@en ;
+                skos:definition "A Reference System that describes a set of standards for measuring time as well as understanding the context of and organizing temporal data."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001331
 cco:ont00001331 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001014 ;
-                 rdfs:label "Legal Name"@en ;
-                 skos:definition "A Proper Name that is an official name for the designated entity as determined by a Government or court of law."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001014 ;
+                rdfs:label "Legal Name"@en ;
+                skos:definition "A Proper Name that is an official name for the designated entity as determined by a Government or court of law."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001340
 cco:ont00001340 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000529 ;
-                 rdfs:label "Calendar Date Identifier"@en ;
-                 skos:definition "A Date Identifier that designates some Day by using a combination of Day, Week, Month, or Year Identifiers formatted according to an implementation of a Calendar System."@en ;
-                 skos:example "January 1, 2018; 1 January 2018; 01/01/18; 01Jan18" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000529 ;
+                rdfs:label "Calendar Date Identifier"@en ;
+                skos:definition "A Date Identifier that designates some Day by using a combination of Day, Week, Month, or Year Identifiers formatted according to an implementation of a Calendar System."@en ;
+                skos:example "January 1, 2018; 1 January 2018; 01/01/18; 01Jan18" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001351
 cco:ont00001351 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000275 ;
-                 rdfs:label "Cartesian Coordinate System"@en ;
-                 skos:altLabel "Rectangular Coordinate System"@en ;
-                 skos:definition "A Spatial Reference System that identifies each point in a spatial region of n-dimensions using an ordered n-tuple of numerical coordinates that are the signed (i.e. positive or negative) distances measured in the same unit of length from the zero point where the fixed perpendicular Coordinate System Axes meet."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Cartesian_coordinate_system&oldid=1058613323"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000275 ;
+                rdfs:label "Cartesian Coordinate System"@en ;
+                skos:altLabel "Rectangular Coordinate System"@en ;
+                skos:definition "A Spatial Reference System that identifies each point in a spatial region of n-dimensions using an ordered n-tuple of numerical coordinates that are the signed (i.e. positive or negative) distances measured in the same unit of length from the zero point where the fixed perpendicular Coordinate System Axes meet."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Cartesian_coordinate_system&oldid=1058613323"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001352
 cco:ont00001352 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000829 ;
-                 rdfs:comment "Greenwich Mean Time (GMT) is the mean solar time at the Royal Observatory in Greenwich, London and has been superseded by Coordinated Universal Time (UTC)."@en ;
-                 rdfs:label "Greenwich Mean Time Zone Identifier"@en ;
-                 skos:definition "A Time Zone Identifier that designates a spatial region where the local time is calculated according to the specified offset from Greenwich Mean Time."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000829 ;
+                rdfs:comment "Greenwich Mean Time (GMT) is the mean solar time at the Royal Observatory in Greenwich, London and has been superseded by Coordinated Universal Time (UTC)."@en ;
+                rdfs:label "Greenwich Mean Time Zone Identifier"@en ;
+                skos:definition "A Time Zone Identifier that designates a spatial region where the local time is calculated according to the specified offset from Greenwich Mean Time."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001364
 cco:ont00001364 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00001163
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001877 ;
-                                                              owl:someValuesFrom obo:BFO_0000001
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00001163 ;
-                 rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en ;
-                 rdfs:label "Interval Measurement Information Content Entity"@en ;
-                 skos:definition "A Measurement Information Content Entity that places a Quality of an Entity onto some interval scale having no true zero value."@en ;
-                 skos:example "The sentence \"The temperature reached -27 degrees Fahrenheit on January 20, 1985 in Chicago, IL.\" is the carrier of an interval measurement as 0 degrees on the Fahrenheit scale does not describe absolute zero."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00001163
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001877 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00001163 ;
+                rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en ;
+                rdfs:label "Interval Measurement Information Content Entity"@en ;
+                skos:definition "A Measurement Information Content Entity that places a Quality of an Entity onto some interval scale having no true zero value."@en ;
+                skos:example "The sentence \"The temperature reached -27 degrees Fahrenheit on January 20, 1985 in Chicago, IL.\" is the carrier of an interval measurement as 0 degrees on the Fahrenheit scale does not describe absolute zero."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 #################################################################
@@ -1496,766 +1504,766 @@ cco:ont00001364 rdf:type owl:Class ;
 
 ###  https://www.commoncoreontologies.org/ont00001392
 cco:ont00001392 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT-8"@en ;
-                 skos:altLabel "PST"@en ,
-                               "Pacific Standard Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT-8"@en ;
+                skos:altLabel "PST"@en ,
+                              "Pacific Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001395
 cco:ont00001395 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT-3:30"@en ;
-                 skos:altLabel "Newfoundland Standard Time"@en ;
-                 cco:ont00001753 "NST" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT-3:30"@en ;
+                skos:altLabel "Newfoundland Standard Time"@en ;
+                cco:ont00001753 "NST" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001398
 cco:ont00001398 rdf:type owl:NamedIndividual ,
-                          cco:ont00000469 ;
-                 rdfs:label "Global Area Reference System"@en ;
-                 cco:ont00001753 "GARS" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00000469 ;
+                rdfs:label "Global Area Reference System"@en ;
+                cco:ont00001753 "GARS" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001403
 cco:ont00001403 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC+2"@en ;
-                 rdfs:label "Bravo Time Zone"@en ;
-                 cco:ont00001753 "B" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+2"@en ;
+                rdfs:label "Bravo Time Zone"@en ;
+                cco:ont00001753 "B" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001405
 cco:ont00001405 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT-2"@en ;
-                 skos:altLabel "BET"@en ,
-                               "Brazil Eastern Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT-2"@en ;
+                skos:altLabel "BET"@en ,
+                              "Brazil Eastern Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001406
 cco:ont00001406 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT+9:30"@en ;
-                 skos:altLabel "Australian Central Standard Time"@en ;
-                 cco:ont00001753 "ACST" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT+9:30"@en ;
+                skos:altLabel "Australian Central Standard Time"@en ;
+                cco:ont00001753 "ACST" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001408
 cco:ont00001408 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC-11"@en ;
-                 rdfs:label "X-ray Time Zone"@en ;
-                 cco:ont00001753 "X" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-11"@en ;
+                rdfs:label "X-ray Time Zone"@en ;
+                cco:ont00001753 "X" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001412
 cco:ont00001412 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC+0"@en ;
-                 rdfs:label "GMT"@en ;
-                 skos:altLabel "Greenwich Mean Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+0"@en ;
+                rdfs:label "GMT"@en ;
+                skos:altLabel "Greenwich Mean Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001414
 cco:ont00001414 rdf:type owl:NamedIndividual ,
-                          cco:ont00001328 ;
-                 rdfs:comment "TT is an astronomical time standard that is a theoretical ideal designed to be free of the irregularities in Earth's rotation and is primarily used for time measurements of astronomical observations made from the surface of Earth. It was formerly called Terrestrial Dynamical Time (TDT), which was formulated to replace Ephemeris Time (ET)."@en ;
-                 rdfs:label "Terrestrial Time"@en ;
-                 cco:ont00001753 "TT" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001328 ;
+                rdfs:comment "TT is an astronomical time standard that is a theoretical ideal designed to be free of the irregularities in Earth's rotation and is primarily used for time measurements of astronomical observations made from the surface of Earth. It was formerly called Terrestrial Dynamical Time (TDT), which was formulated to replace Ephemeris Time (ET)."@en ;
+                rdfs:label "Terrestrial Time"@en ;
+                cco:ont00001753 "TT" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001417
 cco:ont00001417 rdf:type owl:NamedIndividual ,
-                          cco:ont00001328 ;
-                 rdfs:comment "ET is an astronomical time scale that was adopted as a standard in 1952 by the IAU but has since been superseded and is no longer actively used. ET is based on the ephemeris second, which was defined as a fraction of the tropical year for 1900 January 01 as calculated using Newcomb's 1895 tables of the Sun. ET was designed to avoid problems caused by variations in Earth's rotational period and was used for Solar System ephemeris calculations until being replaced by Terrestrial Dynamical Time (TDT) in 1979."@en ;
-                 rdfs:label "Ephemeris Time"@en ;
-                 cco:ont00001753 "ET" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001328 ;
+                rdfs:comment "ET is an astronomical time scale that was adopted as a standard in 1952 by the IAU but has since been superseded and is no longer actively used. ET is based on the ephemeris second, which was defined as a fraction of the tropical year for 1900 January 01 as calculated using Newcomb's 1895 tables of the Sun. ET was designed to avoid problems caused by variations in Earth's rotational period and was used for Solar System ephemeris calculations until being replaced by Terrestrial Dynamical Time (TDT) in 1979."@en ;
+                rdfs:label "Ephemeris Time"@en ;
+                cco:ont00001753 "ET" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001419
 cco:ont00001419 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT+5"@en ;
-                 skos:altLabel "PLT"@en ,
-                               "Pakistan Lahore Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT+5"@en ;
+                skos:altLabel "PLT"@en ,
+                              "Pakistan Lahore Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001421
 cco:ont00001421 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC-6"@en ;
-                 rdfs:label "Sierra Time Zone"@en ;
-                 cco:ont00001753 "S" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-6"@en ;
+                rdfs:label "Sierra Time Zone"@en ;
+                cco:ont00001753 "S" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001424
 cco:ont00001424 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC+1"@en ;
-                 rdfs:label "Alpha Time Zone"@en ;
-                 cco:ont00001753 "A" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+1"@en ;
+                rdfs:label "Alpha Time Zone"@en ;
+                cco:ont00001753 "A" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001430
 cco:ont00001430 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC+6"@en ;
-                 rdfs:label "Foxtrot Time Zone"@en ;
-                 cco:ont00001753 "F" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+6"@en ;
+                rdfs:label "Foxtrot Time Zone"@en ;
+                cco:ont00001753 "F" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001431
 cco:ont00001431 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC-10"@en ;
-                 rdfs:label "Whiskey Time Zone"@en ;
-                 cco:ont00001753 "W" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-10"@en ;
+                rdfs:label "Whiskey Time Zone"@en ;
+                cco:ont00001753 "W" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001434
 cco:ont00001434 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT+1"@en ;
-                 skos:altLabel "ECT"@en ,
-                               "European Central Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT+1"@en ;
+                skos:altLabel "ECT"@en ,
+                              "European Central Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001436
 cco:ont00001436 rdf:type owl:NamedIndividual ,
-                          cco:ont00000630 ;
-                 rdfs:label "Universal Time 1 D"@en ;
-                 cco:ont00001753 "UT1D" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00000630 ;
+                rdfs:label "Universal Time 1 D"@en ;
+                cco:ont00001753 "UT1D" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001439
 cco:ont00001439 rdf:type owl:NamedIndividual ,
-                          cco:ont00000263 ;
-                 rdfs:label "Twenty-Four-Hour Clock Time System"@en ;
-                 skos:altLabel "24-Hour Clock"@en ,
-                               "24-Hour Clock Time System"@en ,
-                               "Military Time"@en ,
-                               "Military Time System"@en ,
-                               "Twenty-Four Hour Clock Time System"@en ,
-                               "Twenty-Four-Hour Clock"@en ;
-                 skos:definition "A Clock Time System for time keeping in which the Day runs from midnight to midnight and is divided into 24 Hours, indicated by the Hours passed since midnight, from 0 to 23."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=24-hour_clock&oldid=1063744105"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00000263 ;
+                rdfs:label "Twenty-Four-Hour Clock Time System"@en ;
+                skos:altLabel "24-Hour Clock"@en ,
+                              "24-Hour Clock Time System"@en ,
+                              "Military Time"@en ,
+                              "Military Time System"@en ,
+                              "Twenty-Four Hour Clock Time System"@en ,
+                              "Twenty-Four-Hour Clock"@en ;
+                skos:definition "A Clock Time System for time keeping in which the Day runs from midnight to midnight and is divided into 24 Hours, indicated by the Hours passed since midnight, from 0 to 23."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=24-hour_clock&oldid=1063744105"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001440
 cco:ont00001440 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT-9"@en ;
-                 skos:altLabel "AST"@en ,
-                               "Alaska Standard Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT-9"@en ;
+                skos:altLabel "AST"@en ,
+                              "Alaska Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001446
 cco:ont00001446 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Mike Time Zone is the same local time as Yankee Time Zone, but is 1 Day (i.e. 24 Hours) ahead of Yankee Time Zone as they are on opposite sides of the International Date Line."@en ,
-                              "Offset from Universal Coordinated Time = UTC+12"@en ;
-                 rdfs:label "Mike Time Zone"@en ;
-                 cco:ont00001753 "M" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Mike Time Zone is the same local time as Yankee Time Zone, but is 1 Day (i.e. 24 Hours) ahead of Yankee Time Zone as they are on opposite sides of the International Date Line."@en ,
+                             "Offset from Universal Coordinated Time = UTC+12"@en ;
+                rdfs:label "Mike Time Zone"@en ;
+                cco:ont00001753 "M" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001454
 cco:ont00001454 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC+11"@en ;
-                 rdfs:label "Lima Time Zone"@en ;
-                 cco:ont00001753 "L" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+11"@en ;
+                rdfs:label "Lima Time Zone"@en ;
+                cco:ont00001753 "L" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001457
 cco:ont00001457 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC-4"@en ;
-                 rdfs:label "Quebec Time Zone"@en ;
-                 cco:ont00001753 "Q" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-4"@en ;
+                rdfs:label "Quebec Time Zone"@en ;
+                cco:ont00001753 "Q" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001461
 cco:ont00001461 rdf:type owl:NamedIndividual ,
-                          cco:ont00001328 ;
-                 rdfs:comment "TDB is a linear scaling of Barycentric Coordinate Time (TCB) and is a relativistic coordinate time scale used in astronomy as a time standard that accounts for time dilation when calculating Orbits and Ephemerides of Astronomical Bodies and interplanetary Spacecraft in the Solar System. TDB is a successor of Ephemeris Time (ET) and is nearly equivalent to the time scale Teph used for DE405 planetary and lunar ephemerides generated by the Jet Propulsion Laboratory."@en ;
-                 rdfs:label "Barycentric Dynamical Time"@en ;
-                 cco:ont00001753 "TDB" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001328 ;
+                rdfs:comment "TDB is a linear scaling of Barycentric Coordinate Time (TCB) and is a relativistic coordinate time scale used in astronomy as a time standard that accounts for time dilation when calculating Orbits and Ephemerides of Astronomical Bodies and interplanetary Spacecraft in the Solar System. TDB is a successor of Ephemeris Time (ET) and is nearly equivalent to the time scale Teph used for DE405 planetary and lunar ephemerides generated by the Jet Propulsion Laboratory."@en ;
+                rdfs:label "Barycentric Dynamical Time"@en ;
+                cco:ont00001753 "TDB" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001467
 cco:ont00001467 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT-4"@en ;
-                 skos:altLabel "PRT"@en ,
-                               "Puerto Rico and US Virgin Islands Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT-4"@en ;
+                skos:altLabel "PRT"@en ,
+                              "Puerto Rico and US Virgin Islands Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001468
 cco:ont00001468 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT+10"@en ;
-                 skos:altLabel "AET"@en ,
-                               "Australia Eastern Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT+10"@en ;
+                skos:altLabel "AET"@en ,
+                              "Australia Eastern Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001476
 cco:ont00001476 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT+4"@en ;
-                 skos:altLabel "NET"@en ,
-                               "Near East Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT+4"@en ;
+                skos:altLabel "NET"@en ,
+                              "Near East Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001480
 cco:ont00001480 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC+9"@en ;
-                 rdfs:label "India Time Zone"@en ;
-                 cco:ont00001753 "I" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+9"@en ;
+                rdfs:label "India Time Zone"@en ;
+                cco:ont00001753 "I" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001488
 cco:ont00001488 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC-7"@en ;
-                 rdfs:label "Tango Time Zone"@en ;
-                 cco:ont00001753 "T" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-7"@en ;
+                rdfs:label "Tango Time Zone"@en ;
+                cco:ont00001753 "T" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001491
 cco:ont00001491 rdf:type owl:NamedIndividual ,
-                          cco:ont00000630 ;
-                 rdfs:label "Universal Time 1 A"@en ;
-                 cco:ont00001753 "UT1A" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00000630 ;
+                rdfs:label "Universal Time 1 A"@en ;
+                cco:ont00001753 "UT1A" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001500
 cco:ont00001500 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC+5"@en ;
-                 rdfs:label "Echo Time Zone"@en ;
-                 cco:ont00001753 "E" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+5"@en ;
+                rdfs:label "Echo Time Zone"@en ;
+                cco:ont00001753 "E" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001506
 cco:ont00001506 rdf:type owl:NamedIndividual ,
-                          cco:ont00000630 ;
-                 rdfs:label "Universal Time 1 F"@en ;
-                 cco:ont00001753 "UT1F" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00000630 ;
+                rdfs:label "Universal Time 1 F"@en ;
+                cco:ont00001753 "UT1F" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001516
 cco:ont00001516 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC-2"@en ;
-                 rdfs:label "Oscar Time Zone"@en ;
-                 cco:ont00001753 "O" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-2"@en ;
+                rdfs:label "Oscar Time Zone"@en ;
+                cco:ont00001753 "O" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001524
 cco:ont00001524 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT-11"@en ;
-                 skos:altLabel "MIT"@en ,
-                               "Midway Islands Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT-11"@en ;
+                skos:altLabel "MIT"@en ,
+                              "Midway Islands Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001527
 cco:ont00001527 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC+8"@en ;
-                 rdfs:label "Hotel Time Zone"@en ;
-                 cco:ont00001753 "H" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+8"@en ;
+                rdfs:label "Hotel Time Zone"@en ;
+                cco:ont00001753 "H" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001529
 cco:ont00001529 rdf:type owl:NamedIndividual ,
-                          cco:ont00001328 ;
-                 rdfs:comment """\"TCG is a coordinate time standard intended to be used as the independent variable of time for all calculations pertaining to precession, nutation, the Moon, and artificial satellites of the Earth. It is equivalent to the proper time experienced by a clock at rest in a coordinate frame co-moving with the center of the Earth: that is, a clock that performs exactly the same movements as the Earth but is outside the Earth's gravity well. It is therefore not influenced by the gravitational time dilation caused by the Earth.\"
+                         cco:ont00001328 ;
+                rdfs:comment """\"TCG is a coordinate time standard intended to be used as the independent variable of time for all calculations pertaining to precession, nutation, the Moon, and artificial satellites of the Earth. It is equivalent to the proper time experienced by a clock at rest in a coordinate frame co-moving with the center of the Earth: that is, a clock that performs exactly the same movements as the Earth but is outside the Earth's gravity well. It is therefore not influenced by the gravitational time dilation caused by the Earth.\"
 From: (https://en.wikipedia.org/wiki/Geocentric_Coordinate_Time)"""@en ;
-                 rdfs:label "Geocentric Coordinate Time"@en ;
-                 cco:ont00001753 "TCG" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:label "Geocentric Coordinate Time"@en ;
+                cco:ont00001753 "TCG" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001534
 cco:ont00001534 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT+7"@en ;
-                 skos:altLabel "VST"@en ,
-                               "Vietnam Standard Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT+7"@en ;
+                skos:altLabel "VST"@en ,
+                              "Vietnam Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001537
 cco:ont00001537 rdf:type owl:NamedIndividual ,
-                          cco:ont00000067 ,
-                          cco:ont00000630 ;
-                 rdfs:comment "UTC is a variant of Universal Time that is calculated by combining Universal Time 1 with International Atomic Time by occasionally adding leap seconds to TAI in order to maintain UTC within 0.9 seconds of UT1. The difference between UTC and UT1 is called DUT1 and always has a value between -0.9 seconds and +0.9 seconds. Coordinated Universal Time is the current basis for civil time and is the reference time for time zones, whose local times are defined based on an offset from UTC."@en ;
-                 rdfs:label "Coordinated Universal Time"@en ;
-                 cco:ont00001753 "UTC" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00000067 ,
+                         cco:ont00000630 ;
+                rdfs:comment "UTC is a variant of Universal Time that is calculated by combining Universal Time 1 with International Atomic Time by occasionally adding leap seconds to TAI in order to maintain UTC within 0.9 seconds of UT1. The difference between UTC and UT1 is called DUT1 and always has a value between -0.9 seconds and +0.9 seconds. Coordinated Universal Time is the current basis for civil time and is the reference time for time zones, whose local times are defined based on an offset from UTC."@en ;
+                rdfs:label "Coordinated Universal Time"@en ;
+                cco:ont00001753 "UTC" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001541
 cco:ont00001541 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT+12"@en ;
-                 skos:altLabel "NST"@en ,
-                               "New Zealand Standard Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT+12"@en ;
+                skos:altLabel "NST"@en ,
+                              "New Zealand Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001548
 cco:ont00001548 rdf:type owl:NamedIndividual ,
-                          cco:ont00000630 ;
-                 rdfs:comment "UT1R is a variant of Universal Time that is a smoothed version of UT1 by filtering out periodic variations due to tidal waves."@en ;
-                 rdfs:label "Universal Time 1 R"@en ;
-                 cco:ont00001753 "UT1R" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00000630 ;
+                rdfs:comment "UT1R is a variant of Universal Time that is a smoothed version of UT1 by filtering out periodic variations due to tidal waves."@en ;
+                rdfs:label "Universal Time 1 R"@en ;
+                cco:ont00001753 "UT1R" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001550
 cco:ont00001550 rdf:type owl:NamedIndividual ,
-                          cco:ont00000276 ;
-                 rdfs:comment "The Julian Calendar was proposed by Julius Caesar as a reform of the Roman Calendar, took effect on 1 January 46 BC, and was the predominant Calendar System in Europe until being largely replaced by the Gregorian Calendar."@en ;
-                 rdfs:label "Julian Calendar"@en ;
-                 skos:definition "A Solar Calendar System that has a regular Year of 365 24-Hour Days divided into 12 Months with a leap day added at the end of February every 4 Years such that the average length of a Julian Year is 365.25 Days."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Julian_calendar&oldid=1063127575"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00000276 ;
+                rdfs:comment "The Julian Calendar was proposed by Julius Caesar as a reform of the Roman Calendar, took effect on 1 January 46 BC, and was the predominant Calendar System in Europe until being largely replaced by the Gregorian Calendar."@en ;
+                rdfs:label "Julian Calendar"@en ;
+                skos:definition "A Solar Calendar System that has a regular Year of 365 24-Hour Days divided into 12 Months with a leap day added at the end of February every 4 Years such that the average length of a Julian Year is 365.25 Days."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Julian_calendar&oldid=1063127575"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001553
 cco:ont00001553 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT+6"@en ;
-                 skos:altLabel "BST"@en ,
-                               "Bangladesh Standard Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT+6"@en ;
+                skos:altLabel "BST"@en ,
+                              "Bangladesh Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001554
 cco:ont00001554 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT-10"@en ;
-                 skos:altLabel "HST"@en ,
-                               "Hawaii Standard Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT-10"@en ;
+                skos:altLabel "HST"@en ,
+                              "Hawaii Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001565
 cco:ont00001565 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT-5"@en ;
-                 skos:altLabel "EST"@en ,
-                               "Eastern Standard Time"@en ,
-                               "IET"@en ,
-                               "Indiana Eastern Standard Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT-5"@en ;
+                skos:altLabel "EST"@en ,
+                              "Eastern Standard Time"@en ,
+                              "IET"@en ,
+                              "Indiana Eastern Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001570
 cco:ont00001570 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT+2"@en ;
-                 skos:altLabel "EET"@en ,
-                               "Eastern European Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT+2"@en ;
+                skos:altLabel "EET"@en ,
+                              "Eastern European Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001580
 cco:ont00001580 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC-3"@en ;
-                 rdfs:label "Papa Time Zone"@en ;
-                 cco:ont00001753 "P" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-3"@en ;
+                rdfs:label "Papa Time Zone"@en ;
+                cco:ont00001753 "P" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001581
 cco:ont00001581 rdf:type owl:NamedIndividual ,
-                          cco:ont00000469 ;
-                 rdfs:comment """The ITRS definition fulfills the following conditions:
+                         cco:ont00000469 ;
+                rdfs:comment """The ITRS definition fulfills the following conditions:
 1. It is geocentric, the center of mass being defined for the whole earth, including oceans and atmosphere.
 2. The unit of length is the metre (SI). This scale is consistent with the TCG time coordinate for a geocentric local frame, in agreement with IAU and IUGG (1991) resolutions. This is obtained by appropriate relativistic modelling.
 3. Its orientation was initially given by the BIH orientation at 1984.0.
 4. The time evolution of the orientation is ensured by using a no-net-rotation condition with regards to horizontal tectonic motions over the whole earth.
 From: (https://www.iers.org/IERS/EN/Science/ITRS/ITRS.html)"""@en ;
-                 rdfs:label "International Terrestrial Reference System"@en ;
-                 cco:ont00001753 "ITRS" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:label "International Terrestrial Reference System"@en ;
+                cco:ont00001753 "ITRS" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001582
 cco:ont00001582 rdf:type owl:NamedIndividual ,
-                          cco:ont00000469 ;
-                 rdfs:label "Universal Transverse Mercator Reference System"@en ;
-                 cco:ont00001753 "UTM" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00000469 ;
+                rdfs:label "Universal Transverse Mercator Reference System"@en ;
+                cco:ont00001753 "UTM" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001584
 cco:ont00001584 rdf:type owl:NamedIndividual ,
-                          cco:ont00000469 ;
-                 rdfs:label "World Geographic Reference System"@en ;
-                 cco:ont00001753 "WGRS" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00000469 ;
+                rdfs:label "World Geographic Reference System"@en ;
+                cco:ont00001753 "WGRS" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001588
 cco:ont00001588 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT+9"@en ;
-                 skos:altLabel "JST"@en ,
-                               "Japan Standard Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT+9"@en ;
+                skos:altLabel "JST"@en ,
+                              "Japan Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001590
 cco:ont00001590 rdf:type owl:NamedIndividual ,
-                          cco:ont00001328 ;
-                 rdfs:comment "TAI is a time standard the values of which are generated by calculating the weighted average of the measurements of more than 400 atomic clocks and is based on the International System of Units (SI) definition of one second equals the time it takes a Cesium-133 atom at the ground state to oscillate exactly 9,192,631,770 times. TAI is extremely precise, but does not perfectly synchronize with Earth times, which is why TAI and UT1 are both used to determine UTC. TAI serves as the main realization of TT."@en ;
-                 rdfs:label "International Atomic Time"@en ;
-                 cco:ont00001753 "TAI" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001328 ;
+                rdfs:comment "TAI is a time standard the values of which are generated by calculating the weighted average of the measurements of more than 400 atomic clocks and is based on the International System of Units (SI) definition of one second equals the time it takes a Cesium-133 atom at the ground state to oscillate exactly 9,192,631,770 times. TAI is extremely precise, but does not perfectly synchronize with Earth times, which is why TAI and UT1 are both used to determine UTC. TAI serves as the main realization of TT."@en ;
+                rdfs:label "International Atomic Time"@en ;
+                cco:ont00001753 "TAI" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001591
 cco:ont00001591 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC-8"@en ;
-                 rdfs:label "Uniform Time Zone"@en ;
-                 cco:ont00001753 "U" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-8"@en ;
+                rdfs:label "Uniform Time Zone"@en ;
+                cco:ont00001753 "U" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001597
 cco:ont00001597 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT+11"@en ;
-                 skos:altLabel "SST"@en ,
-                               "Solomon Standard Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT+11"@en ;
+                skos:altLabel "SST"@en ,
+                              "Solomon Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001599
 cco:ont00001599 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT+3:30"@en ;
-                 skos:altLabel "Iran Standard Time"@en ,
-                               "Iran Time"@en ;
-                 cco:ont00001753 "IRST" ,
-                                  "IT" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT+3:30"@en ;
+                skos:altLabel "Iran Standard Time"@en ,
+                              "Iran Time"@en ;
+                cco:ont00001753 "IRST" ,
+                                "IT" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001603
 cco:ont00001603 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC-1"@en ;
-                 rdfs:label "November Time Zone"@en ;
-                 cco:ont00001753 "N" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-1"@en ;
+                rdfs:label "November Time Zone"@en ;
+                cco:ont00001753 "N" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001607
 cco:ont00001607 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC-9"@en ;
-                 rdfs:label "Victor Time Zone"@en ;
-                 cco:ont00001753 "V" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-9"@en ;
+                rdfs:label "Victor Time Zone"@en ;
+                cco:ont00001753 "V" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001615
 cco:ont00001615 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT-7"@en ;
-                 skos:altLabel "MST"@en ,
-                               "Mountain Standard Time"@en ,
-                               "PNT"@en ,
-                               "Phoenix Standard Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT-7"@en ;
+                skos:altLabel "MST"@en ,
+                              "Mountain Standard Time"@en ,
+                              "PNT"@en ,
+                              "Phoenix Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001624
 cco:ont00001624 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC+7"@en ;
-                 rdfs:label "Golf Time Zone"@en ;
-                 cco:ont00001753 "G" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+7"@en ;
+                rdfs:label "Golf Time Zone"@en ;
+                cco:ont00001753 "G" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001625
 cco:ont00001625 rdf:type owl:NamedIndividual ,
-                          cco:ont00000630 ;
-                 rdfs:comment "UT0 is a variant of Universal Time that is measured by observing the diurnal motion of stars or extragalactic radio sources at a specific location on Earth. It does not take into consideration distorting factors, in particular polar motion, such that its value will differ based on the location it is measured at."@en ;
-                 rdfs:label "Universal Time 0"@en ;
-                 cco:ont00001753 "UT0" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00000630 ;
+                rdfs:comment "UT0 is a variant of Universal Time that is measured by observing the diurnal motion of stars or extragalactic radio sources at a specific location on Earth. It does not take into consideration distorting factors, in particular polar motion, such that its value will differ based on the location it is measured at."@en ;
+                rdfs:label "Universal Time 0"@en ;
+                cco:ont00001753 "UT0" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001626
 cco:ont00001626 rdf:type owl:NamedIndividual ,
-                          cco:ont00000263 ;
-                 rdfs:label "Twelve-Hour Clock Time System"@en ;
-                 skos:altLabel "12-Hour Clock"@en ,
-                               "12-Hour Clock Time System"@en ,
-                               "Twelve Hour Clock"@en ,
-                               "Twelve Hour Clock Time System"@en ,
-                               "Twelve-Hour Clock"@en ;
-                 skos:definition "A Clock Time System for keeping the Time of Day in which the Day runs from midnight to midnight and is divided into two intervals of 12 Hours each, where: the first interval begins at midnight, ends at noon, and is indicated by the suffix 'a.m.'; the second interval begins at noon, ends at midnight, and is indicated by the suffix 'p.m.'; and the midnight and noon Hours are numbered 12 with subsequent Hours numbered 1-11."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=12-hour_clock&oldid=1057602523"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00000263 ;
+                rdfs:label "Twelve-Hour Clock Time System"@en ;
+                skos:altLabel "12-Hour Clock"@en ,
+                              "12-Hour Clock Time System"@en ,
+                              "Twelve Hour Clock"@en ,
+                              "Twelve Hour Clock Time System"@en ,
+                              "Twelve-Hour Clock"@en ;
+                skos:definition "A Clock Time System for keeping the Time of Day in which the Day runs from midnight to midnight and is divided into two intervals of 12 Hours each, where: the first interval begins at midnight, ends at noon, and is indicated by the suffix 'a.m.'; the second interval begins at noon, ends at midnight, and is indicated by the suffix 'p.m.'; and the midnight and noon Hours are numbered 12 with subsequent Hours numbered 1-11."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=12-hour_clock&oldid=1057602523"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001628
 cco:ont00001628 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC-12"@en ,
-                              "Yankee Time Zone is the same local time as Mike Time Zone, but is 1 Day (i.e. 24 Hours) behind Mike Time Zone as they are on opposite sides of the International Date Line."@en ;
-                 rdfs:label "Yankee Time Zone"@en ;
-                 cco:ont00001753 "Y" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-12"@en ,
+                             "Yankee Time Zone is the same local time as Mike Time Zone, but is 1 Day (i.e. 24 Hours) behind Mike Time Zone as they are on opposite sides of the International Date Line."@en ;
+                rdfs:label "Yankee Time Zone"@en ;
+                cco:ont00001753 "Y" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001630
 cco:ont00001630 rdf:type owl:NamedIndividual ,
-                          cco:ont00000469 ;
-                 rdfs:comment """\"WGS 84 is an Earth-centered, Earth-fixed terrestrial reference system and geodetic datum. WGS 84 is based on a consistent set of constants and model parameters that describe the Earth's size, shape, and gravity and geomagnetic fields. WGS 84 is the standard U.S. Department of Defense definition of a global reference system for geospatial information and is the reference system for the Global Positioning System (GPS). It is compatible with the International Terrestrial Reference System (ITRS).\"
+                         cco:ont00000469 ;
+                rdfs:comment """\"WGS 84 is an Earth-centered, Earth-fixed terrestrial reference system and geodetic datum. WGS 84 is based on a consistent set of constants and model parameters that describe the Earth's size, shape, and gravity and geomagnetic fields. WGS 84 is the standard U.S. Department of Defense definition of a global reference system for geospatial information and is the reference system for the Global Positioning System (GPS). It is compatible with the International Terrestrial Reference System (ITRS).\"
 From: (http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf)"""@en ;
-                 rdfs:label "World Geodetic System 1984"@en ;
-                 cco:ont00001753 "WGS 84" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:label "World Geodetic System 1984"@en ;
+                cco:ont00001753 "WGS 84" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001634
 cco:ont00001634 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT-1"@en ;
-                 skos:altLabel "CAT"@en ,
-                               "Central African Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT-1"@en ;
+                skos:altLabel "CAT"@en ,
+                              "Central African Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001648
 cco:ont00001648 rdf:type owl:NamedIndividual ,
-                          cco:ont00000469 ,
-                          cco:ont00001351 ;
-                 rdfs:label "Earth-Centered Earth-Fixed Coordinate System"@en ;
-                 skos:altLabel "Conventional Terrestrial Coordinate System"@en ,
-                               "ECEF"@en ,
-                               "ECR"@en ,
-                               "Earth Centered Earth Fixed"@en ,
-                               "Earth Centered Rotational Coordinate System"@en ,
-                               "Earth-Centered Earth-Fixed"@en ,
-                               "Earth-Centered, Earth-Fixed"@en ;
-                 skos:definition "A Geospatial and Cartesian Coordinate System that identifies positions using an x-axis, y-axis, and z-axis coordinate where the zero point is the center of the Earth, the z-Axis extends toward the North Pole but does not always coincide exactly with the Earth's Axis of Rotation, the x-Axis extends through the intersection of the Prime Meridian and the Equator, the y-Axis completes the right-handed system, and all three axes are fixed to the Earth such that they rotate along with the Earth."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Earth-centered,_Earth-fixed_coordinate_system&oldid=1062678600"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00000469 ,
+                         cco:ont00001351 ;
+                rdfs:label "Earth-Centered Earth-Fixed Coordinate System"@en ;
+                skos:altLabel "Conventional Terrestrial Coordinate System"@en ,
+                              "ECEF"@en ,
+                              "ECR"@en ,
+                              "Earth Centered Earth Fixed"@en ,
+                              "Earth Centered Rotational Coordinate System"@en ,
+                              "Earth-Centered Earth-Fixed"@en ,
+                              "Earth-Centered, Earth-Fixed"@en ;
+                skos:definition "A Geospatial and Cartesian Coordinate System that identifies positions using an x-axis, y-axis, and z-axis coordinate where the zero point is the center of the Earth, the z-Axis extends toward the North Pole but does not always coincide exactly with the Earth's Axis of Rotation, the x-Axis extends through the intersection of the Prime Meridian and the Equator, the y-Axis completes the right-handed system, and all three axes are fixed to the Earth such that they rotate along with the Earth."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Earth-centered,_Earth-fixed_coordinate_system&oldid=1062678600"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001658
 cco:ont00001658 rdf:type owl:NamedIndividual ,
-                          cco:ont00001328 ;
-                 rdfs:comment "Teph (the 'eph' is written as subscript) is an ephemeris time argument developed and calculated at the Jet Propulsion Laboratory (JPL) and implemented in a series of numerically integrated Development Ephemerides (DE), including the currently used DE405. Teph is characterized as a relativistic coordinate time that is nearly equivalent to the IAU's definition of TCB, though Teph is not currently an IAU time standard. Teph is used by the JPL to generate the ephemerides it publishes to support spacecraft navigation and astronomy."@en ;
-                 rdfs:label "Jet Propulsion Laboratory Ephemeris Time Argument"@en ;
-                 skos:altLabel "JPL Ephemeris Time"@en ;
-                 cco:ont00001753 "Teph" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001328 ;
+                rdfs:comment "Teph (the 'eph' is written as subscript) is an ephemeris time argument developed and calculated at the Jet Propulsion Laboratory (JPL) and implemented in a series of numerically integrated Development Ephemerides (DE), including the currently used DE405. Teph is characterized as a relativistic coordinate time that is nearly equivalent to the IAU's definition of TCB, though Teph is not currently an IAU time standard. Teph is used by the JPL to generate the ephemerides it publishes to support spacecraft navigation and astronomy."@en ;
+                rdfs:label "Jet Propulsion Laboratory Ephemeris Time Argument"@en ;
+                skos:altLabel "JPL Ephemeris Time"@en ;
+                cco:ont00001753 "Teph" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001660
 cco:ont00001660 rdf:type owl:NamedIndividual ,
-                          cco:ont00000469 ;
-                 rdfs:comment "This global main field model provides magnetic field values for any location on Earth, e.g. for  navigational purposes (declination) or as a standard for core field subtraction for aeromagnetic surveys. An updated version is adopted by International Association of Geomagnetism and Aeronomy (IAGA) every 5 years)."@en ;
-                 rdfs:label "International Geomagnetic Reference Field"@en ;
-                 cco:ont00001754 "Alken, P., Thébault, E., Beggan, C.D. et al. International Geomagnetic Reference Field: the thirteenth generation. Earth Planets Space 73, 49 (2021). https://doi.org/10.1186/s40623-020-01288-x , https://www.iaga-aiga.org/" .
+                         cco:ont00000469 ;
+                rdfs:comment "This global main field model provides magnetic field values for any location on Earth, e.g. for  navigational purposes (declination) or as a standard for core field subtraction for aeromagnetic surveys. An updated version is adopted by International Association of Geomagnetism and Aeronomy (IAGA) every 5 years)."@en ;
+                rdfs:label "International Geomagnetic Reference Field"@en ;
+                cco:ont00001754 "Alken, P., Thébault, E., Beggan, C.D. et al. International Geomagnetic Reference Field: the thirteenth generation. Earth Planets Space 73, 49 (2021). https://doi.org/10.1186/s40623-020-01288-x , https://www.iaga-aiga.org/" .
 
 
 ###  https://www.commoncoreontologies.org/ont00001661
 cco:ont00001661 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT+8"@en ;
-                 skos:altLabel "CTT"@en ,
-                               "China Taiwan Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT+8"@en ;
+                skos:altLabel "CTT"@en ,
+                              "China Taiwan Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001666
 cco:ont00001666 rdf:type owl:NamedIndividual ,
-                          cco:ont00001328 ;
-                 rdfs:comment """\"Barycentric Coordinate Time (TCB, from the French Temps-coordonnée barycentrique) is a coordinate time standard intended to be used as the independent variable of time for all calculations pertaining to orbits of planets, asteroids, comets, and interplanetary spacecraft in the Solar system. It is equivalent to the proper time experienced by a clock at rest in a coordinate frame co-moving with the barycenter of the Solar system: that is, a clock that performs exactly the same movements as the Solar system but is outside the system's gravity well. It is therefore not influenced by the gravitational time dilation caused by the Sun and the rest of the system.\"
+                         cco:ont00001328 ;
+                rdfs:comment """\"Barycentric Coordinate Time (TCB, from the French Temps-coordonnée barycentrique) is a coordinate time standard intended to be used as the independent variable of time for all calculations pertaining to orbits of planets, asteroids, comets, and interplanetary spacecraft in the Solar system. It is equivalent to the proper time experienced by a clock at rest in a coordinate frame co-moving with the barycenter of the Solar system: that is, a clock that performs exactly the same movements as the Solar system but is outside the system's gravity well. It is therefore not influenced by the gravitational time dilation caused by the Sun and the rest of the system.\"
 From: (https://en.wikipedia.org/wiki/Barycentric_Coordinate_Time)"""@en ;
-                 rdfs:label "Barycentric Coordinate Time"@en ;
-                 cco:ont00001753 "TCB" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:label "Barycentric Coordinate Time"@en ;
+                cco:ont00001753 "TCB" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001674
 cco:ont00001674 rdf:type owl:NamedIndividual ,
-                          cco:ont00000276 ;
-                 rdfs:comment "The Gregorian Calendar was instituted by Pope Gregory XIII via papal bull on 24 February 1582 as a reform of the Julian Calendar to stop the drift of the calendar with respect to the equinoxes and solstices. The Gregorian Calendar is currently the most widely used civil Calendar System in the world and is 13 days ahead of the Julian Calendar Date."@en ;
-                 rdfs:label "Gregorian Calendar"@en ;
-                 skos:definition "A Solar Calendar System that has a regular Year of 365 24-Hour Days divided into 12 Months with a leap day added at the end of February every 4 Years except Years that are evenly divisible by 100 but not 400 such that there are 97 leap Years every 400 Years and the average length of a Gregorian Year is 365.2425 Days (365 Days 5 Hours 49 Minutes 12 Seconds)."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Gregorian_calendar&oldid=1062360692"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00000276 ;
+                rdfs:comment "The Gregorian Calendar was instituted by Pope Gregory XIII via papal bull on 24 February 1582 as a reform of the Julian Calendar to stop the drift of the calendar with respect to the equinoxes and solstices. The Gregorian Calendar is currently the most widely used civil Calendar System in the world and is 13 days ahead of the Julian Calendar Date."@en ;
+                rdfs:label "Gregorian Calendar"@en ;
+                skos:definition "A Solar Calendar System that has a regular Year of 365 24-Hour Days divided into 12 Months with a leap day added at the end of February every 4 Years except Years that are evenly divisible by 100 but not 400 such that there are 97 leap Years every 400 Years and the average length of a Gregorian Year is 365.2425 Days (365 Days 5 Hours 49 Minutes 12 Seconds)."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Gregorian_calendar&oldid=1062360692"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001691
 cco:ont00001691 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT-6"@en ;
-                 skos:altLabel "CST"@en ,
-                               "Central Standard Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT-6"@en ;
+                skos:altLabel "CST"@en ,
+                              "Central Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001692
 cco:ont00001692 rdf:type owl:NamedIndividual ,
-                          cco:ont00001328 ;
-                 rdfs:comment """Unix Time is a Temporal Reference System for describing a point in time, defined as the number of seconds that have elapsed since 00:00:00 Coordinated Universal Time (UTC) Thursday, 1 January 1970 minus the number of leap seconds that have taken place since then.
+                         cco:ont00001328 ;
+                rdfs:comment """Unix Time is a Temporal Reference System for describing a point in time, defined as the number of seconds that have elapsed since 00:00:00 Coordinated Universal Time (UTC) Thursday, 1 January 1970 minus the number of leap seconds that have taken place since then.
 (See: https://en.wikipedia.org/wiki/Unix_time)"""@en ;
-                 rdfs:label "Unix Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                rdfs:label "Unix Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001693
 cco:ont00001693 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC+0"@en ;
-                 rdfs:label "Zulu Time Zone"@en ;
-                 cco:ont00001753 "Z" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+0"@en ;
+                rdfs:label "Zulu Time Zone"@en ;
+                cco:ont00001753 "Z" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001695
 cco:ont00001695 rdf:type owl:NamedIndividual ,
-                          cco:ont00000630 ;
-                 rdfs:comment "UT2 is a variant of Universal Time that smooths UT1 by accounting for both polar motion and variations in Earth's rotation due to seasonal factors, such as changes in vegetation and water or snow distribution."@en ;
-                 rdfs:label "Universal Time 2"@en ;
-                 cco:ont00001753 "UT2" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00000630 ;
+                rdfs:comment "UT2 is a variant of Universal Time that smooths UT1 by accounting for both polar motion and variations in Earth's rotation due to seasonal factors, such as changes in vegetation and water or snow distribution."@en ;
+                rdfs:label "Universal Time 2"@en ;
+                cco:ont00001753 "UT2" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001700
 cco:ont00001700 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Juliet time is used as an indexical to refer to local time without otherwise specifying the time zone."@en ;
-                 rdfs:label "Juliet Time Zone"@en ;
-                 cco:ont00001753 "J" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Juliet time is used as an indexical to refer to local time without otherwise specifying the time zone."@en ;
+                rdfs:label "Juliet Time Zone"@en ;
+                cco:ont00001753 "J" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001701
 cco:ont00001701 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT-3"@en ;
-                 skos:altLabel "AGT"@en ,
-                               "Argentina Standard Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT-3"@en ;
+                skos:altLabel "AGT"@en ,
+                              "Argentina Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001702
 cco:ont00001702 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT+5:30"@en ;
-                 skos:altLabel "Indian Standard Time"@en ,
-                               "Sri Lanka Standard Time"@en ;
-                 cco:ont00001753 "IST" ,
-                                  "SLST" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT+5:30"@en ;
+                skos:altLabel "Indian Standard Time"@en ,
+                              "Sri Lanka Standard Time"@en ;
+                cco:ont00001753 "IST" ,
+                                "SLST" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001704
 cco:ont00001704 rdf:type owl:NamedIndividual ,
-                          cco:ont00001352 ;
-                 rdfs:label "GMT+3"@en ;
-                 skos:altLabel "EAT"@en ,
-                               "Eastern African Time"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001352 ;
+                rdfs:label "GMT+3"@en ;
+                skos:altLabel "EAT"@en ,
+                              "Eastern African Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001712
 cco:ont00001712 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC-5"@en ;
-                 rdfs:label "Romeo Time Zone"@en ;
-                 cco:ont00001753 "R" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-5"@en ;
+                rdfs:label "Romeo Time Zone"@en ;
+                cco:ont00001753 "R" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001716
 cco:ont00001716 rdf:type owl:NamedIndividual ,
-                          cco:ont00000630 ;
-                 rdfs:comment "UT1 is a derivation of UT0 that takes into account distortions caused by polar motion and is proportional to the rotation angle of the Earth with respect to distant quasars, specifically, the International Celestial Reference Frame (ICRF). UT1 is currently the most widely used variant of Universal Time and has the same value everywhere on Earth."@en ;
-                 rdfs:label "Universal Time 1"@en ;
-                 skos:altLabel "Astronomical Time"@en ;
-                 cco:ont00001753 "UT1" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00000630 ;
+                rdfs:comment "UT1 is a derivation of UT0 that takes into account distortions caused by polar motion and is proportional to the rotation angle of the Earth with respect to distant quasars, specifically, the International Celestial Reference Frame (ICRF). UT1 is currently the most widely used variant of Universal Time and has the same value everywhere on Earth."@en ;
+                rdfs:label "Universal Time 1"@en ;
+                skos:altLabel "Astronomical Time"@en ;
+                cco:ont00001753 "UT1" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001723
 cco:ont00001723 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC+4"@en ;
-                 rdfs:label "Delta Time Zone"@en ;
-                 cco:ont00001753 "D" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+4"@en ;
+                rdfs:label "Delta Time Zone"@en ;
+                cco:ont00001753 "D" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001727
 cco:ont00001727 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC+10"@en ;
-                 rdfs:label "Kilo Time Zone"@en ;
-                 cco:ont00001753 "K" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+10"@en ;
+                rdfs:label "Kilo Time Zone"@en ;
+                cco:ont00001753 "K" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001732
 cco:ont00001732 rdf:type owl:NamedIndividual ,
-                          cco:ont00001235 ;
-                 rdfs:comment "Offset from Universal Coordinated Time = UTC+3"@en ;
-                 rdfs:label "Charlie Time Zone"@en ;
-                 cco:ont00001753 "C" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+3"@en ;
+                rdfs:label "Charlie Time Zone"@en ;
+                cco:ont00001753 "C" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
-###  Generated by the OWL API (version 4.5.29) https://github.com/owlcs/owlapi
+###  Generated by the OWL API (version 4.5.26.2023-07-17T20:34:13Z) https://github.com/owlcs/owlapi


### PR DESCRIPTION
1. Relabels Directive ICE as Prescriptive ICE.
2. Changes Designative ICE definition to “An Information Content Entity that consists of a set of symbols that designate some Entity.”
3. Adds an equivalence axiom to Descriptive ICE: ‘Information Content Entity’ and (describes some entity).

See https://github.com/CommonCoreOntology/CommonCoreOntologies/issues/584 and https://github.com/CommonCoreOntology/CommonCoreOntologies/discussions/577 

