### PR TITLE
adding d/r to cco:uses in AgentOntology.ttl (test)

### DIFF
--- a/src/cco-modules/AgentOntology.ttl
+++ b/src/cco-modules/AgentOntology.ttl
@@ -259,6 +259,8 @@ cco:ont00001812 rdf:type owl:ObjectProperty ;
 ###  https://www.commoncoreontologies.org/ont00001813
 cco:ont00001813 rdf:type owl:ObjectProperty ;
                  owl:inverseOf cco:ont00001925 ;
+                 rdfs:domain cco:ont00001017 ;
+                 rdfs:range BFO:0000040 ;
                  rdfs:label "uses"@en ;
                  skos:definition "x uses y iff x is an instance of an Agent and y is an instance of a Material Entity, such that both x and y participate in some instance of a Process wherein x attempts to accomplish a goal by manipulating, deploying, or leveraging some attribute of y."@en ;
                  cco:ont00001760 "https://www.commoncoreontologies.org/AgentOntology"^^xsd:anyURI .


### PR DESCRIPTION
This is the first of a series of changes motivated by Michael Rabenberg's list of domain/range mismatches across cco