### PR TITLE
corrected process starts definition

### DIFF
--- a/src/cco-modules/ExtendedRelationOntology.ttl
+++ b/src/cco-modules/ExtendedRelationOntology.ttl
@@ -548,7 +548,7 @@ cco:ont00001933 rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf cco:ont00001803 ;
                  owl:inverseOf cco:ont00001962 ;
                  rdfs:label "process starts"@en ;
-                 skos:definition "x process_starts y iff x and y are instances of processes, and x is_cause_of y, and i is an instance of a temporal instant, and r is an instant of a temporal interval, and y has starting instance i, and x occurs on r, and r has inside instant i."@en ;
+                 skos:definition "x process_starts y iff x and y are instances of processes, and x is_cause_of y, and i is an instance of a temporal instant, and r is an instance of a temporal interval, and y has starting instance i, and x occurs on r, and r has inside instant i."@en ;
                  skos:scopeNote "A process x starts another process y when x causes y while x is still occurring."@en ;
                  cco:ont00001760 "https://www.commoncoreontologies.org/ExtendedRelationOntology"^^xsd:anyURI .
 
@@ -606,7 +606,7 @@ cco:ont00001959 rdf:type owl:ObjectProperty ;
 cco:ont00001962 rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf cco:ont00001819 ;
                  rdfs:label "process started by"@en ;
-                 skos:definition "x process_started_by y iff x and y are instances of processes, and x is caused_by y, and i is an instance of a temporal instant, and r is an instant of a temporal interval, and x has starting instance i, and y occurs on r, and r has inside instant i."@en ;
+                 skos:definition "x process_started_by y iff x and y are instances of processes, and x is caused_by y, and i is an instance of a temporal instant, and r is an instance of a temporal interval, and x has starting instance i, and y occurs on r, and r has inside instant i."@en ;
                  skos:scopeNote "A process x is started by another process y when y causes x while y is still occurring."@en ;
                  cco:ont00001760 "https://www.commoncoreontologies.org/ExtendedRelationOntology"^^xsd:anyURI .
 

--- a/src/cco-modules/ExtendedRelationOntology.ttl
+++ b/src/cco-modules/ExtendedRelationOntology.ttl
@@ -548,7 +548,7 @@ cco:ont00001933 rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf cco:ont00001803 ;
                  owl:inverseOf cco:ont00001962 ;
                  rdfs:label "process starts"@en ;
-                 skos:definition "x process_starts y iff x and y are instances of processes, and x is_cause_of y, and i is an instance of a temporal instant, and r is an instant of a temporal interval, and y has starting instance i, and x occurs on r, and r interval contains i."@en ;
+                 skos:definition "x process_starts y iff x and y are instances of processes, and x is_cause_of y, and i is an instance of a temporal instant, and r is an instant of a temporal interval, and y has starting instance i, and x occurs on r, and r has inside instant i."@en ;
                  skos:scopeNote "A process x starts another process y when x causes y while x is still occurring."@en ;
                  cco:ont00001760 "https://www.commoncoreontologies.org/ExtendedRelationOntology"^^xsd:anyURI .
 
@@ -606,7 +606,7 @@ cco:ont00001959 rdf:type owl:ObjectProperty ;
 cco:ont00001962 rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf cco:ont00001819 ;
                  rdfs:label "process started by"@en ;
-                 skos:definition "x process_started_by y iff x and y are instances of processes, and x is caused_by y, and i is an instance of a temporal instant, and r is an instant of a temporal interval, and x has starting instance i, and y occurs on r, and r interval contains i."@en ;
+                 skos:definition "x process_started_by y iff x and y are instances of processes, and x is caused_by y, and i is an instance of a temporal instant, and r is an instant of a temporal interval, and x has starting instance i, and y occurs on r, and r has inside instant i."@en ;
                  skos:scopeNote "A process x is started by another process y when y causes x while y is still occurring."@en ;
                  cco:ont00001760 "https://www.commoncoreontologies.org/ExtendedRelationOntology"^^xsd:anyURI .
 


### PR DESCRIPTION
The current definition asserted that a temporal interval 'interval contains' a temporal instant, but the range of 'interval contains' is a one-dimensional temporal region, and a temporal instant is a zero dimensional temporal region.