### PR TITLE
Fixed use of process parthood in Process Profile branch

### DIFF
--- a/src/cco-modules/EventOntology.ttl
+++ b/src/cco-modules/EventOntology.ttl
@@ -1,23 +1,23 @@
 @prefix : <https://www.commoncoreontologies.org/EventOntology#> .
+@prefix cco: <https://www.commoncoreontologies.org/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix cco: <https://www.commoncoreontologies.org/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@base <https://www.commoncoreontologies.org/EventOntology> .
+@base <https://www.commoncoreontologies.org/EventOntology#> .
 
 <https://www.commoncoreontologies.org/EventOntology> rdf:type owl:Ontology ;
-                                                                            owl:versionIRI <https://www.commoncoreontologies.org/2024-11-06/EventOntology> ;
-                                                                            owl:imports <https://www.commoncoreontologies.org/InformationEntityOntology> ;
-                                                                            dcterms:license "BSD 3-Clause: https://github.com/CommonCoreOntology/CommonCoreOntologies/blob/master/LICENSE"@en ;
-                                                                            dcterms:rights "CUBRC Inc., see full license."@en ;
-                                                                            rdfs:comment "This ontology is designed to represent processual entities, especially those performed by agents, that occur within multiple domains."@en ;
-                                                                            rdfs:label "Event Ontology"@en ;
-                                                                            owl:versionInfo "Version 2.0"@en .
+                                                      owl:versionIRI <https://www.commoncoreontologies.org/2024-11-06/EventOntology> ;
+                                                      owl:imports cco:InformationEntityOntology ;
+                                                      dcterms:license "BSD 3-Clause: https://github.com/CommonCoreOntology/CommonCoreOntologies/blob/master/LICENSE"@en ;
+                                                      dcterms:rights "CUBRC Inc., see full license."@en ;
+                                                      rdfs:comment "This ontology is designed to represent processual entities, especially those performed by agents, that occur within multiple domains."@en ;
+                                                      rdfs:label "Event Ontology"@en ;
+                                                      owl:versionInfo "Version 2.0"@en .
 
 #################################################################
 #    Annotation properties
@@ -79,3106 +79,3106 @@ obo:BFO_0000144 rdf:type owl:Class ;
 
 ###  https://www.commoncoreontologies.org/ont00000004
 cco:ont00000004 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000015 ;
-                 rdfs:label "Change"@en ;
-                 skos:definition "A Process in which some independent continuant endures and 1) one or more of the dependent entities it bears increase or decrease in intensity, 2) the entity begins to bear some dependent entity or 3) the entity ceases to bear some dependent entity."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000015 ;
+                rdfs:label "Change"@en ;
+                skos:definition "A Process in which some independent continuant endures and 1) one or more of the dependent entities it bears increase or decrease in intensity, 2) the entity begins to bear some dependent entity or 3) the entity ceases to bear some dependent entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000005
 cco:ont00000005 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000015 ;
-                 rdfs:label "Act"@en ;
-                 skos:definition "A Process in which at least one Agent plays a causative role."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000015 ;
+                rdfs:label "Act"@en ;
+                skos:definition "A Process in which at least one Agent plays a causative role."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000006
 cco:ont00000006 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000530 ;
-                 rdfs:label "Upper Midrange Frequency"@en ;
-                 skos:definition "A Sonic Frequency that is between 2 and 4 kHz."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000530 ;
+                rdfs:label "Upper Midrange Frequency"@en ;
+                skos:definition "A Sonic Frequency that is between 2 and 4 kHz."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000007
 cco:ont00000007 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000015 ;
-                 rdfs:label "Natural Process"@en ;
-                 skos:definition "A Process existing in or produced by nature; rather than by the intent of human beings."@en ;
-                 cco:ont00001754 "http://www.thefreedictionary.com/natural+process" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000015 ;
+                rdfs:label "Natural Process"@en ;
+                skos:definition "A Process existing in or produced by nature; rather than by the intent of human beings."@en ;
+                cco:ont00001754 "http://www.thefreedictionary.com/natural+process" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000008
 cco:ont00000008 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001047 ;
-                 rdfs:label "Sound Frequency"@en ;
-                 skos:definition "A Frequency that is the rate of Oscillations per second of a Sound Wave."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001047 ;
+                rdfs:label "Sound Frequency"@en ;
+                skos:definition "A Frequency that is the rate of Oscillations per second of a Sound Wave."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000011
 cco:ont00000011 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000135 ;
-                 rdfs:label "Nominal Stasis"@en ;
-                 skos:altLabel "Nominal"@en ;
-                 skos:definition "A Stasis of Specifically Dependent Continuant in which some Independent Continuant bears a Quality or Realizable Entity that has a level of intensity or functionality that falls within the designed, expected, or acceptable range such that the Independent Continuant is of normal value, usefulness, or functionality."@en ;
-                 cco:ont00001754 "https://en.oxforddictionaries.com/definition/nominal (Definition 6)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000135 ;
+                rdfs:label "Nominal Stasis"@en ;
+                skos:altLabel "Nominal"@en ;
+                skos:definition "A Stasis of Specifically Dependent Continuant in which some Independent Continuant bears a Quality or Realizable Entity that has a level of intensity or functionality that falls within the designed, expected, or acceptable range such that the Independent Continuant is of normal value, usefulness, or functionality."@en ;
+                cco:ont00001754 "https://en.oxforddictionaries.com/definition/nominal (Definition 6)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000013
 cco:ont00000013 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000554 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:BFO_0000057 ;
-                                   owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000004
-                                                                             [ rdf:type owl:Restriction ;
-                                                                               owl:onProperty obo:BFO_0000101 ;
-                                                                               owl:someValuesFrom obo:BFO_0000031
-                                                                             ]
-                                                                           ) ;
-                                                        rdf:type owl:Class
-                                                      ]
-                                 ] ;
-                 rdfs:label "Gain of Generically Dependent Continuant"@en ;
-                 skos:definition "A Gain of Dependent Continuant wherein some Independent Continuant becomes the carrier of some Generically Dependent Continuant."@en ;
-                 skos:example "A Person forms a Plan, A Person is initiated into a Religion, A photgraphic image is produced." ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000554 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000057 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000004
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:BFO_0000101 ;
+                                                                              owl:someValuesFrom obo:BFO_0000031
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                rdfs:label "Gain of Generically Dependent Continuant"@en ;
+                skos:definition "A Gain of Dependent Continuant wherein some Independent Continuant becomes the carrier of some Generically Dependent Continuant."@en ;
+                skos:example "A Person forms a Plan, A Person is initiated into a Religion, A photgraphic image is produced." ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000016
 cco:ont00000016 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001286 ;
-                 rdfs:label "Triangular Waveform"@en ;
-                 skos:definition "A Waveform that is characterized by a triangular shape due to the continuous linear zig-zag transitions between minimum and maximum Amplitudes of the Wave Cycle."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001286 ;
+                rdfs:label "Triangular Waveform"@en ;
+                skos:definition "A Waveform that is characterized by a triangular shape due to the continuous linear zig-zag transitions between minimum and maximum Amplitudes of the Wave Cycle."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000024
 cco:ont00000024 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000133 ;
-                 rdfs:label "Act of Advising"@en ;
-                 skos:definition "An Act of Directive Communication performed by providing advice or counsel to another agent."@en ;
-                 cco:ont00001754 "http://www.dictionary.com/browse/advising" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000133 ;
+                rdfs:label "Act of Advising"@en ;
+                skos:definition "An Act of Directive Communication performed by providing advice or counsel to another agent."@en ;
+                cco:ont00001754 "http://www.dictionary.com/browse/advising" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000027
 cco:ont00000027 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000517 ;
-                 rdfs:label "Mailing"@en ;
-                 skos:altLabel "Act of Mailing"@en ;
-                 skos:definition "An Act of Communication by Media in which information and tangible objects, usually written documents, are delivered to destinations around the world."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Mail&oldid=1057401839"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000517 ;
+                rdfs:label "Mailing"@en ;
+                skos:altLabel "Act of Mailing"@en ;
+                skos:definition "An Act of Communication by Media in which information and tangible objects, usually written documents, are delivered to destinations around the world."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Mail&oldid=1057401839"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000033
 cco:ont00000033 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000854 ;
-                 rdfs:label "Decrease of Role"@en ;
-                 skos:definition "A Decrease of Realizable Entity in which some Independent Continuant has a decrease of some Role that it bears."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000854 ;
+                rdfs:label "Decrease of Role"@en ;
+                skos:definition "A Decrease of Realizable Entity in which some Independent Continuant has a decrease of some Role that it bears."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000035
 cco:ont00000035 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000490 ;
-                 rdfs:label "Soft X-ray Frequency"@en ;
-                 skos:definition "An X-Ray Frequency that is between 30 petahertz and 3 exahertz."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000490 ;
+                rdfs:label "Soft X-ray Frequency"@en ;
+                skos:definition "An X-Ray Frequency that is between 30 petahertz and 3 exahertz."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000037
 cco:ont00000037 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Act of Observation"@en ;
-                 skos:definition "A Planned Act of acquiring information from a source via the use of one or more senses."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Observation&oldid=1062502087"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Act of Observation"@en ;
+                skos:definition "A Planned Act of acquiring information from a source via the use of one or more senses."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Observation&oldid=1062502087"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000051
 cco:ont00000051 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000908 ;
-                 rdfs:comment "An Act of Construction typically involves the production of only one or a limited number of goods, such as in the construction of an airport or a community of condominiums."@en ;
-                 rdfs:label "Act of Construction"@en ;
-                 skos:definition "An Act of Artifact Processing wherein Artifacts are built on site as prescribed by some contract."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000908 ;
+                rdfs:comment "An Act of Construction typically involves the production of only one or a limited number of goods, such as in the construction of an airport or a community of condominiums."@en ;
+                rdfs:label "Act of Construction"@en ;
+                skos:definition "An Act of Artifact Processing wherein Artifacts are built on site as prescribed by some contract."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000065
 cco:ont00000065 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000357 ;
-                 rdfs:label "Act of Location Change"@en ;
-                 skos:definition "An Act of Motion in which the location of some Object is changed by some Agent."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000357 ;
+                rdfs:label "Act of Location Change"@en ;
+                skos:definition "An Act of Motion in which the location of some Object is changed by some Agent."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000078
 cco:ont00000078 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000345 ;
-                 rdfs:comment "Although the boundary between Act of Estimation and guessing is vague, estimation can be partially distinguished from guessing in that every Act of Estimation has as input some relevant information; whereas an act of guessing can occur sans information (or at least sans pertinent information). For example, if Mr. Green were asked how many blades of grass are in his lawn, he could simply choose a number (i.e. he could guess) or he could estimate the number by counting how many baldes of grass are in 1 square foot of his lawn, measuring the square footage of his lawn, and then multiplying these values to arrive at a number. Hence, many estimates may be loosely considered to be educated guesses."@en ,
-                              "Note that, while every Act of Measuring arguably involves some degree of estimation (for example, a measuring instrument rounding to the nearest ten-thousandth or an Agent reading an analog display), it would be a mistake to classify all Acts of Measuring as Acts of Estimation. This holds even for cases (e.g. census taking) in which sofisticated estimations are often more accurate than other means of measuring (e.g. enumeration)."@en ;
-                 rdfs:label "Act of Estimation"@en ;
-                 skos:altLabel "Act of Approximation"@en ;
-                 skos:definition "An Act of Measuring that involves the comparison of a measurement of a similar Entity or of a portion of the Entity being estimated to produce an approximated measurement of the target Entity."@en ;
-                 skos:example "measuring how much time a train will add to your commute by measuring how long it takes for 10 train cars to pass a given point and then combining this information with an estimate of how many train cars are in a typical train based on your past experience" ,
-                              "measuring the amount of time required to do a task based on how long it took to do a similar task in the past" ,
-                              "measuring the height of a building by counting the number of floors and multiplying it by the height of an average floor in an average building" ,
-                              "measuring the property value of a house based on its square footage and the average cost per square foot of other houses in the area" ;
-                 skos:scopeNote "In all cases, the Agent in an Act of Estimation either lacks complete information, lacks access to the relevant information, or chooses not to use the complete information (perhaps to save money or time) about the thing being estimated; instead, the Agent uses some or all of the relevant information that the Agent does have as a basis for arriving at the estimate."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000345 ;
+                rdfs:comment "Although the boundary between Act of Estimation and guessing is vague, estimation can be partially distinguished from guessing in that every Act of Estimation has as input some relevant information; whereas an act of guessing can occur sans information (or at least sans pertinent information). For example, if Mr. Green were asked how many blades of grass are in his lawn, he could simply choose a number (i.e. he could guess) or he could estimate the number by counting how many baldes of grass are in 1 square foot of his lawn, measuring the square footage of his lawn, and then multiplying these values to arrive at a number. Hence, many estimates may be loosely considered to be educated guesses."@en ,
+                             "Note that, while every Act of Measuring arguably involves some degree of estimation (for example, a measuring instrument rounding to the nearest ten-thousandth or an Agent reading an analog display), it would be a mistake to classify all Acts of Measuring as Acts of Estimation. This holds even for cases (e.g. census taking) in which sofisticated estimations are often more accurate than other means of measuring (e.g. enumeration)."@en ;
+                rdfs:label "Act of Estimation"@en ;
+                skos:altLabel "Act of Approximation"@en ;
+                skos:definition "An Act of Measuring that involves the comparison of a measurement of a similar Entity or of a portion of the Entity being estimated to produce an approximated measurement of the target Entity."@en ;
+                skos:example "measuring how much time a train will add to your commute by measuring how long it takes for 10 train cars to pass a given point and then combining this information with an estimate of how many train cars are in a typical train based on your past experience" ,
+                             "measuring the amount of time required to do a task based on how long it took to do a similar task in the past" ,
+                             "measuring the height of a building by counting the number of floors and multiplying it by the height of an average floor in an average building" ,
+                             "measuring the property value of a house based on its square footage and the average cost per square foot of other houses in the area" ;
+                skos:scopeNote "In all cases, the Agent in an Act of Estimation either lacks complete information, lacks access to the relevant information, or chooses not to use the complete information (perhaps to save money or time) about the thing being estimated; instead, the Agent uses some or all of the relevant information that the Agent does have as a basis for arriving at the estimate."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000079
 cco:ont00000079 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001327 ;
-                 rdfs:label "Act of Social Movement"@en ;
-                 skos:definition "A Social Act composed of a series of performances, displays and campaigns directed at implementing, resisting or undoing a change in society."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Social_movement&oldid=1062720561"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001327 ;
+                rdfs:label "Act of Social Movement"@en ;
+                skos:definition "A Social Act composed of a series of performances, displays and campaigns directed at implementing, resisting or undoing a change in society."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Social_movement&oldid=1062720561"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000083
 cco:ont00000083 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000035 ;
-                 rdfs:label "Process Ending"@en ;
-                 skos:definition "A Process Boundary that occurs on a Zero-Dimensional Temporal Region that is the ending instant of the One-Dimensional Temporal Region on which the Process, of which the Process Boundary is a part, occurs."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000035 ;
+                rdfs:label "Process Ending"@en ;
+                skos:definition "A Process Boundary that occurs on a Zero-Dimensional Temporal Region that is the ending instant of the One-Dimensional Temporal Region on which the Process, of which the Process Boundary is a part, occurs."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000099
 cco:ont00000099 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000007 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:BFO_0000062 ;
-                                   owl:someValuesFrom cco:ont00000765
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001777 ;
-                                   owl:someValuesFrom cco:ont00000752
-                                 ] ;
-                 rdfs:label "Wave Process"@en ;
-                 skos:definition "A Natural Process that involves Oscillation accompanied by a transfer of energy that travels through a portion of matter or spatial region."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Wave&oldid=1062648180"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000007 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000062 ;
+                                  owl:someValuesFrom cco:ont00000765
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000117 ;
+                                  owl:someValuesFrom cco:ont00000752
+                                ] ;
+                rdfs:label "Wave Process"@en ;
+                skos:definition "A Natural Process that involves Oscillation accompanied by a transfer of energy that travels through a portion of matter or spatial region."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Wave&oldid=1062648180"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000100
 cco:ont00000100 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001132 ;
-                 rdfs:label "Stasis of Partially Mission Capable"@en ;
-                 skos:definition "A Stasis of Mission Capability during which the participating Continuant is capable of performing some but not all of its primary functions for the specified Mission."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001132 ;
+                rdfs:label "Stasis of Partially Mission Capable"@en ;
+                skos:definition "A Stasis of Mission Capability during which the participating Continuant is capable of performing some but not all of its primary functions for the specified Mission."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000106
 cco:ont00000106 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001213 ;
-                 rdfs:comment "An End of Life Stasis (EoL) is distinguished from a Stasis of Partially Mission Capable or Stasis of Non-Mission Capable in that EoL is more inclusive such that the participating Artifact may be either Partially or Non-Mission Capable. Additionally, EoL applies only to Artifacts and is typically determined in relation to its original mission and designed primary functions. In contrast, an Artifact's level of Mission Capability depends on the requirements of the mission under consideration such that a given Artifact may simultaneously be Fully Mission Capable for mission1, Partially Mission Capable for mission2, and Non-Mission Capable for mission3."@en ;
-                 rdfs:label "End of Life Stasis"@en ;
-                 skos:definition "A Stasis of Artifact Operationality that holds during a Temporal Interval when the participating Artifact is no longer capable of realizing all of its designed primary Artifact Functions."@en ;
-                 cco:ont00001753 "EOL" ,
-                                  "EoL" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001213 ;
+                rdfs:comment "An End of Life Stasis (EoL) is distinguished from a Stasis of Partially Mission Capable or Stasis of Non-Mission Capable in that EoL is more inclusive such that the participating Artifact may be either Partially or Non-Mission Capable. Additionally, EoL applies only to Artifacts and is typically determined in relation to its original mission and designed primary functions. In contrast, an Artifact's level of Mission Capability depends on the requirements of the mission under consideration such that a given Artifact may simultaneously be Fully Mission Capable for mission1, Partially Mission Capable for mission2, and Non-Mission Capable for mission3."@en ;
+                rdfs:label "End of Life Stasis"@en ;
+                skos:definition "A Stasis of Artifact Operationality that holds during a Temporal Interval when the participating Artifact is no longer capable of realizing all of its designed primary Artifact Functions."@en ;
+                cco:ont00001753 "EOL" ,
+                                "EoL" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000107
 cco:ont00000107 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001048 ;
-                 rdfs:label "Increase of Generically Dependent Continuant"@en ;
-                 skos:definition "An Increase of Dependent Continuant in which some Independent Continuant has an increase of some Generically Dependent Continuant that it bears."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001048 ;
+                rdfs:label "Increase of Generically Dependent Continuant"@en ;
+                skos:definition "An Increase of Dependent Continuant in which some Independent Continuant has an increase of some Generically Dependent Continuant that it bears."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000109
 cco:ont00000109 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Act of Military Force"@en ;
-                 skos:definition "A Planned Act of employing a Military Force to achieve some desired result."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Act of Military Force"@en ;
+                skos:definition "A Planned Act of employing a Military Force to achieve some desired result."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000110
 cco:ont00000110 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000015 ;
-                 rdfs:label "Mechanical Process"@en ;
-                 skos:definition "A Process that is the realization of some Disposition of an Artifact"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000015 ;
+                rdfs:label "Mechanical Process"@en ;
+                skos:definition "A Process that is the realization of some Disposition of an Artifact"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000115
 cco:ont00000115 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000246 ;
-                 rdfs:label "Stasis of Disposition"@en ;
-                 skos:definition "A Stasis of Realizable Entity in which some Independent Continuant bears some Disposition that remains unchanged during a Temporal Interval."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000246 ;
+                rdfs:label "Stasis of Disposition"@en ;
+                skos:definition "A Stasis of Realizable Entity in which some Independent Continuant bears some Disposition that remains unchanged during a Temporal Interval."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000121
 cco:ont00000121 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000588 ;
-                 rdfs:label "Act of Conducting Mass Media Interview"@en ;
-                 skos:definition "An Act of Mass Media Communication involving a conversation between a reporter and a person of public interest, used as a basis of a broadcast or publication."@en ;
-                 cco:ont00001754 "JC3IEDM-MIRD-DMWG-Edition_3.0.2_20090514" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000588 ;
+                rdfs:label "Act of Conducting Mass Media Interview"@en ;
+                skos:definition "An Act of Mass Media Communication involving a conversation between a reporter and a person of public interest, used as a basis of a broadcast or publication."@en ;
+                cco:ont00001754 "JC3IEDM-MIRD-DMWG-Edition_3.0.2_20090514" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000123
 cco:ont00000123 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000402 ;
-                 rdfs:comment "Examples: apologizing, condoling, congratulating, greeting, thanking, accepting (acknowledging an acknowledgment)"@en ;
-                 rdfs:label "Act of Expressive Communication"@en ;
-                 skos:definition "An Act of Communication in which an Agent expresses their attitudes or emotions towards some entity."@en ;
-                 cco:ont00001754 "Derived (loosely) from: John Searle's Speech Acts: An Essay in the Philosophy of Language" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000402 ;
+                rdfs:comment "Examples: apologizing, condoling, congratulating, greeting, thanking, accepting (acknowledging an acknowledgment)"@en ;
+                rdfs:label "Act of Expressive Communication"@en ;
+                skos:definition "An Act of Communication in which an Agent expresses their attitudes or emotions towards some entity."@en ;
+                cco:ont00001754 "Derived (loosely) from: John Searle's Speech Acts: An Essay in the Philosophy of Language" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000131
 cco:ont00000131 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001214 ;
-                 rdfs:label "Increase of Quality"@en ;
-                 skos:definition "An Increase of Specifically Dependent Continuant in which some Indpendent Continuant has an increase of some Quality that it bears."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001214 ;
+                rdfs:label "Increase of Quality"@en ;
+                skos:definition "An Increase of Specifically Dependent Continuant in which some Indpendent Continuant has an increase of some Quality that it bears."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000133
 cco:ont00000133 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000402 ;
-                 rdfs:comment "Examples: advising, admonishing, asking, begging, dismissing, excusing, forbidding, instructing, ordering, permitting, requesting, requiring, suggesting, urging, warning"@en ;
-                 rdfs:label "Act of Directive Communication"@en ;
-                 skos:definition "An Act of Communication that is intended to cause the hearer to take a particular action."@en ;
-                 cco:ont00001754 "Derived (loosely) from: John Searle's Speech Acts: An Essay in the Philosophy of Language" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000402 ;
+                rdfs:comment "Examples: advising, admonishing, asking, begging, dismissing, excusing, forbidding, instructing, ordering, permitting, requesting, requiring, suggesting, urging, warning"@en ;
+                rdfs:label "Act of Directive Communication"@en ;
+                skos:definition "An Act of Communication that is intended to cause the hearer to take a particular action."@en ;
+                cco:ont00001754 "Derived (loosely) from: John Searle's Speech Acts: An Essay in the Philosophy of Language" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000135
 cco:ont00000135 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000819 ;
-                 rdfs:label "Stasis of Specifically Dependent Continuant"@en ;
-                 skos:definition "A Stasis in which some Independent Continuant bears some Specifically Dependent Continuant that remains unchanged during a Temporal Interval."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000819 ;
+                rdfs:label "Stasis of Specifically Dependent Continuant"@en ;
+                skos:definition "A Stasis in which some Independent Continuant bears some Specifically Dependent Continuant that remains unchanged during a Temporal Interval."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000137
 cco:ont00000137 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000836 ;
-                 rdfs:label "Act of Financial Deposit"@en ;
-                 skos:definition "An Act of Financial Instrument Use wherein a Financial Instrument is transferred by an Agent (the Depositor) to another Agent to create a liability to be repaid to the Depositor through an Act of Financial Withdrawal."@en ;
-                 cco:ont00001754 "http://en.wikipedia.org/wiki/Deposit_(bank)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000836 ;
+                rdfs:label "Act of Financial Deposit"@en ;
+                skos:definition "An Act of Financial Instrument Use wherein a Financial Instrument is transferred by an Agent (the Depositor) to another Agent to create a liability to be repaid to the Depositor through an Act of Financial Withdrawal."@en ;
+                cco:ont00001754 "http://en.wikipedia.org/wiki/Deposit_(bank)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000138
 cco:ont00000138 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000503 ;
-                 rdfs:label "Maximum Power"@en ;
-                 skos:definition "A Power that is characterized by the maximum rate of Work, or Energy consumed, done in a given time period."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000503 ;
+                rdfs:label "Maximum Power"@en ;
+                skos:definition "A Power that is characterized by the maximum rate of Work, or Energy consumed, done in a given time period."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000142
 cco:ont00000142 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Act of Government"@en ;
-                 skos:definition "A Planned Act that is initiated or supported by some Geopolitical Entity and enforced by some Government Agent."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Act of Government"@en ;
+                skos:definition "A Planned Act that is initiated or supported by some Geopolitical Entity and enforced by some Government Agent."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000144
 cco:ont00000144 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000433 ;
-                 rdfs:label "Act of Meeting"@en ;
-                 skos:definition "An Act of Association wherein two or more Persons assemble for some common purpose."@en ;
-                 cco:ont00001754 "http://wordnetweb.princeton.edu/perl/webwn?s=meet (Sense Key: meet%2:41:00, get together%2:41:00)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000433 ;
+                rdfs:label "Act of Meeting"@en ;
+                skos:definition "An Act of Association wherein two or more Persons assemble for some common purpose."@en ;
+                cco:ont00001754 "http://wordnetweb.princeton.edu/perl/webwn?s=meet (Sense Key: meet%2:41:00, get together%2:41:00)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000148
 cco:ont00000148 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000368 ;
-                 rdfs:label "Clockwise Rotational Motion"@en ;
-                 skos:altLabel "CW Rotational Motion"@en ,
-                               "Clockwise Rotation"@en ;
-                 skos:definition "A Rotational Motion in which the direction of rotation is toward the right as seen relative to the designated side of the plane of rotation."@en ;
-                 skos:example "the axial rotation of the Earth as seen from above the South Pole" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000368 ;
+                rdfs:label "Clockwise Rotational Motion"@en ;
+                skos:altLabel "CW Rotational Motion"@en ,
+                              "Clockwise Rotation"@en ;
+                skos:definition "A Rotational Motion in which the direction of rotation is toward the right as seen relative to the designated side of the plane of rotation."@en ;
+                skos:example "the axial rotation of the Earth as seen from above the South Pole" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000149
 cco:ont00000149 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000517 ;
-                 rdfs:label "Instant Messaging"@en ;
-                 skos:altLabel "Act of IMing"@en ,
-                               "Act of Instant Messaging"@en ;
-                 skos:definition "An Act of Communication by Media in which real-time direct text-based communication occurs between two or more people using personal computers or other devices, along with shared Instant Messaging Client Software conveyed over a network, such as the Internet."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Instant_messaging&oldid=1062873579"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000517 ;
+                rdfs:label "Instant Messaging"@en ;
+                skos:altLabel "Act of IMing"@en ,
+                              "Act of Instant Messaging"@en ;
+                skos:definition "An Act of Communication by Media in which real-time direct text-based communication occurs between two or more people using personal computers or other devices, along with shared Instant Messaging Client Software conveyed over a network, such as the Internet."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Instant_messaging&oldid=1062873579"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000150
 cco:ont00000150 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000754 ;
-                 rdfs:label "Radio Frequency"@en ;
-                 skos:definition "An Electromagnetic Radiation Frequency of some Electromagnetic Wave that is between 3 kHz and 300 GHz."@en ;
-                 cco:ont00001753 "RF" ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Radio_wave&oldid=1062110903"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000754 ;
+                rdfs:label "Radio Frequency"@en ;
+                skos:definition "An Electromagnetic Radiation Frequency of some Electromagnetic Wave that is between 3 kHz and 300 GHz."@en ;
+                cco:ont00001753 "RF" ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Radio_wave&oldid=1062110903"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000151
 cco:ont00000151 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000379 ;
-                 rdfs:label "Act of Reporting"@en ;
-                 skos:definition "An Act of Representative Communication performed by giving a detailed account or statement."@en ;
-                 cco:ont00001754 "http://www.merriam-webster.com/dictionary/report" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000379 ;
+                rdfs:label "Act of Reporting"@en ;
+                skos:definition "An Act of Representative Communication performed by giving a detailed account or statement."@en ;
+                cco:ont00001754 "http://www.merriam-webster.com/dictionary/report" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000155
 cco:ont00000155 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001337 ;
-                 rdfs:label "Near Infrared Light Frequency"@en ;
-                 skos:definition "An Infrared Light Frequency that is between 214 and 400 terahertz."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electromagnetic_spectrum&oldid=1063851392"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001337 ;
+                rdfs:label "Near Infrared Light Frequency"@en ;
+                skos:definition "An Infrared Light Frequency that is between 214 and 400 terahertz."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electromagnetic_spectrum&oldid=1063851392"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000165
 cco:ont00000165 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Criminal Act"@en ;
-                 skos:definition "A Planned Act committed in violation of rules or laws for which some governing authority (via mechanisms such as legal systems) can prescribe a conviction."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Crime&oldid=1062237249"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Criminal Act"@en ;
+                skos:definition "A Planned Act committed in violation of rules or laws for which some governing authority (via mechanisms such as legal systems) can prescribe a conviction."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Crime&oldid=1062237249"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000166
 cco:ont00000166 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000099 ;
-                 rdfs:label "Wave Cycle"@en ;
-                 skos:definition "A Wave Process that consists of a portion of a Wave Process that begins at an arbitrary point of the Wave Process and ends at the next point when the pattern of the Wave Process begins to repeat."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000099 ;
+                rdfs:label "Wave Cycle"@en ;
+                skos:definition "A Wave Process that consists of a portion of a Wave Process that begins at an arbitrary point of the Wave Process and ends at the next point when the pattern of the Wave Process begins to repeat."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000168
 cco:ont00000168 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000433 ;
-                 rdfs:label "Act of Interpersonal Relationship"@en ;
-                 skos:definition "An Act of Association between two or more Persons that may range from fleeting to enduring."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Interpersonal_relationship&oldid=1060991304"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000433 ;
+                rdfs:label "Act of Interpersonal Relationship"@en ;
+                skos:definition "An Act of Association between two or more Persons that may range from fleeting to enduring."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Interpersonal_relationship&oldid=1060991304"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000169
 cco:ont00000169 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000150 ;
-                 rdfs:comment "The corresponding Wavelength range is 10–1 m"@en ;
-                 rdfs:label "Very High Frequency"@en ;
-                 skos:altLabel "ITU Band Number 8"@en ;
-                 skos:definition "A Radio Frequency that is between 30 and 300 MHz."@en ;
-                 cco:ont00001753 "VHF" ;
-                 cco:ont00001754 "International Telecommunication Union (ITU) and IEEE 521-2002 - IEEE Standard Letter Designations for Radar-Frequency Bands" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000150 ;
+                rdfs:comment "The corresponding Wavelength range is 10–1 m"@en ;
+                rdfs:label "Very High Frequency"@en ;
+                skos:altLabel "ITU Band Number 8"@en ;
+                skos:definition "A Radio Frequency that is between 30 and 300 MHz."@en ;
+                cco:ont00001753 "VHF" ;
+                cco:ont00001754 "International Telecommunication Union (ITU) and IEEE 521-2002 - IEEE Standard Letter Designations for Radar-Frequency Bands" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000179
 cco:ont00000179 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000570 ;
-                 rdfs:comment "More generally, Thrust is the propulsive Force of a Rocket."@en ;
-                 rdfs:label "Thrust"@en ;
-                 skos:definition "A Force that is equal in magnitude to but in the opposite direction of an exerted Force and which is used to describe the forward Force of a Jet or Rocket Engine in reaction to the Acceleration of its Reaction Mass in the opposite direction."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000570 ;
+                rdfs:comment "More generally, Thrust is the propulsive Force of a Rocket."@en ;
+                rdfs:label "Thrust"@en ;
+                skos:definition "A Force that is equal in magnitude to but in the opposite direction of an exerted Force and which is used to describe the forward Force of a Jet or Rocket Engine in reaction to the Acceleration of its Reaction Mass in the opposite direction."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000182
 cco:ont00000182 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000123 ;
-                 rdfs:label "Act of Thanking"@en ;
-                 skos:definition "An Act of Expressive Communication performed by expressing gratitude."@en ;
-                 cco:ont00001754 " http://www.merriam-webster.com/dictionary/thanks" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000123 ;
+                rdfs:label "Act of Thanking"@en ;
+                skos:definition "An Act of Expressive Communication performed by expressing gratitude."@en ;
+                cco:ont00001754 " http://www.merriam-webster.com/dictionary/thanks" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000191
 cco:ont00000191 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001147 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001803 ;
-                                   owl:someValuesFrom cco:ont00000920
-                                 ] ;
-                 rdfs:label "Act of Homicide"@en ;
-                 skos:definition "An Act of Violence which causes the unlawful killing of another person."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001147 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty cco:ont00001803 ;
+                                  owl:someValuesFrom cco:ont00000920
+                                ] ;
+                rdfs:label "Act of Homicide"@en ;
+                skos:definition "An Act of Violence which causes the unlawful killing of another person."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000197
 cco:ont00000197 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000035 ;
-                 rdfs:label "Process Beginning"@en ;
-                 skos:definition "A Process Boundary that occurs on a Zero-Dimensional Temporal Region that is the starting instant of the One-Dimensional Temporal Region on which the Process, of which the Process Boundary is a part, occurs."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000035 ;
+                rdfs:label "Process Beginning"@en ;
+                skos:definition "A Process Boundary that occurs on a Zero-Dimensional Temporal Region that is the starting instant of the One-Dimensional Temporal Region on which the Process, of which the Process Boundary is a part, occurs."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000200
 cco:ont00000200 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000890 ;
-                 rdfs:label "Act of Pilgrimage"@en ;
-                 skos:definition "An Act of Travel to a location of importance to a person's beliefs and faith."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Pilgrimage&oldid=1056524204"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000890 ;
+                rdfs:label "Act of Pilgrimage"@en ;
+                skos:definition "An Act of Travel to a location of importance to a person's beliefs and faith."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Pilgrimage&oldid=1056524204"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000201
 cco:ont00000201 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000065 ;
-                 rdfs:label "Act of Change of Residence"@en ;
-                 skos:definition "An Act of Location Change involving one or more Persons moving from one place of residence to another."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000065 ;
+                rdfs:label "Act of Change of Residence"@en ;
+                skos:definition "An Act of Location Change involving one or more Persons moving from one place of residence to another."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000202
 cco:ont00000202 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001075 ;
-                 rdfs:label "Act of Terrorist Training Instruction"@en ;
-                 skos:definition "An Act of Training Instruction performed by an Agent who realizes a capacity derived from the Agent's affiliation with some Terrorist Organization by imparting knowledge of the tactics, techniques, and/or strategies of the use of violence against civilians in order to attain goals that are political, religous, or ideological in nature to an Agent either directly or indirectly through some communication medium."@en ;
-                 cco:ont00001754 "http://wordnetweb.princeton.edu/perl/webwn?s=terrorism" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001075 ;
+                rdfs:label "Act of Terrorist Training Instruction"@en ;
+                skos:definition "An Act of Training Instruction performed by an Agent who realizes a capacity derived from the Agent's affiliation with some Terrorist Organization by imparting knowledge of the tactics, techniques, and/or strategies of the use of violence against civilians in order to attain goals that are political, religous, or ideological in nature to an Agent either directly or indirectly through some communication medium."@en ;
+                cco:ont00001754 "http://wordnetweb.princeton.edu/perl/webwn?s=terrorism" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000208
 cco:ont00000208 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000123 ;
-                 rdfs:label "Act of Congratulating"@en ;
-                 skos:definition "An Act of Expressive Communication performed by expressing vicarious pleasure to a person on the occasion of their success or good fortune."@en ;
-                 cco:ont00001754 "http://www.merriam-webster.com/dictionary/congratulate" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000123 ;
+                rdfs:label "Act of Congratulating"@en ;
+                skos:definition "An Act of Expressive Communication performed by expressing vicarious pleasure to a person on the occasion of their success or good fortune."@en ;
+                cco:ont00001754 "http://www.merriam-webster.com/dictionary/congratulate" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000209
 cco:ont00000209 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000313 ;
-                 rdfs:label "Sound Wavelength"@en ;
-                 skos:definition "A Wavelength that is the distance a Sound Wave traverses during one Wave Cycle."@en ;
-                 cco:ont00001754 "http://www.physicsclassroom.com/Class/waves/u10l2b.cfm" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000313 ;
+                rdfs:label "Sound Wavelength"@en ;
+                skos:definition "A Wavelength that is the distance a Sound Wave traverses during one Wave Cycle."@en ;
+                cco:ont00001754 "http://www.physicsclassroom.com/Class/waves/u10l2b.cfm" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000222
 cco:ont00000222 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000530 ;
-                 rdfs:label "Presence Frequency"@en ;
-                 skos:definition "A Sonic Frequency that is between 4 and 6 kHz."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000530 ;
+                rdfs:label "Presence Frequency"@en ;
+                skos:definition "A Sonic Frequency that is between 4 and 6 kHz."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000228
 cco:ont00000228 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000005 ;
-                 rdfs:label "Planned Act"@en ;
-                 skos:altLabel "Intentional Act"@en ;
-                 skos:definition "An Act in which at least one Agent plays a causative role and which is prescribed by some Directive Information Content Entity held by at least one of the Agents."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000005 ;
+                rdfs:label "Planned Act"@en ;
+                skos:altLabel "Intentional Act"@en ;
+                skos:definition "An Act in which at least one Agent plays a causative role and which is prescribed by some Directive Information Content Entity held by at least one of the Agents."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000234
 cco:ont00000234 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Act of Training"@en ;
-                 skos:definition "A Planned Act in which knowledge, skills or values are imparted from one or more Agents to at least one other Agent."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Education&oldid=1064011752"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Act of Training"@en ;
+                skos:definition "A Planned Act in which knowledge, skills or values are imparted from one or more Agents to at least one other Agent."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Education&oldid=1064011752"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000235
 cco:ont00000235 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000687 ;
-                 rdfs:label "Act of Vocational Training Acquisition"@en ;
-                 skos:definition "An Act of Training Acquisition performed by an Agent by acquiring skills required for a specific occupation in industry, agriculture or trade from an Agent or communication medium that realizes a capacity derived from its affiliation with a Vocational School, Technical School, Trade Organization, or Industry Educational Program Provider."@en ;
-                 cco:ont00001754 "http://wordnetweb.princeton.edu/perl/webwn?s=vocational%20training" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000687 ;
+                rdfs:label "Act of Vocational Training Acquisition"@en ;
+                skos:definition "An Act of Training Acquisition performed by an Agent by acquiring skills required for a specific occupation in industry, agriculture or trade from an Agent or communication medium that realizes a capacity derived from its affiliation with a Vocational School, Technical School, Trade Organization, or Industry Educational Program Provider."@en ;
+                cco:ont00001754 "http://wordnetweb.princeton.edu/perl/webwn?s=vocational%20training" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000237
 cco:ont00000237 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000687 ;
-                 rdfs:label "Act of Terrorist Training Acquisition"@en ;
-                 skos:definition "An Act of Training Acquisition performed by an Agent by acquiring knowledge of the tactics, techniques, and/or strategies of the use of violence against civilians in order to attain goals that are political, religous, or ideological in nature from an Agent or communication medium that realizes a capacity derived from its affiliation with a Terrorist Organization."@en ;
-                 cco:ont00001754 "http://wordnetweb.princeton.edu/perl/webwn?s=terrorism" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000687 ;
+                rdfs:label "Act of Terrorist Training Acquisition"@en ;
+                skos:definition "An Act of Training Acquisition performed by an Agent by acquiring knowledge of the tactics, techniques, and/or strategies of the use of violence against civilians in order to attain goals that are political, religous, or ideological in nature from an Agent or communication medium that realizes a capacity derived from its affiliation with a Terrorist Organization."@en ;
+                cco:ont00001754 "http://wordnetweb.princeton.edu/perl/webwn?s=terrorism" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000240
 cco:ont00000240 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001162 ;
-                 rdfs:label "Act of Oath Taking"@en ;
-                 skos:definition "An Act of Commissive Communication performed by stating or promising, usually calling upon something or someone that the oath maker considers sacred."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Oath&oldid=1052326917"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001162 ;
+                rdfs:label "Act of Oath Taking"@en ;
+                skos:definition "An Act of Commissive Communication performed by stating or promising, usually calling upon something or someone that the oath maker considers sacred."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Oath&oldid=1052326917"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000246
 cco:ont00000246 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000135 ;
-                 rdfs:label "Stasis of Realizable Entity"@en ;
-                 skos:definition "A Stasis of Specifically Dependent Continuant in which some Independent Continuant bears some Realizable Entity that remains unchanged during a Temporal Interval."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000135 ;
+                rdfs:label "Stasis of Realizable Entity"@en ;
+                skos:definition "A Stasis of Specifically Dependent Continuant in which some Independent Continuant bears some Realizable Entity that remains unchanged during a Temporal Interval."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000250
 cco:ont00000250 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000865 ;
-                 rdfs:label "Loss of Realizable Entity"@en ;
-                 skos:definition "A Loss of Specifically Dependent Continuant in which some Independent Continuant ceases to be the bearer of some Realizable Entity."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000865 ;
+                rdfs:label "Loss of Realizable Entity"@en ;
+                skos:definition "A Loss of Specifically Dependent Continuant in which some Independent Continuant ceases to be the bearer of some Realizable Entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000260
 cco:ont00000260 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000675 ;
-                 rdfs:label "Muzzle Blast"@en ;
-                 skos:definition "A Sound Wave Process that is caused by a projectile being pushed from the barrel of a firearm by an explosive charge."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000675 ;
+                rdfs:label "Muzzle Blast"@en ;
+                skos:definition "A Sound Wave Process that is caused by a projectile being pushed from the barrel of a firearm by an explosive charge."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000261
 cco:ont00000261 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000754 ;
-                 rdfs:comment """Currently gamma radiation is distinguished from x-rays by their source--either inside or outside of the nucleus--rather than by frequency, energy, and wavelength.
+                rdfs:subClassOf cco:ont00000754 ;
+                rdfs:comment """Currently gamma radiation is distinguished from x-rays by their source--either inside or outside of the nucleus--rather than by frequency, energy, and wavelength.
 https://en.wikipedia.org/wiki/Gamma_ray#Naming_conventions_and_overlap_in_terminology"""@en ;
-                 rdfs:label "Gamma Ray Frequency"@en ;
-                 skos:definition "An Electromagnetic Radiation Frequency of some Electromagnetic Wave that is above 30 exahertz."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Gamma_ray&oldid=1062115897"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:label "Gamma Ray Frequency"@en ;
+                skos:definition "An Electromagnetic Radiation Frequency of some Electromagnetic Wave that is above 30 exahertz."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Gamma_ray&oldid=1062115897"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000265
 cco:ont00000265 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001327 ;
-                 rdfs:label "Election"@en ;
-                 skos:altLabel "Act of Political Election"@en ;
-                 skos:definition "A Social Act by which a population chooses an individual to hold public office."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Election&oldid=1063238552"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001327 ;
+                rdfs:label "Election"@en ;
+                skos:altLabel "Act of Political Election"@en ;
+                skos:definition "A Social Act by which a population chooses an individual to hold public office."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Election&oldid=1063238552"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000272
 cco:ont00000272 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000007 ;
-                 rdfs:label "Combustion"@en ;
-                 skos:altLabel "Burning Process"@en ,
-                               "Combustion Process"@en ;
-                 skos:definition "A Natural Process in which a Portion of Fuel or other Material Entity is burned."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000007 ;
+                rdfs:label "Combustion"@en ;
+                skos:altLabel "Burning Process"@en ,
+                              "Combustion Process"@en ;
+                skos:definition "A Natural Process in which a Portion of Fuel or other Material Entity is burned."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000278
 cco:ont00000278 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000144 ;
-                 rdfs:comment "The SI unit of measure for Momentum is Newton seconds (N s)."@en ;
-                 rdfs:label "Momentum"@en ;
-                 skos:definition "A Process Profile of an object in Motion that is the product of its Mass and Velocity with respect to a frame of reference."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000144 ;
+                rdfs:comment "The SI unit of measure for Momentum is Newton seconds (N s)."@en ;
+                rdfs:label "Momentum"@en ;
+                skos:definition "A Process Profile of an object in Motion that is the product of its Mass and Velocity with respect to a frame of reference."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000286
 cco:ont00000286 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000100 ;
-                 rdfs:label "Stasis of Partially Mission Capable Maintenance"@en ;
-                 skos:definition "A Stasis of Partially Mission Capable during which the participating Continuant is not capable of performing some of its primary functions for the specified Mission due to participating in an Act Of Maintenance."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000100 ;
+                rdfs:label "Stasis of Partially Mission Capable Maintenance"@en ;
+                skos:definition "A Stasis of Partially Mission Capable during which the participating Continuant is not capable of performing some of its primary functions for the specified Mission due to participating in an Act Of Maintenance."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000290
 cco:ont00000290 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000726 ;
-                 rdfs:label "Decrease of Specifically Dependent Continuant"@en ;
-                 skos:definition "A Decrease of Dependent Continuant in which some Independent Continuant has a decrease in some Specifically Dependent Continuant that it bears."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000726 ;
+                rdfs:label "Decrease of Specifically Dependent Continuant"@en ;
+                skos:definition "A Decrease of Dependent Continuant in which some Independent Continuant has a decrease in some Specifically Dependent Continuant that it bears."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000291
 cco:ont00000291 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000566 ;
-                 rdfs:label "Act of Decoy Use"@en ;
-                 skos:definition "An Act of Artifact Employment in which some Agent uses some Decoy."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000566 ;
+                rdfs:label "Act of Decoy Use"@en ;
+                skos:definition "An Act of Artifact Employment in which some Agent uses some Decoy."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000296
 cco:ont00000296 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000763 ;
-                 rdfs:label "Angular Velocity"@en ;
-                 skos:altLabel "Rotational Velocity"@en ;
-                 skos:definition "A Velocity that is characterized by both the angular Speed of an object and the Axis about which the object is Rotating."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Angular_velocity&oldid=1060081663"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000763 ;
+                rdfs:label "Angular Velocity"@en ;
+                skos:altLabel "Rotational Velocity"@en ;
+                skos:definition "A Velocity that is characterized by both the angular Speed of an object and the Axis about which the object is Rotating."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Angular_velocity&oldid=1060081663"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000305
 cco:ont00000305 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000380 ;
-                 rdfs:label "Sound Pressure"@en ;
-                 skos:altLabel "Acoustic Pressure"@en ;
-                 skos:definition "A Pressure that is caused by a Sound Wave and is a local deviation from the ambient Pressure."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000380 ;
+                rdfs:label "Sound Pressure"@en ;
+                skos:altLabel "Acoustic Pressure"@en ;
+                skos:definition "A Pressure that is caused by a Sound Wave and is a local deviation from the ambient Pressure."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000308
 cco:ont00000308 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001226 ;
-                 rdfs:label "Act of Military Service"@en ;
-                 skos:definition "An Act of Employment wherein a Person serves as a member of a Military Force, whether voluntarily or by conscription."@en ;
-                 cco:ont00001754 "http://www.collinsdictionary.com/dictionary/english/military-service" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001226 ;
+                rdfs:label "Act of Military Service"@en ;
+                skos:definition "An Act of Employment wherein a Person serves as a member of a Military Force, whether voluntarily or by conscription."@en ;
+                cco:ont00001754 "http://www.collinsdictionary.com/dictionary/english/military-service" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000312
 cco:ont00000312 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000007 ;
-                 rdfs:label "Propulsion Process"@en ;
-                 skos:definition "A Natural Process in which one or more Forces are generated and applied to a participating Object such that the Object is set in Motion or has the direction or magnitude of its Motion altered."@en ;
-                 skos:example "a twin-engine turboprop plane rotating both of its propellers against a portion of atmosphere to propel the plane forward" ,
-                              "an apple falling to the ground under the power of Earth's gravitational force" ,
-                              "burning a portion of fuel to produce exhaust that is ejected through a jet nozzle to propel a rocket and its payload" ,
-                              "heat from a fire causing ashes to rise into the sky" ,
-                              "launching a water balloon using a sling shot" ,
-                              "the wind blowing leaves across a lawn" ,
-                              "turning a paddle wheel against a portion of water to propel the paddle boat forward" ;
-                 skos:scopeNote "In each case, a Propulsion Process minimally involves the Object being propelled, a Reaction Mass (e.g. a portion of water, atmosphere, exhaust, etc.), and the Force(s) acting between these two entities."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000007 ;
+                rdfs:label "Propulsion Process"@en ;
+                skos:definition "A Natural Process in which one or more Forces are generated and applied to a participating Object such that the Object is set in Motion or has the direction or magnitude of its Motion altered."@en ;
+                skos:example "a twin-engine turboprop plane rotating both of its propellers against a portion of atmosphere to propel the plane forward" ,
+                             "an apple falling to the ground under the power of Earth's gravitational force" ,
+                             "burning a portion of fuel to produce exhaust that is ejected through a jet nozzle to propel a rocket and its payload" ,
+                             "heat from a fire causing ashes to rise into the sky" ,
+                             "launching a water balloon using a sling shot" ,
+                             "the wind blowing leaves across a lawn" ,
+                             "turning a paddle wheel against a portion of water to propel the paddle boat forward" ;
+                skos:scopeNote "In each case, a Propulsion Process minimally involves the Object being propelled, a Reaction Mass (e.g. a portion of water, atmosphere, exhaust, etc.), and the Force(s) acting between these two entities."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000313
 cco:ont00000313 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000752 ;
-                 rdfs:comment "Assuming a non-dispersive media, the Wavelength will be the inverse of the Frequency."@en ;
-                 rdfs:label "Wavelength"@en ;
-                 skos:definition "A Wave Process Profile that is the distance the Wave Process traverses during one Wave Cycle."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000752 ;
+                rdfs:comment "Assuming a non-dispersive media, the Wavelength will be the inverse of the Frequency."@en ;
+                rdfs:label "Wavelength"@en ;
+                skos:definition "A Wave Process Profile that is the distance the Wave Process traverses during one Wave Cycle."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000320
 cco:ont00000320 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001251 ;
-                 rdfs:label "Act of Reconnaissance"@en ;
-                 skos:definition "An Act of Intelligence Gathering used to determine an Agent's disposition and intention; the composition and capabilities of Equipment and Facilities, and the surrounding landforms and weather conditions."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Reconnaissance&oldid=1038843823"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001251 ;
+                rdfs:label "Act of Reconnaissance"@en ;
+                skos:definition "An Act of Intelligence Gathering used to determine an Agent's disposition and intention; the composition and capabilities of Equipment and Facilities, and the surrounding landforms and weather conditions."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Reconnaissance&oldid=1038843823"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000322
 cco:ont00000322 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000836 ;
-                 rdfs:label "Act of Funding"@en ;
-                 skos:definition "An Act of Financial Instrument Use in which an Agent provides a sum of money to another Agent for a particular purpose."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000836 ;
+                rdfs:label "Act of Funding"@en ;
+                skos:definition "An Act of Financial Instrument Use in which an Agent provides a sum of money to another Agent for a particular purpose."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000335
 cco:ont00000335 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000819 ;
-                 rdfs:label "Stasis of Generically Dependent Continuant"@en ;
-                 skos:definition "A Stasis in which some Independent Continuant bears some Generically Dependent Continuant that remains unchanged during a Temporal Interval."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000819 ;
+                rdfs:label "Stasis of Generically Dependent Continuant"@en ;
+                skos:definition "A Stasis in which some Independent Continuant bears some Generically Dependent Continuant that remains unchanged during a Temporal Interval."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000345
 cco:ont00000345 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Act of Measuring"@en ;
-                 skos:definition "A Planned Act that involves determining the extent, dimensions, quanity, or quality of an Entity relative to some standard."@en ;
-                 skos:example "putting an object on a scale to measure its weight in kilograms" ,
-                              "rating Hollywood movies on a 1 to 5 star scale" ,
-                              "using a tape measure to determine the height and width of a doorway in inches" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Act of Measuring"@en ;
+                skos:definition "A Planned Act that involves determining the extent, dimensions, quanity, or quality of an Entity relative to some standard."@en ;
+                skos:example "putting an object on a scale to measure its weight in kilograms" ,
+                             "rating Hollywood movies on a 1 to 5 star scale" ,
+                             "using a tape measure to determine the height and width of a doorway in inches" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000351
 cco:ont00000351 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000133 ;
-                 rdfs:label "Act of Commanding"@en ;
-                 skos:definition "An Act of Directive Communication through which an Agent exercises authoritative control or power over another Agent's actions."@en ;
-                 cco:ont00001754 "http://wordnetweb.princeton.edu/perl/webwn?s=commanding (Edited 08-22-2016)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000133 ;
+                rdfs:label "Act of Commanding"@en ;
+                skos:definition "An Act of Directive Communication that exercises authoritative control or power over another agent's actions."@en ;
+                cco:ont00001754 "http://wordnetweb.princeton.edu/perl/webwn?s=commanding (Edited 08-22-2016)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000354
 cco:ont00000354 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000379 ;
-                 rdfs:label "Act of Testifying"@en ;
-                 skos:definition "An Act of Representative Communication performed by stating one's personal knowledge or belief."@en ;
-                 cco:ont00001754 "http://www.merriam-webster.com/dictionary/testify" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000379 ;
+                rdfs:label "Act of Testifying"@en ;
+                skos:definition "An Act of Representative Communication performed by stating one's personal knowledge or belief."@en ;
+                cco:ont00001754 "http://www.merriam-webster.com/dictionary/testify" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000356
 cco:ont00000356 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000588 ;
-                 rdfs:label "Act of Publishing Mass Media Article"@en ;
-                 skos:definition "An Act of Mass Media Communication involving the preparation and public issuance of a non-fictional essay, especially one included with others in a newspaper, magazine, journal, etc."@en ;
-                 cco:ont00001754 "JC3IEDM-MIRD-DMWG-Edition_3.0.2_20090514" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000588 ;
+                rdfs:label "Act of Publishing Mass Media Article"@en ;
+                skos:definition "An Act of Mass Media Communication involving the preparation and public issuance of a non-fictional essay, especially one included with others in a newspaper, magazine, journal, etc."@en ;
+                cco:ont00001754 "JC3IEDM-MIRD-DMWG-Edition_3.0.2_20090514" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000357
 cco:ont00000357 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Act of Motion"@en ;
-                 skos:definition "A Planned Act by which an Agent causes the position or location of some Object to change."@en ;
-                 cco:ont00001754 "http://www.merriam-webster.com/dictionary/motion" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Act of Motion"@en ;
+                skos:definition "A Planned Act by which an Agent causes the position or location of some Object to change."@en ;
+                cco:ont00001754 "http://www.merriam-webster.com/dictionary/motion" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000360
 cco:ont00000360 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001289 ;
-                 rdfs:label "Wounded Stasis"@en ;
-                 skos:altLabel "Wounded"@en ;
-                 skos:definition "A Damaged Stasis in which a Person or other organism is the bearer of a Quality or Realizable Entity that has suffered impairment (i.e., a decrease or loss) due to an injuring event."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001289 ;
+                rdfs:label "Wounded Stasis"@en ;
+                skos:altLabel "Wounded"@en ;
+                skos:definition "A Damaged Stasis in which a Person or other organism is the bearer of a Quality or Realizable Entity that has suffered impairment (i.e., a decrease or loss) due to an injuring event."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000361
 cco:ont00000361 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001356 ;
-                 rdfs:label "Increase of Function"@en ;
-                 skos:definition "An Increase of Disposition in which some Independent Continuant has an increase of some Function that it bears."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001356 ;
+                rdfs:label "Increase of Function"@en ;
+                skos:definition "An Increase of Disposition in which some Independent Continuant has an increase of some Function that it bears."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000366
 cco:ont00000366 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Act of Information Processing"@en ;
-                 skos:definition "A Planned Act in which one or more input Information Content Entities are received, manipulated, transferred, or stored by an Agent."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Act of Information Processing"@en ;
+                skos:definition "A Planned Act in which one or more input Information Content Entities are received, manipulated, transferred, or stored by an Agent."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000367
 cco:ont00000367 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001075 ;
-                 rdfs:label "Act of Military Training Instruction"@en ;
-                 skos:definition "An Act of Training Instruction performed by an Agent who realizes a capacity derived from the Agent's affiliation with some Military Organization by imparting knowledge of the tactics, techniques, and/or strategies of Military Operations to an Agent either directly or indirectly through some communication medium."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001075 ;
+                rdfs:label "Act of Military Training Instruction"@en ;
+                skos:definition "An Act of Training Instruction performed by an Agent who realizes a capacity derived from the Agent's affiliation with some Military Organization by imparting knowledge of the tactics, techniques, and/or strategies of Military Operations to an Agent either directly or indirectly through some communication medium."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000368
 cco:ont00000368 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001133 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001777 ;
-                                   owl:someValuesFrom cco:ont00000296
-                                 ] ;
-                 rdfs:label "Rotational Motion"@en ;
-                 skos:altLabel "Rotation"@en ;
-                 skos:definition "A Motion Process in which an Object moves in a Circular or Elliptical Path around an Axis of Rotation."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rotation&oldid=1055998344"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001133 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty cco:ont00001777 ;
+                                  owl:someValuesFrom cco:ont00000296
+                                ] ;
+                rdfs:label "Rotational Motion"@en ;
+                skos:altLabel "Rotation"@en ;
+                skos:definition "A Motion Process in which an Object moves in a Circular or Elliptical Path around an Axis of Rotation."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rotation&oldid=1055998344"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000370
 cco:ont00000370 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000123 ;
-                 rdfs:label "Act of Condoling"@en ;
-                 skos:definition "An Act of Expressive Communication performed by expressing sympathy or sorrow."@en ;
-                 cco:ont00001754 "http://www.thefreedictionary.com/condoling" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000123 ;
+                rdfs:label "Act of Condoling"@en ;
+                skos:definition "An Act of Expressive Communication performed by expressing sympathy or sorrow."@en ;
+                cco:ont00001754 "http://www.thefreedictionary.com/condoling" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000371
 cco:ont00000371 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:comment "An Act of Prediction may involve the use of some or no relevant information. An Act of Prediction that utilizes relevant information may also be (or at least involve) an Act of Estimation. Hence, these two classes are not disjoint. Furthermore, neither class subsumes the other since estimates can be made about existing entities and not all predictions produce measurements (e.g. predicting that it will rain tomorrow)."@en ;
-                 rdfs:label "Act of Prediction"@en ;
-                 skos:definition "A Planned Act that involves the generation of a Predictive Information Content entity that is intended to describe an uncertain possible future event, value, entity, or attribute of an entity."@en ;
-                 skos:example "a chess master predicting the next 8 moves his opponent will make" ,
-                              "predicting that a particular stock will double in value over the next fiscal quarter" ,
-                              "using sample exit polls data to predict the winners of an election" ;
-                 skos:scopeNote "Predictions can only be made about things that are not yet the case (i.e. future things) and are further restricted to being about things that do not have a probability of either 1 (necessary) or 0 (impossible). For example, assuming that no organism is immortal, one cannot predict of a given organism that it will eventually die; however, one may predict uncertain things about the organism's eventual death, such as its precise cause or time."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:comment "An Act of Prediction may involve the use of some or no relevant information. An Act of Prediction that utilizes relevant information may also be (or at least involve) an Act of Estimation. Hence, these two classes are not disjoint. Furthermore, neither class subsumes the other since estimates can be made about existing entities and not all predictions produce measurements (e.g. predicting that it will rain tomorrow)."@en ;
+                rdfs:label "Act of Prediction"@en ;
+                skos:definition "A Planned Act that involves the generation of a Predictive Information Content entity that is intended to describe an uncertain possible future event, value, entity, or attribute of an entity."@en ;
+                skos:example "a chess master predicting the next 8 moves his opponent will make" ,
+                             "predicting that a particular stock will double in value over the next fiscal quarter" ,
+                             "using sample exit polls data to predict the winners of an election" ;
+                skos:scopeNote "Predictions can only be made about things that are not yet the case (i.e. future things) and are further restricted to being about things that do not have a probability of either 1 (necessary) or 0 (impossible). For example, assuming that no organism is immortal, one cannot predict of a given organism that it will eventually die; however, one may predict uncertain things about the organism's eventual death, such as its precise cause or time."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000379
 cco:ont00000379 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000402 ;
-                 rdfs:comment "Examples: affirming, alleging, announcing, answering, attributing, claiming, classifying, concurring, confirming, conjecturing, denying, disagreeing, disclosing, disputing, identifying, informing, insisting, predicting, ranking, reporting, stating, stipulating"@en ;
-                 rdfs:label "Act of Representative Communication"@en ;
-                 skos:definition "An Act of Communication that commits a speaker to the truth of the expressed proposition."@en ;
-                 cco:ont00001754 "Derived (loosely) from: John Searle's Speech Acts: An Essay in the Philosophy of Language" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000402 ;
+                rdfs:comment "Examples: affirming, alleging, announcing, answering, attributing, claiming, classifying, concurring, confirming, conjecturing, denying, disagreeing, disclosing, disputing, identifying, informing, insisting, predicting, ranking, reporting, stating, stipulating"@en ;
+                rdfs:label "Act of Representative Communication"@en ;
+                skos:definition "An Act of Communication that commits a speaker to the truth of the expressed proposition."@en ;
+                cco:ont00001754 "Derived (loosely) from: John Searle's Speech Acts: An Essay in the Philosophy of Language" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000380
 cco:ont00000380 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000570 ;
-                 rdfs:label "Pressure"@en ;
-                 skos:definition "A Force that is applied perpendicular to the surface of an Object per unit area over which that Force is distributed."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000570 ;
+                rdfs:label "Pressure"@en ;
+                skos:definition "A Force that is applied perpendicular to the surface of an Object per unit area over which that Force is distributed."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000384
 cco:ont00000384 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000789 ;
-                 rdfs:label "Rectilinear Motion"@en ;
-                 skos:altLabel "Linear Motion"@en ;
-                 skos:definition "A Translational Motion process in which an Object moves along a straight path."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000789 ;
+                rdfs:label "Rectilinear Motion"@en ;
+                skos:altLabel "Linear Motion"@en ;
+                skos:definition "A Translational Motion process in which an Object moves along a straight path."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000386
 cco:ont00000386 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000517 ;
-                 rdfs:comment "Essentially, webcasting is “broadcasting” over the Internet."@en ;
-                 rdfs:label "Webcast"@en ;
-                 skos:altLabel "Act of Webcasting"@en ;
-                 skos:definition "An Act of Communciation by Media transmitted to an audience over the Internet using streaming media technology to distribute a single content source that may be distributed live or on demand."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Webcast&oldid=1062685084"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000517 ;
+                rdfs:comment "Essentially, webcasting is “broadcasting” over the Internet."@en ;
+                rdfs:label "Webcast"@en ;
+                skos:altLabel "Act of Webcasting"@en ;
+                skos:definition "An Act of Communciation by Media transmitted to an audience over the Internet using streaming media technology to distribute a single content source that may be distributed live or on demand."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Webcast&oldid=1062685084"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000389
 cco:ont00000389 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001334 ;
-                 rdfs:label "Act of Buying"@en ;
-                 skos:definition "An Act of Purchasing wherein a Financial Instrument is used by an Agent (the Buyer) to acquire ownership of a good from another Agent (the Seller)."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001334 ;
+                rdfs:label "Act of Buying"@en ;
+                skos:definition "An Act of Purchasing wherein a Financial Instrument is used by an Agent (the Buyer) to acquire ownership of a good from another Agent (the Seller)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000391
 cco:ont00000391 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000754 ;
-                 rdfs:comment "The corresponding Wavelength range is 1–0.1 mm"@en ;
-                 rdfs:label "Tremendously High Frequency"@en ;
-                 skos:altLabel "ITU Band Number 12"@en ,
-                               "Submillimeter Band Frequency"@en ,
-                               "Terahertz Radiation Frequency"@en ;
-                 skos:definition "An Electromagnetic Radiation Frequency of some Electromagnetic Wave that is between 300 GHz and 3 THz."@en ;
-                 cco:ont00001753 "THF" ;
-                 cco:ont00001754 "International Telecommunication Union (ITU)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000754 ;
+                rdfs:comment "The corresponding Wavelength range is 1–0.1 mm"@en ;
+                rdfs:label "Tremendously High Frequency"@en ;
+                skos:altLabel "ITU Band Number 12"@en ,
+                              "Submillimeter Band Frequency"@en ,
+                              "Terahertz Radiation Frequency"@en ;
+                skos:definition "An Electromagnetic Radiation Frequency of some Electromagnetic Wave that is between 300 GHz and 3 THz."@en ;
+                cco:ont00001753 "THF" ;
+                cco:ont00001754 "International Telecommunication Union (ITU)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000395
 cco:ont00000395 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000554 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:BFO_0000057 ;
-                                   owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000004
-                                                                             [ rdf:type owl:Restriction ;
-                                                                               owl:onProperty obo:BFO_0000196 ;
-                                                                               owl:someValuesFrom obo:BFO_0000020
-                                                                             ]
-                                                                           ) ;
-                                                        rdf:type owl:Class
-                                                      ]
-                                 ] ;
-                 rdfs:label "Gain of Specifically Dependent Continuant"@en ;
-                 skos:definition "A Gain of Dependent Continuant in which some Independent Continuant becomes the bearer of some Specifically Dependent Continuant."@en ;
-                 skos:example "A Person becomes pregnant (gain of quality), A person becomes forgetful (gain of disposition), A vehicle becomes amphibious (gain of function), A Person becomes a Database Administrator (gain of role)." ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000554 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000057 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000004
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:BFO_0000196 ;
+                                                                              owl:someValuesFrom obo:BFO_0000020
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                rdfs:label "Gain of Specifically Dependent Continuant"@en ;
+                skos:definition "A Gain of Dependent Continuant in which some Independent Continuant becomes the bearer of some Specifically Dependent Continuant."@en ;
+                skos:example "A Person becomes pregnant (gain of quality), A person becomes forgetful (gain of disposition), A vehicle becomes amphibious (gain of function), A Person becomes a Database Administrator (gain of role)." ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000396
 cco:ont00000396 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000150 ;
-                 rdfs:comment "The corresponding Wavelength range is 100,000–10,000 km"@en ;
-                 rdfs:label "Extremely Low Frequency"@en ;
-                 skos:altLabel "ITU Band Number 1"@en ;
-                 skos:definition "A Radio Frequency that is between 3 and 30 Hz."@en ;
-                 cco:ont00001753 "ELF" ;
-                 cco:ont00001754 "International Telecommunication Union (ITU)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000150 ;
+                rdfs:comment "The corresponding Wavelength range is 100,000–10,000 km"@en ;
+                rdfs:label "Extremely Low Frequency"@en ;
+                skos:altLabel "ITU Band Number 1"@en ;
+                skos:definition "A Radio Frequency that is between 3 and 30 Hz."@en ;
+                cco:ont00001753 "ELF" ;
+                cco:ont00001754 "International Telecommunication Union (ITU)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000401
 cco:ont00000401 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000008 ;
-                 rdfs:label "Fundamental Frequency"@en ;
-                 skos:definition "A Sound Frequency that is the lowest Frequency of a Sound Wave."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000008 ;
+                rdfs:label "Fundamental Frequency"@en ;
+                skos:definition "A Sound Frequency that is the lowest Frequency of a Sound Wave."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000402
 cco:ont00000402 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Act of Communication"@en ;
-                 skos:definition "A Planned Act in which some Information Content Entity is transferred from some Agent to Another."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Communication&oldid=1063752020"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Act of Communication"@en ;
+                skos:definition "A Planned Act in which some Information Content Entity is transferred from some Agent to Another."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Communication&oldid=1063752020"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000414
 cco:ont00000414 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001286 ;
-                 rdfs:label "Square Waveform"@en ;
-                 skos:definition "A Waveform that is characterized by a square shape due to the near-instantaneous transitions between minimum and maximum Amplitudes of the Wave Cycle."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001286 ;
+                rdfs:label "Square Waveform"@en ;
+                skos:definition "A Waveform that is characterized by a square shape due to the near-instantaneous transitions between minimum and maximum Amplitudes of the Wave Cycle."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000416
 cco:ont00000416 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000588 ;
-                 rdfs:label "Act of Publishing Mass Media Press Release"@en ;
-                 skos:definition "An Act of Mass Media Communication involving the preparation and public issuance of an official statement issued to one or more members of the media for the purpose of announcing newsworthy information."@en ;
-                 cco:ont00001754 "JC3IEDM-MIRD-DMWG-Edition_3.0.2_20090514" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000588 ;
+                rdfs:label "Act of Publishing Mass Media Press Release"@en ;
+                skos:definition "An Act of Mass Media Communication involving the preparation and public issuance of an official statement issued to one or more members of the media for the purpose of announcing newsworthy information."@en ;
+                cco:ont00001754 "JC3IEDM-MIRD-DMWG-Edition_3.0.2_20090514" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000418
 cco:ont00000418 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000005 ;
-                 rdfs:label "Biographical Life"@en ;
-                 skos:definition "An Act composed of the Life Events that occur during the course of existence of an Agent (i.e. Person or Organization)."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000005 ;
+                rdfs:label "Biographical Life"@en ;
+                skos:definition "An Act composed of the Life Events that occur during the course of existence of an Agent (i.e. Person or Organization)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000430
 cco:ont00000430 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000850 ;
-                 rdfs:label "Stable Orientation"@en ;
-                 skos:definition "A Stasis of Quality that holds during a Temporal Interval when an object maintains the same Spatial Orientation."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000850 ;
+                rdfs:label "Stable Orientation"@en ;
+                skos:definition "A Stasis of Quality that holds during a Temporal Interval when an object maintains the same Spatial Orientation."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000433
 cco:ont00000433 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001327 ;
-                 rdfs:label "Act of Association"@en ;
-                 skos:definition "A Social Act wherein an Agent unites with some other Agent in a Planned Act, enterprise or business."@en ;
-                 cco:ont00001754 "http://en.wiktionary.org/wiki/associate" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001327 ;
+                rdfs:label "Act of Association"@en ;
+                skos:definition "A Social Act wherein an Agent unites with some other Agent in a Planned Act, enterprise or business."@en ;
+                cco:ont00001754 "http://en.wiktionary.org/wiki/associate" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000438
 cco:ont00000438 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001374 ;
-                 rdfs:label "Act of Official Documentation"@en ;
-                 skos:definition "An Act of Declarative Communication in which an Agent records some information for official use by another Agent."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001374 ;
+                rdfs:label "Act of Official Documentation"@en ;
+                skos:definition "An Act of Declarative Communication in which an Agent records some information for official use by another Agent."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000449
 cco:ont00000449 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001334 ;
-                 rdfs:comment "Comment: Remuneration normally consists of salary or hourly wages, but also applies to commission, stock options, fringe benefits, etc."@en ;
-                 rdfs:label "Act of Remuneration"@en ;
-                 skos:definition "An Act of Purchasing wherein a Financial Instrument is used by an Agent (the Employer) to compensate another Agent (the Employee) for the services they perform for the Employer."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Remuneration&oldid=1033306001"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001334 ;
+                rdfs:comment "Comment: Remuneration normally consists of salary or hourly wages, but also applies to commission, stock options, fringe benefits, etc."@en ;
+                rdfs:label "Act of Remuneration"@en ;
+                skos:definition "An Act of Purchasing wherein a Financial Instrument is used by an Agent (the Employer) to compensate another Agent (the Employee) for the services they perform for the Employer."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Remuneration&oldid=1033306001"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000455
 cco:ont00000455 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001327 ;
-                 rdfs:label "Act of Ceremony"@en ;
-                 skos:definition "A Social Act of ritual significance, performed on a special occasion."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ceremony&oldid=1064081855"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001327 ;
+                rdfs:label "Act of Ceremony"@en ;
+                skos:definition "A Social Act of ritual significance, performed on a special occasion."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ceremony&oldid=1064081855"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000462
 cco:ont00000462 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000609 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:BFO_0000057 ;
-                                   owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000004
-                                                                             [ rdf:type owl:Restriction ;
-                                                                               owl:onProperty obo:BFO_0000196 ;
-                                                                               owl:someValuesFrom obo:BFO_0000034
-                                                                             ]
-                                                                           ) ;
-                                                        rdf:type owl:Class
-                                                      ]
-                                 ] ;
-                 rdfs:comment "This class should be used to demarcate the start of the temporal interval (through the BFO 'occupies temporal region' property) that the Entity bears the Function."@en ;
-                 rdfs:label "Gain of Function"@en ;
-                 skos:definition "A Gain of Disposition in which some Independent Continuant becomes the bearer of some Function."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000609 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000057 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000004
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:BFO_0000196 ;
+                                                                              owl:someValuesFrom obo:BFO_0000034
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                rdfs:comment "This class should be used to demarcate the start of the temporal interval (through the BFO 'occupies temporal region' property) that the Entity bears the Function."@en ;
+                rdfs:label "Gain of Function"@en ;
+                skos:definition "A Gain of Disposition in which some Independent Continuant becomes the bearer of some Function."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000463
 cco:ont00000463 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001075 ;
-                 rdfs:label "Act of Educational Training Instruction"@en ;
-                 skos:definition "An Act of Training Instruction performed by an Agent who realizes a capacity derived from the Agent's affiliation with some Educational Organization by imparting knowledge of a curriculum to an Agent either directly or indirectly through some communication medium."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001075 ;
+                rdfs:label "Act of Educational Training Instruction"@en ;
+                skos:definition "An Act of Training Instruction performed by an Agent who realizes a capacity derived from the Agent's affiliation with some Educational Organization by imparting knowledge of a curriculum to an Agent either directly or indirectly through some communication medium."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000490
 cco:ont00000490 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000754 ;
-                 rdfs:label "X-ray Frequency"@en ;
-                 skos:definition "An Electromagnetic Radiation Frequency of some Electromagnetic Wave that is between 30 petahertz and 30 exahertz."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000754 ;
+                rdfs:label "X-ray Frequency"@en ;
+                skos:definition "An Electromagnetic Radiation Frequency of some Electromagnetic Wave that is between 30 petahertz and 30 exahertz."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000492
 cco:ont00000492 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000517 ;
-                 rdfs:label "Email Messaging"@en ;
-                 skos:altLabel "Act of Emailing"@en ;
-                 skos:definition "An Act of Communication by Media in which text-based communication occurs between two or more people using personal computers or other devices using some Email Client Software conveyed over the Internet."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Email&oldid=1063646749"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000517 ;
+                rdfs:label "Email Messaging"@en ;
+                skos:altLabel "Act of Emailing"@en ;
+                skos:definition "An Act of Communication by Media in which text-based communication occurs between two or more people using personal computers or other devices using some Email Client Software conveyed over the Internet."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Email&oldid=1063646749"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000501
 cco:ont00000501 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000836 ;
-                 rdfs:label "Act of Financial Withdrawal"@en ;
-                 skos:definition "An Act of Financial Instrument Use wherein a Financial Instrument is transferred by an Agent to another Agent (the Depositor) from an account created by an earlier Act of Financial Deposit performed by the Depositor."@en ;
-                 cco:ont00001754 "http://en.wikipedia.org/wiki/Deposit_(bank)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000836 ;
+                rdfs:label "Act of Financial Withdrawal"@en ;
+                skos:definition "An Act of Financial Instrument Use wherein a Financial Instrument is transferred by an Agent to another Agent (the Depositor) from an account created by an earlier Act of Financial Deposit performed by the Depositor."@en ;
+                cco:ont00001754 "http://en.wikipedia.org/wiki/Deposit_(bank)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000503
 cco:ont00000503 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000144 ;
-                 rdfs:label "Power"@en ;
-                 skos:definition "A Process Profile that is characterized by the rate of Work, or Energy consumed, done in a given time period."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000144 ;
+                rdfs:label "Power"@en ;
+                skos:definition "A Process Profile that is characterized by the rate of Work, or Energy consumed, done in a given time period."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000508
 cco:ont00000508 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000610 ;
-                 rdfs:label "Near Ultraviolet Light Frequency"@en ;
-                 skos:definition "An Ultraviolet Light Frequency that is between 750 terahertz and 3 petahertz."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ultraviolet&oldid=1062593453"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000610 ;
+                rdfs:label "Near Ultraviolet Light Frequency"@en ;
+                skos:definition "An Ultraviolet Light Frequency that is between 750 terahertz and 3 petahertz."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ultraviolet&oldid=1062593453"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000511
 cco:ont00000511 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Act of Planning"@en ;
-                 skos:definition "A Planned Act that involves making a Plan to achieve some specified Objective."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Act of Planning"@en ;
+                skos:definition "A Planned Act that involves making a Plan to achieve some specified Objective."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000513
 cco:ont00000513 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000566 ;
-                 rdfs:label "Act of Tool Use"@en ;
-                 skos:definition "An Act of Artifact Employment in which some Agent uses some Tool."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000566 ;
+                rdfs:label "Act of Tool Use"@en ;
+                skos:definition "An Act of Artifact Employment in which some Agent uses some Tool."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000514
 cco:ont00000514 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000752 ;
-                 rdfs:label "Transverse Wave Profile"@en ;
-                 skos:altLabel "Transverse Wave"@en ;
-                 skos:definition "A Wave Process Profile in which the displacement of participating particles is perpendicular to the direction of the Wave Process' propogation."@en ;
-                 cco:ont00001754 "http://www.acs.psu.edu/drussell/Demos/waves/wavemotion.html" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000752 ;
+                rdfs:label "Transverse Wave Profile"@en ;
+                skos:altLabel "Transverse Wave"@en ;
+                skos:definition "A Wave Process Profile in which the displacement of participating particles is perpendicular to the direction of the Wave Process' propogation."@en ;
+                cco:ont00001754 "http://www.acs.psu.edu/drussell/Demos/waves/wavemotion.html" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000515
 cco:ont00000515 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000566 ;
-                 rdfs:label "Act of Vehicle Use"@en ;
-                 skos:definition "An Act of Artifact Employment in which some Agent uses some Vehicle."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000566 ;
+                rdfs:label "Act of Vehicle Use"@en ;
+                skos:definition "An Act of Artifact Employment in which some Agent uses some Vehicle."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000517
 cco:ont00000517 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000402 ;
-                 rdfs:label "Act of Communication by Media"@en ;
-                 skos:definition "An Act of Communication in which some Artifact is used to transfer an Information Bearing Entity from sender(s) to receiver(s)."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000402 ;
+                rdfs:label "Act of Communication by Media"@en ;
+                skos:definition "An Act of Communication in which some Artifact is used to transfer an Information Bearing Entity from sender(s) to receiver(s)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000519
 cco:ont00000519 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000732 ;
-                 rdfs:comment "The corresponding Wavelength range is 10–1 mm"@en ;
-                 rdfs:label "Extremely High Frequency"@en ;
-                 skos:altLabel "ITU Band Number 11"@en ,
-                               "Millimeter Band Frequency"@en ;
-                 skos:definition "A Microwave Frequency that is between 30 and 300 GHz."@en ;
-                 cco:ont00001753 "EHF" ;
-                 cco:ont00001754 "International Telecommunication Union (ITU)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000732 ;
+                rdfs:comment "The corresponding Wavelength range is 10–1 mm"@en ;
+                rdfs:label "Extremely High Frequency"@en ;
+                skos:altLabel "ITU Band Number 11"@en ,
+                              "Millimeter Band Frequency"@en ;
+                skos:definition "A Microwave Frequency that is between 30 and 300 GHz."@en ;
+                cco:ont00001753 "EHF" ;
+                cco:ont00001754 "International Telecommunication Union (ITU)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000520
 cco:ont00000520 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000065 ;
-                 rdfs:label "Act of Departure"@en ;
-                 skos:definition "An Act of Location Change that consists of the participating entity leaving its starting location such that the larger Act of Location Change is initiated."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000065 ;
+                rdfs:label "Act of Departure"@en ;
+                skos:definition "An Act of Location Change that consists of the participating entity leaving its starting location such that the larger Act of Location Change is initiated."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000521
 cco:ont00000521 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001272 ;
-                 rdfs:label "Act of Assassination"@en ;
-                 skos:definition "An Act of Murder of a prominent person."@en ;
-                 cco:ont00001754 "JC3IEDM-MIRD-DMWG-Edition_3.0.2_20090514" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001272 ;
+                rdfs:label "Act of Assassination"@en ;
+                skos:definition "An Act of Murder of a prominent person."@en ;
+                cco:ont00001754 "JC3IEDM-MIRD-DMWG-Edition_3.0.2_20090514" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000523
 cco:ont00000523 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000862 ;
-                 rdfs:label "Loudness"@en ;
-                 skos:definition "A Sound Process Profile that is characterized by the amplitude and total energy of translated sound waves, typically on a continuum from soft to loud."@en ;
-                 cco:ont00001754 "https://byjus.com/physics/loudness-of-sound/"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000862 ;
+                rdfs:label "Loudness"@en ;
+                skos:definition "A Sound Process Profile that is characterized by the amplitude and total energy of translated sound waves, typically on a continuum from soft to loud."@en ;
+                cco:ont00001754 "https://byjus.com/physics/loudness-of-sound/"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000530
 cco:ont00000530 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000008 ;
-                 rdfs:comment "Sound waves with frequencies in this range are typically audible to humans."@en ;
-                 rdfs:label "Sonic Frequency"@en ;
-                 skos:altLabel "Audible Frequency"@en ;
-                 skos:definition "A Sound Frequency that is between 20 Hz and 20 kHz."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000008 ;
+                rdfs:comment "Sound waves with frequencies in this range are typically audible to humans."@en ;
+                rdfs:label "Sonic Frequency"@en ;
+                skos:altLabel "Audible Frequency"@en ;
+                skos:definition "A Sound Frequency that is between 20 Hz and 20 kHz."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000535
 cco:ont00000535 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000290 ;
-                 rdfs:label "Decrease of Quality"@en ;
-                 skos:definition "A Decrease of Specifically Dependent Continuant in which some Independent Continuant has a decrease of some Quality that it bears."@en ;
-                 skos:example "Weight Loss, Decreasing Temperature, decreasing color intensity, loss of structural integrity" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000290 ;
+                rdfs:label "Decrease of Quality"@en ;
+                skos:definition "A Decrease of Specifically Dependent Continuant in which some Independent Continuant has a decrease of some Quality that it bears."@en ;
+                skos:example "Weight Loss, Decreasing Temperature, decreasing color intensity, loss of structural integrity" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000542
 cco:ont00000542 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000876 ;
-                 rdfs:label "Loss of Generically Dependent Continuant"@en ;
-                 skos:definition "A Loss of Dependent Continuant in which some Independent Continuant ceases to be the carrier of some Generically Dependent Continuant."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000876 ;
+                rdfs:label "Loss of Generically Dependent Continuant"@en ;
+                skos:definition "A Loss of Dependent Continuant in which some Independent Continuant ceases to be the carrier of some Generically Dependent Continuant."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000543
 cco:ont00000543 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000854 ;
-                 rdfs:label "Decrease of Disposition"@en ;
-                 skos:definition "A Decrease of Realizable Entity in which some Independent Continuant has a decrease of some Disposition it bears."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000854 ;
+                rdfs:label "Decrease of Disposition"@en ;
+                skos:definition "A Decrease of Realizable Entity in which some Independent Continuant has a decrease of some Disposition it bears."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000544
 cco:ont00000544 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000040
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001936 ;
-                                                              owl:someValuesFrom cco:ont00000741
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf obo:BFO_0000040 ;
-                 rdfs:comment "Although people speak of targeting a process, say, a parade, what in fact are being targeted are the material participants of that process. The disruption or ceasing of the process is the objective of some plan, but not technically a target. Only material things can be targeted for action. Even if some dependent entity is described as being the target, the material thing for which that dependent entity depends is the object of a targeting process."@en ;
-                 rdfs:label "Target"@en ;
-                 skos:definition "A Material Entity that is the object of an Act of Targeting."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000040
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001936 ;
+                                                             owl:someValuesFrom cco:ont00000741
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:BFO_0000040 ;
+                rdfs:comment "Although people speak of targeting a process, say, a parade, what in fact are being targeted are the material participants of that process. The disruption or ceasing of the process is the objective of some plan, but not technically a target. Only material things can be targeted for action. Even if some dependent entity is described as being the target, the material thing for which that dependent entity depends is the object of a targeting process."@en ;
+                rdfs:label "Target"@en ;
+                skos:definition "A Material Entity that is the object of an Act of Targeting."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000546
 cco:ont00000546 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000005 ;
-                 rdfs:label "Unplanned Act"@en ;
-                 skos:altLabel "Unintentional Act"@en ;
-                 skos:definition "An Act in which at least one Agent plays a causative role and which is not prescribed by some Objective held by any of the Agents."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000005 ;
+                rdfs:label "Unplanned Act"@en ;
+                skos:altLabel "Unintentional Act"@en ;
+                skos:definition "An Act in which at least one Agent plays a causative role and which is not prescribed by some Objective held by any of the Agents."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000554
 cco:ont00000554 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000004 ;
-                 rdfs:label "Gain of Dependent Continuant"@en ;
-                 skos:definition "A Change in which an Independent Continuant becomes the bearer or carrier of some Dependent Continuant."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000004 ;
+                rdfs:label "Gain of Dependent Continuant"@en ;
+                skos:definition "A Change in which an Independent Continuant becomes the bearer or carrier of some Dependent Continuant."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000555
 cco:ont00000555 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000135 ;
-                 rdfs:label "Enhanced Stasis"@en ;
-                 skos:altLabel "Enhanced"@en ;
-                 skos:definition "A Stasis of Specifically Dependent Continuant in which some Independent Continuant bears a Quality or Realizable Entity that has undergone improvement (i.e., an increase or gain) due to a previous action or event such that the Independent Continuant is now of greater value, usefulness, or functionality."@en ;
-                 cco:ont00001754 "http://www.thefreedictionary.com/enhance" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000135 ;
+                rdfs:label "Enhanced Stasis"@en ;
+                skos:altLabel "Enhanced"@en ;
+                skos:definition "A Stasis of Specifically Dependent Continuant in which some Independent Continuant bears a Quality or Realizable Entity that has undergone improvement (i.e., an increase or gain) due to a previous action or event such that the Independent Continuant is now of greater value, usefulness, or functionality."@en ;
+                cco:ont00001754 "http://www.thefreedictionary.com/enhance" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000557
 cco:ont00000557 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001132 ;
-                 rdfs:label "Stasis of Non-Mission Capable"@en ;
-                 skos:definition "A Stasis of Mission Capability during which the participating Continuant is not capable of performing any of its primary functions for the specified Mission."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001132 ;
+                rdfs:label "Stasis of Non-Mission Capable"@en ;
+                skos:definition "A Stasis of Mission Capability during which the participating Continuant is not capable of performing any of its primary functions for the specified Mission."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000558
 cco:ont00000558 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000099 ;
-                 rdfs:label "Visible Light Reflection Process"@en ;
-                 skos:definition "A Wave Process in which an Electromagnetic Wave with a Visible Light Frequency is reflected off a portion of matter."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000099 ;
+                rdfs:label "Visible Light Reflection Process"@en ;
+                skos:definition "A Wave Process in which an Electromagnetic Wave with a Visible Light Frequency is reflected off a portion of matter."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000566
 cco:ont00000566 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Act of Artifact Employment"@en ;
-                 skos:definition "A Planned Act of using an Artifact."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Act of Artifact Employment"@en ;
+                skos:definition "A Planned Act of using an Artifact."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000570
 cco:ont00000570 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000144 ;
-                 rdfs:label "Force"@en ;
-                 skos:definition "A Process Profile that is the rate of change of an object's Momentum, is the product of an object's Mass and Acceleration with respect to an inertial frame of reference, and is measured in units of Newtons (N)."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000144 ;
+                rdfs:label "Force"@en ;
+                skos:definition "A Process Profile that is the rate of change of an object's Momentum, is the product of an object's Mass and Acceleration with respect to an inertial frame of reference, and is measured in units of Newtons (N)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000572
 cco:ont00000572 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000765 ;
-                 rdfs:label "Sound Production"@en ;
-                 skos:altLabel "Sound Production Process"@en ;
-                 skos:definition "A Wave Production Process that produces a Sound Wave."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000765 ;
+                rdfs:label "Sound Production"@en ;
+                skos:altLabel "Sound Production Process"@en ;
+                skos:definition "A Wave Production Process that produces a Sound Wave."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000573
 cco:ont00000573 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000687 ;
-                 rdfs:label "Act of Religious Training Acquisition"@en ;
-                 skos:definition "An Act of Training Acquisition performed by an Agent by acquiring knowledge of the tenets and/or practices of a religion from an Agent or communication medium that realizes a capacity derived from its affiliation with a Religious Organization."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000687 ;
+                rdfs:label "Act of Religious Training Acquisition"@en ;
+                skos:definition "An Act of Training Acquisition performed by an Agent by acquiring knowledge of the tenets and/or practices of a religion from an Agent or communication medium that realizes a capacity derived from its affiliation with a Religious Organization."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000580
 cco:ont00000580 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001286 ;
-                 rdfs:label "Sine Waveform"@en ;
-                 skos:altLabel "Sinusoidal Waveform"@en ;
-                 skos:definition "A Waveform that is characterized by a smooth curved shape due to the continuous non-linear transitions between minimum and maximum Amplitudes of the Wave Cycle."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001286 ;
+                rdfs:label "Sine Waveform"@en ;
+                skos:altLabel "Sinusoidal Waveform"@en ;
+                skos:definition "A Waveform that is characterized by a smooth curved shape due to the continuous non-linear transitions between minimum and maximum Amplitudes of the Wave Cycle."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000584
 cco:ont00000584 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000357 ;
-                 rdfs:comment "An Act of Position Change does not entail a change of location."@en ;
-                 rdfs:label "Act of Position Change"@en ;
-                 skos:definition "An Act of Motion in which the position (i.e. the orientation, alignment, or arrangement) of some Object or of one or more of an Object's parts is changed by some Agent."@en ;
-                 skos:example "a top spinning in place" ,
-                              "adjusting your posture" ,
-                              "raising your left arm" ,
-                              "swivelling your office chair to face the window" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000357 ;
+                rdfs:comment "An Act of Position Change does not entail a change of location."@en ;
+                rdfs:label "Act of Position Change"@en ;
+                skos:definition "An Act of Motion in which the position (i.e. the orientation, alignment, or arrangement) of some Object or of one or more of an Object's parts is changed by some Agent."@en ;
+                skos:example "a top spinning in place" ,
+                             "adjusting your posture" ,
+                             "raising your left arm" ,
+                             "swivelling your office chair to face the window" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000585
 cco:ont00000585 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001286 ;
-                 rdfs:label "Sawtooth Waveform"@en ;
-                 skos:definition "A Waveform that is characterized by a sawtooth shape due to the continuous linear transition from minimum to maximum Amplitudes followed by a near-instantaneous transition from the maximum to minimum Amplitudes of the Wave Cycle."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001286 ;
+                rdfs:label "Sawtooth Waveform"@en ;
+                skos:definition "A Waveform that is characterized by a sawtooth shape due to the continuous linear transition from minimum to maximum Amplitudes followed by a near-instantaneous transition from the maximum to minimum Amplitudes of the Wave Cycle."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000588
 cco:ont00000588 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000402 ;
-                 rdfs:label "Act of Mass Media Communication"@en ;
-                 skos:definition "An Act of Communication intended to reach a large audience using a medium such as the internet, television, radio, newspaper, and magazine."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Media&oldid=1062799283"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000402 ;
+                rdfs:label "Act of Mass Media Communication"@en ;
+                skos:definition "An Act of Communication intended to reach a large audience using a medium such as the internet, television, radio, newspaper, and magazine."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Media&oldid=1062799283"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000594
 cco:ont00000594 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000007 ;
-                 rdfs:label "Ignition Process"@en ;
-                 skos:altLabel "Ignition"@en ;
-                 skos:definition "A Natural Process that initiates a Combustion process."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000007 ;
+                rdfs:label "Ignition Process"@en ;
+                skos:altLabel "Ignition"@en ;
+                skos:definition "A Natural Process that initiates a Combustion process."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000595
 cco:ont00000595 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000065 ;
-                 rdfs:label "Act of Cargo Transportation"@en ;
-                 skos:definition "An Act of Location Change involving the movement of manufactured goods through some Transportation Agent."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000065 ;
+                rdfs:label "Act of Cargo Transportation"@en ;
+                skos:definition "An Act of Location Change involving the movement of manufactured goods through some Transportation Agent."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000609
 cco:ont00000609 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000642 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:BFO_0000057 ;
-                                   owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000004
-                                                                             [ rdf:type owl:Restriction ;
-                                                                               owl:onProperty obo:BFO_0000196 ;
-                                                                               owl:someValuesFrom obo:BFO_0000016
-                                                                             ]
-                                                                           ) ;
-                                                        rdf:type owl:Class
-                                                      ]
-                                 ] ;
-                 rdfs:comment "This class should be used to demarcate the start of the temporal interval (through the BFO 'occupies temporal region' property) that the Entity bears the Disposition."@en ;
-                 rdfs:label "Gain of Disposition"@en ;
-                 skos:definition "A Gain of Realizable Entity in which some Independent Continuant becomes the bearer of some Disposition."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000642 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000057 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000004
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:BFO_0000196 ;
+                                                                              owl:someValuesFrom obo:BFO_0000016
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                rdfs:comment "This class should be used to demarcate the start of the temporal interval (through the BFO 'occupies temporal region' property) that the Entity bears the Disposition."@en ;
+                rdfs:label "Gain of Disposition"@en ;
+                skos:definition "A Gain of Realizable Entity in which some Independent Continuant becomes the bearer of some Disposition."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000610
 cco:ont00000610 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000754 ;
-                 rdfs:label "Ultraviolet Light Frequency"@en ;
-                 skos:definition "An Electromagnetic Radiation Frequency of some Electromagnetic Wave that is between 750 terahertz and 30 petahertz."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ultraviolet&oldid=1062593453"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000754 ;
+                rdfs:label "Ultraviolet Light Frequency"@en ;
+                skos:definition "An Electromagnetic Radiation Frequency of some Electromagnetic Wave that is between 750 terahertz and 30 petahertz."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ultraviolet&oldid=1062593453"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000611
 cco:ont00000611 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001214 ;
-                 rdfs:label "Increase of Realizable Entity"@en ;
-                 skos:definition "An Increase of Specifically Dependent Continuant in which some Independent Continuant has an increase of some Realizable Entity that it bears."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001214 ;
+                rdfs:label "Increase of Realizable Entity"@en ;
+                skos:definition "An Increase of Specifically Dependent Continuant in which some Independent Continuant has an increase of some Realizable Entity that it bears."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000612
 cco:ont00000612 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000566 ;
-                 rdfs:label "Act of Weapon Use"@en ;
-                 skos:definition "An Act of Artifact Employment in which some Agent uses some Weapon."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000566 ;
+                rdfs:label "Act of Weapon Use"@en ;
+                skos:definition "An Act of Artifact Employment in which some Agent uses some Weapon."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000613
 cco:ont00000613 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000250 ;
-                 rdfs:label "Loss of Role"@en ;
-                 skos:definition "A Loss of Realizable Entity in which some Independent Continuant ceases to be the bearer of some Role."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000250 ;
+                rdfs:label "Loss of Role"@en ;
+                skos:definition "A Loss of Realizable Entity in which some Independent Continuant ceases to be the bearer of some Role."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000615
 cco:ont00000615 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000433 ;
-                 rdfs:label "Act of Encounter"@en ;
-                 skos:definition "An Act of Association wherein two or more Persons meet in a casual or unplanned manner."@en ;
-                 cco:ont00001754 "http://wordnetweb.princeton.edu/perl/webwn?s=encounter (Sense Key: Encounter%2:38:00)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000433 ;
+                rdfs:label "Act of Encounter"@en ;
+                skos:definition "An Act of Association wherein two or more Persons meet in a casual or unplanned manner."@en ;
+                cco:ont00001754 "http://wordnetweb.princeton.edu/perl/webwn?s=encounter (Sense Key: Encounter%2:38:00)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000621
 cco:ont00000621 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001286 ;
-                 rdfs:label "Inverse Sawtooth Waveform"@en ;
-                 skos:definition "A Waveform that is characterized by a sawtooth shape due to the continuous linear transition from maximum to minimum Amplitudes followed by a near-instantaneous transition from the minimum to maximum Amplitudes of the Wave Cycle."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001286 ;
+                rdfs:label "Inverse Sawtooth Waveform"@en ;
+                skos:definition "A Waveform that is characterized by a sawtooth shape due to the continuous linear transition from maximum to minimum Amplitudes followed by a near-instantaneous transition from the minimum to maximum Amplitudes of the Wave Cycle."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000622
 cco:ont00000622 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001132 ;
-                 rdfs:label "Stasis of Fully Mission Capable"@en ;
-                 skos:definition "A Stasis of Mission Capability during which the participating Continuant is capable of performing all of its primary functions for the specified Mission."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001132 ;
+                rdfs:label "Stasis of Fully Mission Capable"@en ;
+                skos:definition "A Stasis of Mission Capability during which the participating Continuant is capable of performing all of its primary functions for the specified Mission."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000636
 cco:ont00000636 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000345 ;
-                 rdfs:comment "Note that, while most if not all Acts of Appraisal involve some estimating and many Acts of Estimation involve some appraising (i.e. these classes are not disjoint), neither class subsumes the other. For example, some Acts of Appraisal (e.g. a tax assessor appraising the value of a building) impart a normative element to the measured value while others (e.g. a gustatory appraisal that fresh green beans taste better than canned green beans) involve complete information. Furthermore, many Acts of Estimation (e.g. estimating the height of a tree) are concerned solely with determining a numerical value (as opposed to the nature, value, importance, condition, or quality)."@en ;
-                 rdfs:label "Act of Appraisal"@en ;
-                 skos:definition "An Act of Measuring that involves evaluating, assessing, estimating, or judging the nature, value, importance, condition, or quality of something or someone."@en ;
-                 skos:example "a food critic rating the quality of a restaurant's ambiance, service, and food" ,
-                              "a mechanic assessing whether a damaged vehicle is repairable" ,
-                              "an insurance agent appraising the financial value of a building" ;
-                 skos:scopeNote "In the context of an Act of Appraisal, the terms 'value', 'condition', and 'quality' do not have the same meanings as their counterparts that are defined in the Common Core Ontologies. For example, a knife may be appraised to be of high quality if it is sharp and sturdy or to be of inferior quality if it is dull or fragile."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000345 ;
+                rdfs:comment "Note that, while most if not all Acts of Appraisal involve some estimating and many Acts of Estimation involve some appraising (i.e. these classes are not disjoint), neither class subsumes the other. For example, some Acts of Appraisal (e.g. a tax assessor appraising the value of a building) impart a normative element to the measured value while others (e.g. a gustatory appraisal that fresh green beans taste better than canned green beans) involve complete information. Furthermore, many Acts of Estimation (e.g. estimating the height of a tree) are concerned solely with determining a numerical value (as opposed to the nature, value, importance, condition, or quality)."@en ;
+                rdfs:label "Act of Appraisal"@en ;
+                skos:definition "An Act of Measuring that involves evaluating, assessing, estimating, or judging the nature, value, importance, condition, or quality of something or someone."@en ;
+                skos:example "a food critic rating the quality of a restaurant's ambiance, service, and food" ,
+                             "a mechanic assessing whether a damaged vehicle is repairable" ,
+                             "an insurance agent appraising the financial value of a building" ;
+                skos:scopeNote "In the context of an Act of Appraisal, the terms 'value', 'condition', and 'quality' do not have the same meanings as their counterparts that are defined in the Common Core Ontologies. For example, a knife may be appraised to be of high quality if it is sharp and sturdy or to be of inferior quality if it is dull or fragile."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000642
 cco:ont00000642 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000395 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:BFO_0000057 ;
-                                   owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000004
-                                                                             [ rdf:type owl:Restriction ;
-                                                                               owl:onProperty obo:BFO_0000196 ;
-                                                                               owl:someValuesFrom obo:BFO_0000017
-                                                                             ]
-                                                                           ) ;
-                                                        rdf:type owl:Class
-                                                      ]
-                                 ] ;
-                 rdfs:label "Gain of Realizable Entity"@en ;
-                 skos:definition "A Gain of Specifically Dependent Continuant in which some Independent Continuant becomes the bearer of some Realizable Entity."@en ;
-                 skos:example "An informant becomes unreliable (disposition), A person begins to speak French (function), a person becomes a welder (role)." ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000395 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000057 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000004
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:BFO_0000196 ;
+                                                                              owl:someValuesFrom obo:BFO_0000017
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                rdfs:label "Gain of Realizable Entity"@en ;
+                skos:definition "A Gain of Specifically Dependent Continuant in which some Independent Continuant becomes the bearer of some Realizable Entity."@en ;
+                skos:example "An informant becomes unreliable (disposition), A person begins to speak French (function), a person becomes a welder (role)." ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000643
 cco:ont00000643 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000150 ;
-                 rdfs:comment "The corresponding Wavelength range is 10–1 km"@en ;
-                 rdfs:label "Low Frequency"@en ;
-                 skos:altLabel "ITU Band Number 5"@en ;
-                 skos:definition "A Radio Frequency that is between 30 and 300 kHz."@en ;
-                 cco:ont00001753 "LF" ;
-                 cco:ont00001754 "International Telecommunication Union (ITU)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000150 ;
+                rdfs:comment "The corresponding Wavelength range is 10–1 km"@en ;
+                rdfs:label "Low Frequency"@en ;
+                skos:altLabel "ITU Band Number 5"@en ;
+                skos:definition "A Radio Frequency that is between 30 and 300 kHz."@en ;
+                cco:ont00001753 "LF" ;
+                cco:ont00001754 "International Telecommunication Union (ITU)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000644
 cco:ont00000644 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000004 ;
-                 rdfs:comment "Oscillation is often thought of in the sense of motion, e.g., a swinging clock pendulum. However, the repetitive variation in location around a central point is technically a process of vibration, sometimes referred to as mechanical oscillation. Use the term Vibration Motion for those cases."@en ;
-                 rdfs:label "Oscillation Process"@en ;
-                 skos:altLabel "Oscillation"@en ;
-                 skos:definition "A Change in which the dependent entity alternates between two or more stases."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Oscillation&oldid=1002978272"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000004 ;
+                rdfs:comment "Oscillation is often thought of in the sense of motion, e.g., a swinging clock pendulum. However, the repetitive variation in location around a central point is technically a process of vibration, sometimes referred to as mechanical oscillation. Use the term Vibration Motion for those cases."@en ;
+                rdfs:label "Oscillation Process"@en ;
+                skos:altLabel "Oscillation"@en ;
+                skos:definition "A Change in which the dependent entity alternates between two or more stases."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Oscillation&oldid=1002978272"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000654
 cco:ont00000654 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001147 ;
-                 rdfs:label "Act of Terrorism"@en ;
-                 skos:definition "An Act of Violence which creates fear and which is prescribed by religious, political or ideological objectives, and which deliberately target or disregard the safety of civilians and are committed by members of non-government organizations."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Terrorism&oldid=1063471352"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001147 ;
+                rdfs:label "Act of Terrorism"@en ;
+                skos:definition "An Act of Violence which creates fear and which is prescribed by religious, political or ideological objectives, and which deliberately target or disregard the safety of civilians and are committed by members of non-government organizations."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Terrorism&oldid=1063471352"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000660
 cco:ont00000660 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000015
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001819 ;
-                                                              owl:someValuesFrom obo:BFO_0000015
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf obo:BFO_0000015 ;
-                 rdfs:label "Effect"@en ;
-                 skos:altLabel "Consequence"@en ;
-                 skos:definition "A Process that follows and is caused by some previous Process."@en ;
-                 cco:ont00001754 "http://wordnetweb.princeton.edu/perl/webwn?s=effect" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000015
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001819 ;
+                                                             owl:someValuesFrom obo:BFO_0000015
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:BFO_0000015 ;
+                rdfs:label "Effect"@en ;
+                skos:altLabel "Consequence"@en ;
+                skos:definition "A Process that follows and is caused by some previous Process."@en ;
+                cco:ont00001754 "http://wordnetweb.princeton.edu/perl/webwn?s=effect" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000672
 cco:ont00000672 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000150 ;
-                 rdfs:comment "The corresponding Wavelength range is 10,000–1,000 km"@en ;
-                 rdfs:label "Super Low Frequency"@en ;
-                 skos:altLabel "ITU Band Number 2"@en ;
-                 skos:definition "A Radio Frequency that is between 30 and 300 Hz."@en ;
-                 cco:ont00001753 "SLF" ;
-                 cco:ont00001754 "International Telecommunication Union (ITU)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000150 ;
+                rdfs:comment "The corresponding Wavelength range is 10,000–1,000 km"@en ;
+                rdfs:label "Super Low Frequency"@en ;
+                skos:altLabel "ITU Band Number 2"@en ;
+                skos:definition "A Radio Frequency that is between 30 and 300 Hz."@en ;
+                cco:ont00001753 "SLF" ;
+                cco:ont00001754 "International Telecommunication Union (ITU)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000675
 cco:ont00000675 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001028 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001777 ;
-                                   owl:someValuesFrom cco:ont00001227
-                                 ] ;
-                 rdfs:label "Sound Wave Process"@en ;
-                 skos:definition "A Mechanical Wave Process of Pressure and displacement that is parallel to the propogation direction of the Wave Process through a medium."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Sound&oldid=1050465877"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001028 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000117 ;
+                                  owl:someValuesFrom cco:ont00001227
+                                ] ;
+                rdfs:label "Sound Wave Process"@en ;
+                skos:definition "A Mechanical Wave Process of Pressure and displacement that is parallel to the propogation direction of the Wave Process through a medium."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Sound&oldid=1050465877"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000676
 cco:ont00000676 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Act of Inhabitancy"@en ;
-                 skos:definition "A Planned Act in which a Person lives at a Site for a period of time that may be as short as 1 day/night or as long as the Person's entire life."@en ;
-                 cco:ont00001754 "http://www.merriam-webster.com/dictionary/inhabit" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Act of Inhabitancy"@en ;
+                skos:definition "A Planned Act in which a Person lives at a Site for a period of time that may be as short as 1 day/night or as long as the Person's entire life."@en ;
+                cco:ont00001754 "http://www.merriam-webster.com/dictionary/inhabit" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000684
 cco:ont00000684 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000821 ;
-                 rdfs:label "Act of Contract Formation"@en ;
-                 skos:definition "An Act of Promising having a lawful object entered into voluntarily by two or more agents with legal capacity, each of whom intends to create one or more legal obligations between them."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Contract&oldid=1061365227"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000821 ;
+                rdfs:label "Act of Contract Formation"@en ;
+                skos:definition "An Act of Promising having a lawful object entered into voluntarily by two or more agents with legal capacity, each of whom intends to create one or more legal obligations between them."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Contract&oldid=1061365227"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000687
 cco:ont00000687 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000234 ;
-                 rdfs:label "Act of Training Acquisition"@en ;
-                 skos:definition "An Act of Training performed by an Agent by acquiring knowledge from another Agent."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000234 ;
+                rdfs:label "Act of Training Acquisition"@en ;
+                skos:definition "An Act of Training performed by an Agent by acquiring knowledge from another Agent."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000712
 cco:ont00000712 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000144 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001777 ;
-                                   owl:someValuesFrom cco:ont00000763
-                                 ] ;
-                 rdfs:label "Acceleration"@en ;
-                 skos:definition "A Process Profile that is the rate of change of the Velocity of an object."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Acceleration&oldid=1062249960"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000144 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000117 ;
+                                  owl:someValuesFrom cco:ont00000763
+                                ] ;
+                rdfs:label "Acceleration"@en ;
+                skos:definition "A Process Profile that is the rate of change of the Velocity of an object."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Acceleration&oldid=1062249960"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000725
 cco:ont00000725 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000455 ;
-                 rdfs:label "Wedding"@en ;
-                 skos:altLabel "Act of Wedding Ceremony"@en ;
-                 skos:definition "An Act of Ceremony in which two Persons are united in Marriage or a similar institution."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Wedding&oldid=1063857279"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000455 ;
+                rdfs:label "Wedding"@en ;
+                skos:altLabel "Act of Wedding Ceremony"@en ;
+                skos:definition "An Act of Ceremony in which two Persons are united in Marriage or a similar institution."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Wedding&oldid=1063857279"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000726
 cco:ont00000726 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000004 ;
-                 rdfs:label "Decrease of Dependent Continuant"@en ;
-                 skos:definition "A Change in which some Independent Continuant has a decrease in the level of some Dependent Continuant that it bears."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000004 ;
+                rdfs:label "Decrease of Dependent Continuant"@en ;
+                skos:definition "A Change in which some Independent Continuant has a decrease in the level of some Dependent Continuant that it bears."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000732
 cco:ont00000732 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000150 ;
-                 rdfs:comment "The corresponding Wavelength range is 1,000–1 mm"@en ;
-                 rdfs:label "Microwave Frequency"@en ;
-                 skos:definition "A Radio Frequency that is between 300 MHz and 300 GHz."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Microwave&oldid=1062124842"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000150 ;
+                rdfs:comment "The corresponding Wavelength range is 1,000–1 mm"@en ;
+                rdfs:label "Microwave Frequency"@en ;
+                skos:definition "A Radio Frequency that is between 300 MHz and 300 GHz."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Microwave&oldid=1062124842"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000739
 cco:ont00000739 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000676 ;
-                 rdfs:label "Act of Sojourn"@en ;
-                 skos:definition "An Act of Inhabitancy in which a Person lives in a dwelling temporarily, often during stages of an Act of Travel."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000676 ;
+                rdfs:label "Act of Sojourn"@en ;
+                skos:definition "An Act of Inhabitancy in which a Person lives in a dwelling temporarily, often during stages of an Act of Travel."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000741
 cco:ont00000741 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Act of Targeting"@en ;
-                 skos:definition "A Planned Act wherein some Agent maintains one or more entities as the objects of potential action given some operational requirement."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Act of Targeting"@en ;
+                skos:definition "A Planned Act wherein some Agent maintains one or more entities as the objects of potential action given some operational requirement."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000744
 cco:ont00000744 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000433 ;
-                 rdfs:label "Act of Social Group Membership"@en ;
-                 skos:definition "An Act of Association wherein a Person belongs to some Social Group."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000433 ;
+                rdfs:label "Act of Social Group Membership"@en ;
+                skos:definition "An Act of Association wherein a Person belongs to some Social Group."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000750
 cco:ont00000750 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000517 ;
-                 rdfs:label "Text Messaging"@en ;
-                 skos:altLabel "Act of Text Messaging"@en ,
-                               "Act of Texting"@en ;
-                 skos:definition "An Act of Communication by Media involving the exchange of brief written messages between fixed-line phone or mobile phone and fixed or portable devices over a network."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Text_messaging&oldid=1062261405"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000517 ;
+                rdfs:label "Text Messaging"@en ;
+                skos:altLabel "Act of Text Messaging"@en ,
+                              "Act of Texting"@en ;
+                skos:definition "An Act of Communication by Media involving the exchange of brief written messages between fixed-line phone or mobile phone and fixed or portable devices over a network."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Text_messaging&oldid=1062261405"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000752
 cco:ont00000752 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000144
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001857 ;
-                                                              owl:someValuesFrom cco:ont00000099
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf obo:BFO_0000144 ;
-                 rdfs:comment "This is a defined class used to group process profiles of Wave Processes. Note that not every relevant process profile can be asserted as a subtype, however, because they (e.g. Frequency and Amplitude) are applicable to other processes as well (e.g. Oscillation Process)."@en ;
-                 rdfs:label "Wave Process Profile"@en ;
-                 skos:definition "A Process Profile of a Wave Process."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000144
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:BFO_0000132 ;
+                                                             owl:someValuesFrom cco:ont00000099
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:BFO_0000144 ;
+                rdfs:comment "This is a defined class used to group process profiles of Wave Processes. Note that not every relevant process profile can be asserted as a subtype, however, because they (e.g. Frequency and Amplitude) are applicable to other processes as well (e.g. Oscillation Process)."@en ;
+                rdfs:label "Wave Process Profile"@en ;
+                skos:definition "A Process Profile of a Wave Process."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000753
 cco:ont00000753 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000150 ;
-                 rdfs:comment "The corresponding Wavelength range is 1,000–100 km"@en ;
-                 rdfs:label "Ultra Low Frequency"@en ;
-                 skos:altLabel "ITU Band Number 3"@en ;
-                 skos:definition "A Radio Frequency that is between 300 Hz and 3 kHz."@en ;
-                 cco:ont00001753 "ULF" ;
-                 cco:ont00001754 "International Telecommunication Union (ITU)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000150 ;
+                rdfs:comment "The corresponding Wavelength range is 1,000–100 km"@en ;
+                rdfs:label "Ultra Low Frequency"@en ;
+                skos:altLabel "ITU Band Number 3"@en ;
+                skos:definition "A Radio Frequency that is between 300 Hz and 3 kHz."@en ;
+                cco:ont00001753 "ULF" ;
+                cco:ont00001754 "International Telecommunication Union (ITU)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000754
 cco:ont00000754 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001047 ;
-                 rdfs:comment "Divisions between EM radiation frequencies are fiat and sources vary on where to draw boundaries."@en ;
-                 rdfs:label "Electromagnetic Radiation Frequency"@en ;
-                 skos:definition "A Frequency that is characterized by the rate of Oscillations per second of an Electromagnetic Wave."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electromagnetic_spectrum&oldid=1063851392"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001047 ;
+                rdfs:comment "Divisions between EM radiation frequencies are fiat and sources vary on where to draw boundaries."@en ;
+                rdfs:label "Electromagnetic Radiation Frequency"@en ;
+                skos:definition "A Frequency that is characterized by the rate of Oscillations per second of an Electromagnetic Wave."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electromagnetic_spectrum&oldid=1063851392"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000760
 cco:ont00000760 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000752 ;
-                 rdfs:label "Surface Wave Profile"@en ;
-                 skos:altLabel "Surface Wave"@en ;
-                 skos:definition "A Wave Process Profile in which the Wave Process propogates along the surface of a medium and which involves both transverse and longitudinal wave profiles such that the motion of the displacement of participating particles is circular or elliptical."@en ;
-                 skos:example "the motion of an ocean wave" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000752 ;
+                rdfs:label "Surface Wave Profile"@en ;
+                skos:altLabel "Surface Wave"@en ;
+                skos:definition "A Wave Process Profile in which the Wave Process propogates along the surface of a medium and which involves both transverse and longitudinal wave profiles such that the motion of the displacement of participating particles is circular or elliptical."@en ;
+                skos:example "the motion of an ocean wave" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000763
 cco:ont00000763 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000144 ;
-                 rdfs:label "Velocity"@en ;
-                 skos:definition "A Process Profile of an object's Motion that is characterized by its Speed and direction with respect to a frame of reference."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Velocity&oldid=1063300750"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000144 ;
+                rdfs:label "Velocity"@en ;
+                skos:definition "A Process Profile of an object's Motion that is characterized by its Speed and direction with respect to a frame of reference."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Velocity&oldid=1063300750"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000765
 cco:ont00000765 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000007 ;
-                 rdfs:label "Wave Production"@en ;
-                 skos:altLabel "Wave Production Process"@en ;
-                 skos:definition "A Natural Process in which a Wave Process is generated."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000007 ;
+                rdfs:label "Wave Production"@en ;
+                skos:altLabel "Wave Production Process"@en ;
+                skos:definition "A Natural Process in which a Wave Process is generated."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000769
 cco:ont00000769 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000133 ;
-                 rdfs:label "Act of Requesting"@en ;
-                 skos:definition "An Act of Directive Communication performed by asking for something."@en ;
-                 cco:ont00001754 "http://www.merriam-webster.com/dictionary/request" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000133 ;
+                rdfs:label "Act of Requesting"@en ;
+                skos:definition "An Act of Directive Communication performed by asking for something."@en ;
+                cco:ont00001754 "http://www.merriam-webster.com/dictionary/request" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000772
 cco:ont00000772 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000144 ;
-                 rdfs:comment "An Impulse changes the Momentum (and potentially also the direction of Motion) of the object it is applied to and is typically measured in Newton meters."@en ;
-                 rdfs:label "Impulsive Force"@en ;
-                 skos:altLabel "Imp"@en ,
-                               "Impulse"@en ,
-                               "J"@en ;
-                 skos:definition "A Process Profile that is the integral of a Force that is applied to a portion of matter over a period of time."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000144 ;
+                rdfs:comment "An Impulse changes the Momentum (and potentially also the direction of Motion) of the object it is applied to and is typically measured in Newton meters."@en ;
+                rdfs:label "Impulsive Force"@en ;
+                skos:altLabel "Imp"@en ,
+                              "Impulse"@en ,
+                              "J"@en ;
+                skos:definition "A Process Profile that is the integral of a Force that is applied to a portion of matter over a period of time."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000773
 cco:ont00000773 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000789 ;
-                 rdfs:label "Curvilinear Motion"@en ;
-                 skos:altLabel "Curved Motion"@en ;
-                 skos:definition "A Translational Motion process in which an Object moves along a curved path."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000789 ;
+                rdfs:label "Curvilinear Motion"@en ;
+                skos:altLabel "Curved Motion"@en ;
+                skos:definition "A Translational Motion process in which an Object moves along a curved path."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000783
 cco:ont00000783 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000557 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001819 ;
-                                   owl:someValuesFrom cco:ont00000950
-                                 ] ;
-                 rdfs:label "Stasis of Non-Mission Capable Maintenance"@en ;
-                 skos:definition "A Stasis of Non-Mission Capable during which the participating Continuant is not capable of performing its primary functions for the specified Mission due to participating in an Act Of Maintenance."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000557 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty cco:ont00001819 ;
+                                  owl:someValuesFrom cco:ont00000950
+                                ] ;
+                rdfs:label "Stasis of Non-Mission Capable Maintenance"@en ;
+                skos:definition "A Stasis of Non-Mission Capable during which the participating Continuant is not capable of performing its primary functions for the specified Mission due to participating in an Act Of Maintenance."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000786
 cco:ont00000786 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000611 ;
-                 rdfs:label "Increase of Role"@en ;
-                 skos:definition "An Increase of Realizable Entity in which some Independent Continuant has an increase of some Role that it bears."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000611 ;
+                rdfs:label "Increase of Role"@en ;
+                skos:definition "An Increase of Realizable Entity in which some Independent Continuant has an increase of some Role that it bears."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000789
 cco:ont00000789 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001133 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001777 ;
-                                   owl:someValuesFrom cco:ont00000763
-                                 ] ;
-                 rdfs:label "Translational Motion"@en ;
-                 skos:definition "A Motion Process in which the participating Object changes its position from one portion of space to another."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001133 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty cco:ont00001777 ;
+                                  owl:someValuesFrom cco:ont00000763
+                                ] ;
+                rdfs:label "Translational Motion"@en ;
+                skos:definition "A Motion Process in which the participating Object changes its position from one portion of space to another."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000812
 cco:ont00000812 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000951 ;
-                 rdfs:label "Electromagnetic Pulse"@en ;
-                 skos:altLabel "EMP"@en ,
-                               "Transient Electromagnetic Disturbance"@en ;
-                 skos:definition "An Electromagnetic Wave Process that consists of a short high-energy burst of electromagnetic energy."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electromagnetic_pulse&oldid=1060859738"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000951 ;
+                rdfs:label "Electromagnetic Pulse"@en ;
+                skos:altLabel "EMP"@en ,
+                              "Transient Electromagnetic Disturbance"@en ;
+                skos:definition "An Electromagnetic Wave Process that consists of a short high-energy burst of electromagnetic energy."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electromagnetic_pulse&oldid=1060859738"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000819
 cco:ont00000819 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000015 ;
-                 rdfs:label "Stasis"@en ;
-                 skos:definition "A Process in which one or more Independent Continuants endure in an unchanging condition."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000015 ;
+                rdfs:label "Stasis"@en ;
+                skos:definition "A Process in which one or more Independent Continuants endure in an unchanging condition."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000820
 cco:ont00000820 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000246 ;
-                 rdfs:label "Stasis of Function"@en ;
-                 skos:definition "A Stasis of Realizable Entity in which some Independent Continuant bears some Function that remains unchanged during a Temporal Interval."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000246 ;
+                rdfs:label "Stasis of Function"@en ;
+                skos:definition "A Stasis of Realizable Entity in which some Independent Continuant bears some Function that remains unchanged during a Temporal Interval."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000821
 cco:ont00000821 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001162 ;
-                 rdfs:label "Act of Promising"@en ;
-                 skos:definition "An Act of Commissive Communication performed by declaring that the promising agent will do, or refrain from doing, the specified action."@en ;
-                 cco:ont00001754 "http://www.merriam-webster.com/dictionary/promise" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001162 ;
+                rdfs:label "Act of Promising"@en ;
+                skos:definition "An Act of Commissive Communication performed by declaring that the promising agent will do, or refrain from doing, the specified action."@en ;
+                cco:ont00001754 "http://www.merriam-webster.com/dictionary/promise" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000822
 cco:ont00000822 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000150 ;
-                 rdfs:comment "The corresponding Wavelength range is 100–10 km"@en ;
-                 rdfs:label "Very Low Frequency"@en ;
-                 skos:altLabel "ITU Band Number 4"@en ;
-                 skos:definition "A Radio Frequency that is between 3 and 30 kHz."@en ;
-                 cco:ont00001753 "VLF" ;
-                 cco:ont00001754 "International Telecommunication Union (ITU)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000150 ;
+                rdfs:comment "The corresponding Wavelength range is 100–10 km"@en ;
+                rdfs:label "Very Low Frequency"@en ;
+                skos:altLabel "ITU Band Number 4"@en ;
+                skos:definition "A Radio Frequency that is between 3 and 30 kHz."@en ;
+                cco:ont00001753 "VLF" ;
+                cco:ont00001754 "International Telecommunication Union (ITU)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000824
 cco:ont00000824 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000246 ;
-                 rdfs:label "Stasis of Role"@en ;
-                 skos:definition "A Stasis of Realizable Entity in which some Independent Continuant bears some Role that remains unchanged during a Temporal Interval."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000246 ;
+                rdfs:label "Stasis of Role"@en ;
+                skos:definition "A Stasis of Realizable Entity in which some Independent Continuant bears some Role that remains unchanged during a Temporal Interval."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000830
 cco:ont00000830 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000144 ;
-                 rdfs:comment "An object's speed is the scalar absolute value of it's Velocity."@en ;
-                 rdfs:label "Speed"@en ;
-                 skos:definition "A Process Profile that is characterized by the magnitude of an object's motion with respect to a frame of reference during some time period."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Speed&oldid=1058949945"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000144 ;
+                rdfs:comment "An object's speed is the scalar absolute value of it's Velocity."@en ;
+                rdfs:label "Speed"@en ;
+                skos:definition "A Process Profile that is characterized by the magnitude of an object's motion with respect to a frame of reference during some time period."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Speed&oldid=1058949945"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000834
 cco:ont00000834 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001337 ;
-                 rdfs:label "Mid Infrared Light Frequency"@en ;
-                 skos:definition "An Infrared Light Frequency that is between 20 and 214 terahertz."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electromagnetic_spectrum&oldid=1063851392"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001337 ;
+                rdfs:label "Mid Infrared Light Frequency"@en ;
+                skos:definition "An Infrared Light Frequency that is between 20 and 214 terahertz."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electromagnetic_spectrum&oldid=1063851392"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000836
 cco:ont00000836 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000566 ;
-                 rdfs:label "Act of Financial Instrument Use"@en ;
-                 skos:definition "An Act of Artifact Employment in which some Agent uses some Financial Instrument."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000566 ;
+                rdfs:label "Act of Financial Instrument Use"@en ;
+                skos:definition "An Act of Artifact Employment in which some Agent uses some Financial Instrument."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000839
 cco:ont00000839 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000836 ;
-                 rdfs:label "Act of Donating"@en ;
-                 skos:definition "An Act of Financial Instrument Use wherein a Financial Instrument is tranfered by an Agent (the Donor) to another Agent (the Recipient) without return consideration."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Donation&oldid=1059373518"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000836 ;
+                rdfs:label "Act of Donating"@en ;
+                skos:definition "An Act of Financial Instrument Use wherein a Financial Instrument is tranfered by an Agent (the Donor) to another Agent (the Recipient) without return consideration."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Donation&oldid=1059373518"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000842
 cco:ont00000842 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000530 ;
-                 rdfs:label "Sub-Bass Frequency"@en ;
-                 skos:definition "A Sonic Frequency that is between 20 and 60 Hz."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000530 ;
+                rdfs:label "Sub-Bass Frequency"@en ;
+                skos:definition "A Sonic Frequency that is between 20 and 60 Hz."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000847
 cco:ont00000847 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001213 ;
-                 owl:disjointWith cco:ont00000936 ;
-                 rdfs:label "Active Stasis"@en ;
-                 skos:definition "A Stasis of Artifact Operationality that holds during a Temporal Interval when an Artifact is realizing one or more of its designed Artifact Functions (especially one of its primary functions)."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001213 ;
+                owl:disjointWith cco:ont00000936 ;
+                rdfs:label "Active Stasis"@en ;
+                skos:definition "A Stasis of Artifact Operationality that holds during a Temporal Interval when an Artifact is realizing one or more of its designed Artifact Functions (especially one of its primary functions)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000850
 cco:ont00000850 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000135 ;
-                 rdfs:label "Stasis of Quality"@en ;
-                 skos:definition "A Stasis of Specifically Dependent Continuant in which some Independent Continuant bears some Quality that remains unchanged during a Temporal Interval."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000135 ;
+                rdfs:label "Stasis of Quality"@en ;
+                skos:definition "A Stasis of Specifically Dependent Continuant in which some Independent Continuant bears some Quality that remains unchanged during a Temporal Interval."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000854
 cco:ont00000854 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000290 ;
-                 rdfs:label "Decrease of Realizable Entity"@en ;
-                 skos:definition "A Decrease of Specifically Dependent Continuant in which some Independent Continuant has a decrease of some Realizable Entity that it bears."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000290 ;
+                rdfs:label "Decrease of Realizable Entity"@en ;
+                skos:definition "A Decrease of Specifically Dependent Continuant in which some Independent Continuant has a decrease of some Realizable Entity that it bears."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000855
 cco:ont00000855 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000660 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:BFO_0000132 ;
-                                   owl:someValuesFrom cco:ont00000065
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001819 ;
-                                   owl:someValuesFrom cco:ont00000065
-                                 ] ;
-                 rdfs:label "Effect of Location Change"@en ;
-                 skos:definition "An Effect caused by some Act of Location Change and which results in an Object being located in a different place."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000660 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000132 ;
+                                  owl:someValuesFrom cco:ont00000065
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty cco:ont00001819 ;
+                                  owl:someValuesFrom cco:ont00000065
+                                ] ;
+                rdfs:label "Effect of Location Change"@en ;
+                skos:definition "An Effect caused by some Act of Location Change and which results in an Object being located in a different place."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000859
 cco:ont00000859 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000517 ;
-                 rdfs:label "Television Broadcast"@en ;
-                 skos:altLabel "Act of Television Broadcasting"@en ;
-                 skos:definition "An Act of Communciation by Media that is transmitted to an audience through a television network."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Television_broadcasting&oldid=1063890047"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000517 ;
+                rdfs:label "Television Broadcast"@en ;
+                skos:altLabel "Act of Television Broadcasting"@en ;
+                skos:definition "An Act of Communciation by Media that is transmitted to an audience through a television network."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Television_broadcasting&oldid=1063890047"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000862
 cco:ont00000862 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000144
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001857 ;
-                                                              owl:someValuesFrom cco:ont00000675
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf obo:BFO_0000144 ;
-                 rdfs:label "Sound Process Profile"@en ;
-                 skos:altLabel "Sound Quality"@en ;
-                 skos:definition "A Process Profile that is part of a sound reception process and is characterized by properties of incoming sound waves as they are translated by some sensory system."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Sound&oldid=1050465877"^^xsd:anyURI ,
-                                  "http://www.animations.physics.unsw.edu.au/waves-sound/quantifying/index.html" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000144
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:BFO_0000132 ;
+                                                             owl:someValuesFrom cco:ont00000675
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:BFO_0000144 ;
+                rdfs:label "Sound Process Profile"@en ;
+                skos:altLabel "Sound Quality"@en ;
+                skos:definition "A Process Profile that is part of a sound reception process and is characterized by properties of incoming sound waves as they are translated by some sensory system."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Sound&oldid=1050465877"^^xsd:anyURI ,
+                                "http://www.animations.physics.unsw.edu.au/waves-sound/quantifying/index.html" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000863
 cco:ont00000863 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000379 ;
-                 rdfs:label "Act of Confessing"@en ;
-                 skos:definition "An Act of Representative Communication in which a person makes an admission of misdeeds or faults."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000379 ;
+                rdfs:label "Act of Confessing"@en ;
+                skos:definition "An Act of Representative Communication in which a person makes an admission of misdeeds or faults."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000865
 cco:ont00000865 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000876 ;
-                 rdfs:label "Loss of Specifically Dependent Continuant"@en ;
-                 skos:definition "A Loss of Dependent Continuant in which some Independent Continuant ceases to be the bearer of some Specifically Dependent Continuant."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000876 ;
+                rdfs:label "Loss of Specifically Dependent Continuant"@en ;
+                skos:definition "A Loss of Dependent Continuant in which some Independent Continuant ceases to be the bearer of some Specifically Dependent Continuant."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000866
 cco:ont00000866 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000517 ;
-                 rdfs:label "Radio Broadcast"@en ;
-                 skos:altLabel "Act of Radio Broadcasting"@en ;
-                 skos:definition "An Act of Communciation by Media that is transmitted to an audience through a radio network."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Radio_network&oldid=1037183126"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000517 ;
+                rdfs:label "Radio Broadcast"@en ;
+                skos:altLabel "Act of Radio Broadcasting"@en ;
+                skos:definition "An Act of Communciation by Media that is transmitted to an audience through a radio network."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Radio_network&oldid=1037183126"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000875
 cco:ont00000875 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000402 ;
-                 rdfs:label "Act of Personal Communication"@en ;
-                 skos:definition "An Act of Communication having a small audience."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000402 ;
+                rdfs:label "Act of Personal Communication"@en ;
+                skos:definition "An Act of Communication having a small audience."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000876
 cco:ont00000876 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000004 ;
-                 rdfs:label "Loss of Dependent Continuant"@en ;
-                 skos:definition "A Change in which some Independent Continuant ceases to be the bearer or carrier of some Dependent Continuant."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000004 ;
+                rdfs:label "Loss of Dependent Continuant"@en ;
+                skos:definition "A Change in which some Independent Continuant ceases to be the bearer or carrier of some Dependent Continuant."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000879
 cco:ont00000879 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000433 ;
-                 rdfs:label "Act of Religious Group Affiliation"@en ;
-                 skos:definition "An Act of Association wherein some Person belongs to some Religious Demonination or sub-Denomination."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000433 ;
+                rdfs:label "Act of Religious Group Affiliation"@en ;
+                skos:definition "An Act of Association wherein some Person belongs to some Religious Demonination or sub-Denomination."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000883
 cco:ont00000883 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001162 ;
-                 rdfs:label "Act of Inviting"@en ;
-                 skos:definition "An Act of Commissive Communication performed by requesting the presence or participation of the audience, and which may include offering an incentive or inducement."@en ;
-                 cco:ont00001754 "http://www.merriam-webster.com/dictionary/invite" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001162 ;
+                rdfs:label "Act of Inviting"@en ;
+                skos:definition "An Act of Commissive Communication performed by requesting the presence or participation of the audience, and which may include offering an incentive or inducement."@en ;
+                cco:ont00001754 "http://www.merriam-webster.com/dictionary/invite" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000884
 cco:ont00000884 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000836 ;
-                 rdfs:label "Act of Loaning"@en ;
-                 skos:definition "An Act of Financial Instrument Use wherein a Financial Instrument is given by an Agent (the Creditor) to another Agent (the Debtor) in order to receive Repayments from the Debtor which are of greater Financial Value."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Loan&oldid=1063513958"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000836 ;
+                rdfs:label "Act of Loaning"@en ;
+                skos:definition "An Act of Financial Instrument Use wherein a Financial Instrument is given by an Agent (the Creditor) to another Agent (the Debtor) in order to receive Repayments from the Debtor which are of greater Financial Value."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Loan&oldid=1063513958"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000889
 cco:ont00000889 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000037 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001777 ;
-                                   owl:someValuesFrom cco:ont00000558
-                                 ] ;
-                 rdfs:label "Visible Observation"@en ;
-                 skos:definition "An Act of Observation that involves visual perception."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000037 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty cco:ont00001777 ;
+                                  owl:someValuesFrom cco:ont00000558
+                                ] ;
+                rdfs:label "Visible Observation"@en ;
+                skos:definition "An Act of Observation that involves visual perception."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000890
 cco:ont00000890 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000065 ;
-                 rdfs:label "Act of Travel"@en ;
-                 skos:definition "An Act of Location Change wherein one or more Persons move between relatively distant geographical locations for any purpose and any duration, with or without any means of transport."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Travel&oldid=1037229469"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000065 ;
+                rdfs:label "Act of Travel"@en ;
+                skos:definition "An Act of Location Change wherein one or more Persons move between relatively distant geographical locations for any purpose and any duration, with or without any means of transport."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Travel&oldid=1037229469"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000895
 cco:ont00000895 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000335 ;
-                 rdfs:label "Married"@en ;
-                 skos:altLabel "Married Stasis"@en ;
-                 skos:definition "A Stasis of Generically Dependent Continuant that consists of a socially, culturally, or ritually recognized union or legal contract between spouses that establishes rights and obligations between them, between them and their children, and between them and their in-laws."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Marriage&oldid=1064076951"^^xsd:anyURI ,
-                                  "Haviland, William A.; Prins, Harald E. L.; McBride, Bunny; Walrath, Dana (2011). Cultural Anthropology: The Human Challenge (13th ed.). Cengage Learning. ISBN 978-0-495-81178-7" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000335 ;
+                rdfs:label "Married"@en ;
+                skos:altLabel "Married Stasis"@en ;
+                skos:definition "A Stasis of Generically Dependent Continuant that consists of a socially, culturally, or ritually recognized union or legal contract between spouses that establishes rights and obligations between them, between them and their children, and between them and their in-laws."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Marriage&oldid=1064076951"^^xsd:anyURI ,
+                                "Haviland, William A.; Prins, Harald E. L.; McBride, Bunny; Walrath, Dana (2011). Cultural Anthropology: The Human Challenge (13th ed.). Cengage Learning. ISBN 978-0-495-81178-7" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000902
 cco:ont00000902 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000566 ;
-                 rdfs:label "Act of Facility Use"@en ;
-                 skos:definition "An Act of Artifact Employment in which an Agent makes use of some Facility."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000566 ;
+                rdfs:label "Act of Facility Use"@en ;
+                skos:definition "An Act of Artifact Employment in which an Agent makes use of some Facility."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000908
 cco:ont00000908 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Act of Artifact Processing"@en ;
-                 skos:definition "A Planned Act of performing a series of mechanical or chemical operations on something in order to change or preserve it."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Act of Artifact Processing"@en ;
+                skos:definition "A Planned Act of performing a series of mechanical or chemical operations on something in order to change or preserve it."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000910
 cco:ont00000910 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000144 ;
-                 rdfs:label "Amplitude"@en ;
-                 skos:definition "A Process Profile of an Oscillation Process that is the absolute value of the maximum displacement from a zero, equilibrium, or mean value during one cycle of the Oscillation Process."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000144 ;
+                rdfs:label "Amplitude"@en ;
+                skos:definition "A Process Profile of an Oscillation Process that is the absolute value of the maximum displacement from a zero, equilibrium, or mean value during one cycle of the Oscillation Process."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000920
 cco:ont00000920 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000007 ;
-                 rdfs:label "Death"@en ;
-                 skos:definition "A Natural Process in which all biological functions that sustain a living organism cease."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Death&oldid=1064114499"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000007 ;
+                rdfs:label "Death"@en ;
+                skos:definition "A Natural Process in which all biological functions that sustain a living organism cease."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Death&oldid=1064114499"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000922
 cco:ont00000922 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000065 ;
-                 rdfs:label "Act of Arrival"@en ;
-                 skos:definition "An Act of Location Change that consists of the participating entity reaching its destination such that the larger Act of Location Change is completed."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000065 ;
+                rdfs:label "Act of Arrival"@en ;
+                skos:definition "An Act of Location Change that consists of the participating entity reaching its destination such that the larger Act of Location Change is completed."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000924
 cco:ont00000924 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001191 ;
-                 rdfs:comment "A Beginning of Life Stasis (BoL) is a relatively brief Operational Stasis that is primarily of interest for the purpose of establishing a baseline for operational parameters to be compared to the designed specifications as well as the Artifact's performance throughout its operational life."@en ;
-                 rdfs:label "Beginning of Life Stasis"@en ;
-                 skos:definition "A Operational Stasis that holds during a Temporal Interval when an Artifact is first put into operational use such that its designed set of Artifact Functions is capable of operating at or near their designed peak performance levels."@en ;
-                 cco:ont00001753 "BOL" ,
-                                  "BoL" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001191 ;
+                rdfs:comment "A Beginning of Life Stasis (BoL) is a relatively brief Operational Stasis that is primarily of interest for the purpose of establishing a baseline for operational parameters to be compared to the designed specifications as well as the Artifact's performance throughout its operational life."@en ;
+                rdfs:label "Beginning of Life Stasis"@en ;
+                skos:definition "A Operational Stasis that holds during a Temporal Interval when an Artifact is first put into operational use such that its designed set of Artifact Functions is capable of operating at or near their designed peak performance levels."@en ;
+                cco:ont00001753 "BOL" ,
+                                "BoL" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000925
 cco:ont00000925 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000687 ;
-                 rdfs:label "Act of Military Training Acquisition"@en ;
-                 skos:definition "An Act of Training Acquisition performed by an Agent by acquiring knowledge of the tactics, techniques, and/or strategies of Military Operations from an Agent or communication medium that realizes a capacity derived from its affiliation with a Military Organization."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000687 ;
+                rdfs:label "Act of Military Training Acquisition"@en ;
+                skos:definition "An Act of Training Acquisition performed by an Agent by acquiring knowledge of the tactics, techniques, and/or strategies of Military Operations from an Agent or communication medium that realizes a capacity derived from its affiliation with a Military Organization."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000926
 cco:ont00000926 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000123 ;
-                 rdfs:label "Act of Apologizing"@en ;
-                 skos:definition "An Act of Expressive Communication performed by acknowledging and expressing regret for a fault, shortcoming, or failure."@en ;
-                 cco:ont00001754 "http://wordnetweb.princeton.edu/perl/webwn?s=apologizing" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000123 ;
+                rdfs:label "Act of Apologizing"@en ;
+                skos:definition "An Act of Expressive Communication performed by acknowledging and expressing regret for a fault, shortcoming, or failure."@en ;
+                cco:ont00001754 "http://wordnetweb.princeton.edu/perl/webwn?s=apologizing" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000927
 cco:ont00000927 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000530 ;
-                 rdfs:label "Bass Frequency"@en ;
-                 skos:definition "A Sonic Frequency that is between 60 and 250 Hz."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000530 ;
+                rdfs:label "Bass Frequency"@en ;
+                skos:definition "A Sonic Frequency that is between 60 and 250 Hz."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000935
 cco:ont00000935 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000566 ;
-                 rdfs:label "Act of Legal Instrument Use"@en ;
-                 skos:definition "An Act of Artifact Employment in which some Agent uses some Legal Instrument."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000566 ;
+                rdfs:label "Act of Legal Instrument Use"@en ;
+                skos:definition "An Act of Artifact Employment in which some Agent uses some Legal Instrument."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000936
 cco:ont00000936 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001213 ;
-                 rdfs:label "Deactivated Stasis"@en ;
-                 skos:definition "A Stasis of Artifact Operationality that holds during a Temporal Interval when an Artifact is not realizing any of its designed Artifact Functions (or at least not realizing any of its primary functions)."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001213 ;
+                rdfs:label "Deactivated Stasis"@en ;
+                skos:definition "A Stasis of Artifact Operationality that holds during a Temporal Interval when an Artifact is not realizing any of its designed Artifact Functions (or at least not realizing any of its primary functions)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000948
 cco:ont00000948 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000455 ;
-                 rdfs:label "Act of Religious Worship"@en ;
-                 skos:definition "An Act of Ceremony wherein there occurs acts of religious devotion usually directed towards a deity."@en ;
-                 cco:ont00001754 "http://en.wikipedia.org/wiki/Worship (Sense Key: Worship%2:42:00 or Worship%1:04:00::)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000455 ;
+                rdfs:label "Act of Religious Worship"@en ;
+                skos:definition "An Act of Ceremony wherein there occurs acts of religious devotion usually directed towards a deity."@en ;
+                cco:ont00001754 "http://en.wikipedia.org/wiki/Worship (Sense Key: Worship%2:42:00 or Worship%1:04:00::)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000949
 cco:ont00000949 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Act of Consumption"@en ;
-                 skos:definition "A Planned Act in which a resource is ingested or used up."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Act of Consumption"@en ;
+                skos:definition "A Planned Act in which a resource is ingested or used up."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000950
 cco:ont00000950 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000970 ;
-                 rdfs:label "Act of Maintenance"@en ;
-                 skos:definition "An Act of Artifact Modification in which an Artifact is modified in order to preserve or restore one or more of its designed Qualities or Functions."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000970 ;
+                rdfs:label "Act of Maintenance"@en ;
+                skos:definition "An Act of Artifact Modification in which an Artifact is modified in order to preserve or restore one or more of its designed Qualities or Functions."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000951
 cco:ont00000951 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000099 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001777 ;
-                                   owl:someValuesFrom cco:ont00000514
-                                 ] ;
-                 rdfs:label "Electromagnetic Wave Process"@en ;
-                 skos:altLabel "Electromagnetic Radiation"@en ;
-                 skos:definition "A Wave Process that is produced by charged particles, involves the periodic Oscillation of electric and magnetic fields at right angles to each other and the direction of wave propogation such that it has a Transverse Wave Profile, and which transfers electromagnetic radiant energy through a portion of space or matter."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000099 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000117 ;
+                                  owl:someValuesFrom cco:ont00000514
+                                ] ;
+                rdfs:label "Electromagnetic Wave Process"@en ;
+                skos:altLabel "Electromagnetic Radiation"@en ;
+                skos:definition "A Wave Process that is produced by charged particles, involves the periodic Oscillation of electric and magnetic fields at right angles to each other and the direction of wave propogation such that it has a Transverse Wave Profile, and which transfers electromagnetic radiant energy through a portion of space or matter."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000953
 cco:ont00000953 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000862 ;
-                 rdfs:label "Pitch"@en ;
-                 skos:definition "A Sound Process Profile that is characterized by the frequency of translated sound waves, typically on a continuum from low to high."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000862 ;
+                rdfs:label "Pitch"@en ;
+                skos:definition "A Sound Process Profile that is characterized by the frequency of translated sound waves, typically on a continuum from low to high."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000955
 cco:ont00000955 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000278 ;
-                 rdfs:label "Angular Momentum"@en ;
-                 skos:definition "A Momentum that is the product of an object's moment of inertia and its Angular Velocity."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Angular_momentum&oldid=1063992505"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000278 ;
+                rdfs:label "Angular Momentum"@en ;
+                skos:definition "A Momentum that is the product of an object's moment of inertia and its Angular Velocity."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Angular_momentum&oldid=1063992505"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000960
 cco:ont00000960 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001190 ;
-                 rdfs:label "Fixed Line Network Telephone Call"@en ;
-                 skos:definition "A Telephone Call transmitted over a telephone network where the telephones are wired into a single telephone exchange."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telephone_network&oldid=1046265527"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001190 ;
+                rdfs:label "Fixed Line Network Telephone Call"@en ;
+                skos:definition "A Telephone Call transmitted over a telephone network where the telephones are wired into a single telephone exchange."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telephone_network&oldid=1046265527"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000964
 cco:ont00000964 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000150 ;
-                 rdfs:comment "The corresponding Wavelength range is 1,000–100 m"@en ;
-                 rdfs:label "Medium Frequency"@en ;
-                 skos:altLabel "ITU Band Number 6"@en ;
-                 skos:definition "A Radio Frequency that is between 300 kHz and 3 MHz."@en ;
-                 cco:ont00001753 "MF" ;
-                 cco:ont00001754 "International Telecommunication Union (ITU)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000150 ;
+                rdfs:comment "The corresponding Wavelength range is 1,000–100 m"@en ;
+                rdfs:label "Medium Frequency"@en ;
+                skos:altLabel "ITU Band Number 6"@en ;
+                skos:definition "A Radio Frequency that is between 300 kHz and 3 MHz."@en ;
+                cco:ont00001753 "MF" ;
+                cco:ont00001754 "International Telecommunication Union (ITU)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000970
 cco:ont00000970 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000908 ;
-                 rdfs:comment "Excluded from this class are instances of role change or role creation such as the introduction of an artifact as a piece of evidence in a trial or the loading of artifacts onto a ship for transport."@en ;
-                 rdfs:label "Act of Artifact Modification"@en ;
-                 skos:definition "An Act of Artifact Processing in which an existing Artifact is acted upon in a manner that changes, adds, or removes one or more of its Qualities, Dispositions, or Functions."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000908 ;
+                rdfs:comment "Excluded from this class are instances of role change or role creation such as the introduction of an artifact as a piece of evidence in a trial or the loading of artifacts onto a ship for transport."@en ;
+                rdfs:label "Act of Artifact Modification"@en ;
+                skos:definition "An Act of Artifact Processing in which an existing Artifact is acted upon in a manner that changes, adds, or removes one or more of its Qualities, Dispositions, or Functions."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000971
 cco:ont00000971 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000402 ;
-                 rdfs:label "Act of Deceptive Communication"@en ;
-                 skos:definition "Ac Act of Communication intended to mislead the audience by distortion or falsification of evidence and induce a reaction that is prejudicial to the interests of the audience."@en ;
-                 cco:ont00001754 "JC3IEDM-MIRD-DMWG-Edition_3.0.2_20090514" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000402 ;
+                rdfs:label "Act of Deceptive Communication"@en ;
+                skos:definition "Ac Act of Communication intended to mislead the audience by distortion or falsification of evidence and induce a reaction that is prejudicial to the interests of the audience."@en ;
+                cco:ont00001754 "JC3IEDM-MIRD-DMWG-Edition_3.0.2_20090514" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000977
 cco:ont00000977 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000588 ;
-                 rdfs:label "Act of Publishing Mass Media Documentary"@en ;
-                 skos:definition "An Act of Mass Media Communication involving the preparation and public issuance of information that provides a factual record or report."@en ;
-                 cco:ont00001754 "JC3IEDM-MIRD-DMWG-Edition_3.0.2_20090514" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000588 ;
+                rdfs:label "Act of Publishing Mass Media Documentary"@en ;
+                skos:definition "An Act of Mass Media Communication involving the preparation and public issuance of information that provides a factual record or report."@en ;
+                cco:ont00001754 "JC3IEDM-MIRD-DMWG-Edition_3.0.2_20090514" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000978
 cco:ont00000978 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000015
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001803 ;
-                                                              owl:someValuesFrom obo:BFO_0000015
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf obo:BFO_0000015 ;
-                 rdfs:label "Cause"@en ;
-                 skos:definition "A Process that is the cause of or one of the causes of some other Process."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000015
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001803 ;
+                                                             owl:someValuesFrom obo:BFO_0000015
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:BFO_0000015 ;
+                rdfs:label "Cause"@en ;
+                skos:definition "A Process that is the cause of or one of the causes of some other Process."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000981
 cco:ont00000981 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000566 ;
-                 rdfs:label "Act of Portion of Material Consumption"@en ;
-                 skos:definition "An Act of Artifact Employment in which a Portion of Material is expended."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000566 ;
+                rdfs:label "Act of Portion of Material Consumption"@en ;
+                skos:definition "An Act of Artifact Employment in which a Portion of Material is expended."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000982
 cco:ont00000982 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000543 ;
-                 rdfs:label "Decrease of Function"@en ;
-                 skos:definition "A Decrease of Disposition in which some Independent Continuant has a decrease of some Function that it bears."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000543 ;
+                rdfs:label "Decrease of Function"@en ;
+                skos:definition "A Decrease of Disposition in which some Independent Continuant has a decrease of some Function that it bears."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000983
 cco:ont00000983 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00001028
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001777 ;
-                                                              owl:someValuesFrom cco:ont00000514
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00001028 ;
-                 rdfs:label "Shear Wave Process"@en ;
-                 skos:definition "A Mechanical Wave that has a Transverse Wave Profile."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00001028
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:BFO_0000117 ;
+                                                             owl:someValuesFrom cco:ont00000514
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00001028 ;
+                rdfs:label "Shear Wave Process"@en ;
+                skos:definition "A Mechanical Wave that has a Transverse Wave Profile."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000989
 cco:ont00000989 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000732 ;
-                 rdfs:comment "The corresponding Wavelength range is 100–10 mm"@en ;
-                 rdfs:label "Super High Frequency"@en ;
-                 skos:altLabel "ITU Band Number 10"@en ;
-                 skos:definition "A Microwave Frequency that is between 3 and 30 GHz."@en ;
-                 cco:ont00001753 "SHF" ;
-                 cco:ont00001754 "International Telecommunication Union (ITU)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000732 ;
+                rdfs:comment "The corresponding Wavelength range is 100–10 mm"@en ;
+                rdfs:label "Super High Frequency"@en ;
+                skos:altLabel "ITU Band Number 10"@en ;
+                skos:definition "A Microwave Frequency that is between 3 and 30 GHz."@en ;
+                cco:ont00001753 "SHF" ;
+                cco:ont00001754 "International Telecommunication Union (ITU)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000999
 cco:ont00000999 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001213 ;
-                 owl:disjointWith cco:ont00001191 ;
-                 rdfs:label "Defunct Stasis"@en ;
-                 skos:definition "A Stasis of Artifact Operationality that holds during a Temporal Interval when an Artifact no longer maintains its designed set of Artifact Functions (or at least no longer maintains its primary functions)."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001213 ;
+                owl:disjointWith cco:ont00001191 ;
+                rdfs:label "Defunct Stasis"@en ;
+                skos:definition "A Stasis of Artifact Operationality that holds during a Temporal Interval when an Artifact no longer maintains its designed set of Artifact Functions (or at least no longer maintains its primary functions)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001021
 cco:ont00001021 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000379 ;
-                 rdfs:label "Act of Denying"@en ;
-                 skos:definition "An Act of Representative Communication performed by either asserting that something is not true or real or refusing to satisfy a request or desire."@en ;
-                 cco:ont00001754 "http://www.merriam-webster.com/dictionary/denial" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000379 ;
+                rdfs:label "Act of Denying"@en ;
+                skos:definition "An Act of Representative Communication performed by either asserting that something is not true or real or refusing to satisfy a request or desire."@en ;
+                cco:ont00001754 "http://www.merriam-webster.com/dictionary/denial" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001028
 cco:ont00001028 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000099 ;
-                 rdfs:label "Mechanical Wave Process"@en ;
-                 skos:definition "A Wave Process that involves Oscillation of a portion of matter such that energy is transferred through the material medium."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Mechanical_wave&oldid=1057233679"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000099 ;
+                rdfs:label "Mechanical Wave Process"@en ;
+                skos:definition "A Wave Process that involves Oscillation of a portion of matter such that energy is transferred through the material medium."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Mechanical_wave&oldid=1057233679"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001031
 cco:ont00001031 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001162 ;
-                 rdfs:label "Act of Volunteering"@en ;
-                 skos:definition "An Act of Commissive Communication performed by voluntarily undertaking or expressing a willingness to undertake a service."@en ;
-                 skos:example "entering into military service voluntarily" ,
-                              "rendering a service voluntarily" ;
-                 cco:ont00001754 "http://www.merriam-webster.com/dictionary/volunteer" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001162 ;
+                rdfs:label "Act of Volunteering"@en ;
+                skos:definition "An Act of Commissive Communication performed by voluntarily undertaking or expressing a willingness to undertake a service."@en ;
+                skos:example "entering into military service voluntarily" ,
+                             "rendering a service voluntarily" ;
+                cco:ont00001754 "http://www.merriam-webster.com/dictionary/volunteer" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001032
 cco:ont00001032 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001374 ;
-                 rdfs:label "Act of Assignment"@en ;
-                 skos:definition "An Act of Declarative Communication in which rights held by one party (the assignor) are transferred to another party (the assignee) with regard to a particular entity as specified by the details of the assignment, which is often prescribed by a contract."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Assignment_(law)&oldid=1056101591"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001374 ;
+                rdfs:label "Act of Assignment"@en ;
+                skos:definition "An Act of Declarative Communication in which rights held by one party (the assignor) are transferred to another party (the assignee) with regard to a particular entity as specified by the details of the assignment, which is often prescribed by a contract."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Assignment_(law)&oldid=1056101591"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001039
 cco:ont00001039 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000836 ;
-                 rdfs:label "Act of Repayment"@en ;
-                 skos:definition "An Act of Financial Instrument Use wherein a Financial Instrument is transferred by an Agent (the Debtor) to another Agent (the Creditor) to decrease the amount the Debtor owes to the Creditor from an earlier Act of Loaning."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Loan&oldid=1063513958"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000836 ;
+                rdfs:label "Act of Repayment"@en ;
+                skos:definition "An Act of Financial Instrument Use wherein a Financial Instrument is transferred by an Agent (the Debtor) to another Agent (the Creditor) to decrease the amount the Debtor owes to the Creditor from an earlier Act of Loaning."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Loan&oldid=1063513958"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001047
 cco:ont00001047 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000144 ;
-                 rdfs:label "Frequency"@en ;
-                 skos:altLabel "Temporal Frequency"@en ;
-                 skos:definition "A Process Profile that is characterized by the number of repetitive processes during a particular time period."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Frequency&oldid=1062800545"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000144 ;
+                rdfs:label "Frequency"@en ;
+                skos:altLabel "Temporal Frequency"@en ;
+                skos:definition "A Process Profile that is characterized by the number of repetitive processes during a particular time period."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Frequency&oldid=1062800545"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001048
 cco:ont00001048 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000004 ;
-                 rdfs:label "Increase of Dependent Continuant"@en ;
-                 skos:definition "A Change in which some Independent Continuant has an increase in the level of some Dependent Continuant that it bears."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000004 ;
+                rdfs:label "Increase of Dependent Continuant"@en ;
+                skos:definition "A Change in which some Independent Continuant has an increase in the level of some Dependent Continuant that it bears."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001053
 cco:ont00001053 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000065 ;
-                 rdfs:label "Act of Collision"@en ;
-                 skos:definition "An Act of Location Change involving the movement of one object such that it collides with another object."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000065 ;
+                rdfs:label "Act of Collision"@en ;
+                skos:definition "An Act of Location Change involving the movement of one object such that it collides with another object."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001056
 cco:ont00001056 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000754 ;
-                 rdfs:comment "Visible light overlaps with near infrared and near ultraviolet."@en ;
-                 rdfs:label "Visible Light Frequency"@en ;
-                 skos:definition "An Electromagnetic Radiation Frequency of some Electromagnetic Wave that is between 400 and 800 terahertz."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Light&oldid=1062630851"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000754 ;
+                rdfs:comment "Visible light overlaps with near infrared and near ultraviolet."@en ;
+                rdfs:label "Visible Light Frequency"@en ;
+                skos:definition "An Electromagnetic Radiation Frequency of some Electromagnetic Wave that is between 400 and 800 terahertz."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Light&oldid=1062630851"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001057
 cco:ont00001057 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000588 ;
-                 rdfs:label "Act of Issuing Mass Media Press Release"@en ;
-                 skos:definition "An Act of Mass Media Communication involving sending forth, distributing, or putting into circulation an official statement issued to one or more members of the media for the purpose of announcing newsworthy information."@en ;
-                 cco:ont00001754 "JC3IEDM-MIRD-DMWG-Edition_3.0.2_20090514" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000588 ;
+                rdfs:label "Act of Issuing Mass Media Press Release"@en ;
+                skos:definition "An Act of Mass Media Communication involving sending forth, distributing, or putting into circulation an official statement issued to one or more members of the media for the purpose of announcing newsworthy information."@en ;
+                cco:ont00001754 "JC3IEDM-MIRD-DMWG-Edition_3.0.2_20090514" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001066
 cco:ont00001066 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000250 ;
-                 rdfs:label "Loss of Disposition"@en ;
-                 skos:definition "A Loss of Realizable Entity in which some Independent Continuant ceases to be the bearer of some Disposition."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000250 ;
+                rdfs:label "Loss of Disposition"@en ;
+                skos:definition "A Loss of Realizable Entity in which some Independent Continuant ceases to be the bearer of some Disposition."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001068
 cco:ont00001068 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000395 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:BFO_0000057 ;
-                                   owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000004
-                                                                             [ rdf:type owl:Restriction ;
-                                                                               owl:onProperty obo:BFO_0000196 ;
-                                                                               owl:someValuesFrom obo:BFO_0000019
-                                                                             ]
-                                                                           ) ;
-                                                        rdf:type owl:Class
-                                                      ]
-                                 ] ;
-                 rdfs:label "Gain of Quality"@en ;
-                 skos:definition "A Gain of Specifically Dependent Continuant in which an Independent Continuant becomes the bearer of some Quality."@en ;
-                 skos:example "A person becoming pregnant." ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000395 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000057 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000004
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:BFO_0000196 ;
+                                                                              owl:someValuesFrom obo:BFO_0000019
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                rdfs:label "Gain of Quality"@en ;
+                skos:definition "A Gain of Specifically Dependent Continuant in which an Independent Continuant becomes the bearer of some Quality."@en ;
+                skos:example "A person becoming pregnant." ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001072
 cco:ont00001072 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000169 ;
-                 rdfs:label "FM Radio Broadcast Frequency"@en ;
-                 skos:altLabel "Frequency Modulation Radio Broadcast Frequency"@en ;
-                 skos:definition "A Very High Frequency that is between 88 and 108 MHz."@en ;
-                 cco:ont00001754 "International Telecommunication Union (ITU) Region 2" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000169 ;
+                rdfs:label "FM Radio Broadcast Frequency"@en ;
+                skos:altLabel "Frequency Modulation Radio Broadcast Frequency"@en ;
+                skos:definition "A Very High Frequency that is between 88 and 108 MHz."@en ;
+                cco:ont00001754 "International Telecommunication Union (ITU) Region 2" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001074
 cco:ont00001074 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000687 ;
-                 rdfs:label "Act of Educational Training Acquisition"@en ;
-                 skos:definition "An Act of Training Acquisition performed by an Agent by acquiring knowledge of a curriculum from an Agent or communication medium that realizes a capacity derived from its affiliation with some Educational Organization."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000687 ;
+                rdfs:label "Act of Educational Training Acquisition"@en ;
+                skos:definition "An Act of Training Acquisition performed by an Agent by acquiring knowledge of a curriculum from an Agent or communication medium that realizes a capacity derived from its affiliation with some Educational Organization."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001075
 cco:ont00001075 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000234 ;
-                 rdfs:label "Act of Training Instruction"@en ;
-                 skos:definition "An Act of Training performed by an Agent by imparting knowledge to another Agent."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000234 ;
+                rdfs:label "Act of Training Instruction"@en ;
+                skos:definition "An Act of Training performed by an Agent by imparting knowledge to another Agent."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001080
 cco:ont00001080 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001337 ;
-                 rdfs:label "Far Infrared Light Frequency"@en ;
-                 skos:definition "An Infrared Light Frequency that is between 300 gigahertz and 20 terahertz."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electromagnetic_spectrum&oldid=1063851392"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001337 ;
+                rdfs:label "Far Infrared Light Frequency"@en ;
+                skos:definition "An Infrared Light Frequency that is between 300 gigahertz and 20 terahertz."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electromagnetic_spectrum&oldid=1063851392"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001094
 cco:ont00001094 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001251 ;
-                 rdfs:label "Act of Espionage"@en ;
-                 skos:definition "An Act of Intelligence Gathering involving the obtaining of information that is considered secret or confidential without the permission of the holder of the information."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Espionage&oldid=1062702647"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001251 ;
+                rdfs:label "Act of Espionage"@en ;
+                skos:definition "An Act of Intelligence Gathering involving the obtaining of information that is considered secret or confidential without the permission of the holder of the information."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Espionage&oldid=1062702647"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001108
 cco:ont00001108 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000732 ;
-                 rdfs:comment """The corresponding Wavelength range is 1–0.1 m.
+                rdfs:subClassOf cco:ont00000732 ;
+                rdfs:comment """The corresponding Wavelength range is 1–0.1 m.
 
 Note that the ITU definition of UHF is broader than the definition given by IEEE 521-2002 - IEEE Standard Letter Designations for Radar-Frequency Bands, which sets the frequency range at 300 MHz to 1 GHz."""@en ;
-                 rdfs:label "Ultra High Frequency"@en ;
-                 skos:altLabel "ITU Band Number 9"@en ;
-                 skos:definition "A Microwave Frequency that is between 300 MHz and 3 GHz."@en ;
-                 cco:ont00001753 "UHF" ;
-                 cco:ont00001754 "International Telecommunication Union (ITU)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:label "Ultra High Frequency"@en ;
+                skos:altLabel "ITU Band Number 9"@en ;
+                skos:definition "A Microwave Frequency that is between 300 MHz and 3 GHz."@en ;
+                cco:ont00001753 "UHF" ;
+                cco:ont00001754 "International Telecommunication Union (ITU)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001109
 cco:ont00001109 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000368 ;
-                 rdfs:label "Counter-Clockwise Rotational Motion"@en ;
-                 skos:altLabel "Anti-Clockwise Rotation"@en ,
-                               "CCW Rotational Motion"@en ,
-                               "Counter-Clockwise Rotation"@en ;
-                 skos:definition "A Rotational Motion in which the direction of rotation is toward the left as seen relative to the designated side of the plane of rotation."@en ;
-                 skos:example "the axial rotation of the Earth as seen from above the North Pole" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000368 ;
+                rdfs:label "Counter-Clockwise Rotational Motion"@en ;
+                skos:altLabel "Anti-Clockwise Rotation"@en ,
+                              "CCW Rotational Motion"@en ,
+                              "Counter-Clockwise Rotation"@en ;
+                skos:definition "A Rotational Motion in which the direction of rotation is toward the left as seen relative to the designated side of the plane of rotation."@en ;
+                skos:example "the axial rotation of the Earth as seen from above the North Pole" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001111
 cco:ont00001111 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000530 ;
-                 rdfs:label "Low Midrange Frequency"@en ;
-                 skos:definition "A Sonic Frequency that is between 250 and 500 Hz."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000530 ;
+                rdfs:label "Low Midrange Frequency"@en ;
+                skos:definition "A Sonic Frequency that is between 250 and 500 Hz."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001112
 cco:ont00001112 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000712 ;
-                 rdfs:label "Proper Acceleration"@en ;
-                 skos:definition "An Acceleration of an object relative to a free-fall, or inertial, observer who is momentarily at rest relative to the object being measured (hence, gravity does not cause Proper Acceleration)."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Proper_acceleration&oldid=1058169867"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000712 ;
+                rdfs:label "Proper Acceleration"@en ;
+                skos:definition "An Acceleration of an object relative to a free-fall, or inertial, observer who is momentarily at rest relative to the object being measured (hence, gravity does not cause Proper Acceleration)."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Proper_acceleration&oldid=1058169867"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001115
 cco:ont00001115 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001190 ;
-                 rdfs:label "Private Network Telephone Call"@en ;
-                 skos:definition "A Telephone Call transmitted over a network where a closed group of telephones are connected primarily to each other and use a gateway to reach the outside world, usually used inside companies and call centers (a.k.a. private branch exchange (PBX))."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telephone_network&oldid=1046265527"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001190 ;
+                rdfs:label "Private Network Telephone Call"@en ;
+                skos:definition "A Telephone Call transmitted over a network where a closed group of telephones are connected primarily to each other and use a gateway to reach the outside world, usually used inside companies and call centers (a.k.a. private branch exchange (PBX))."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telephone_network&oldid=1046265527"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001120
 cco:ont00001120 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001075 ;
-                 rdfs:label "Act of Religious Training Instruction"@en ;
-                 skos:definition "An Act of Training Instruction performed by an Agent who realizes a capacity derived from the Agent's affiliation with some Religious Organization by imparting knowledge of the tenets and/or practices of a religion to an Agent either directly or indirectly through some communication medium."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001075 ;
+                rdfs:label "Act of Religious Training Instruction"@en ;
+                skos:definition "An Act of Training Instruction performed by an Agent who realizes a capacity derived from the Agent's affiliation with some Religious Organization by imparting knowledge of the tenets and/or practices of a religion to an Agent either directly or indirectly through some communication medium."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001122
 cco:ont00001122 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000007 ;
-                 rdfs:label "Radio Interference"@en ;
-                 skos:definition "A Natural Process in which a radio signal is disrupted, whether unintentionally or as the result of an Act of Radio Jamming, Act of Radio Spoofing, or similar Planned Act."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000007 ;
+                rdfs:label "Radio Interference"@en ;
+                skos:definition "A Natural Process in which a radio signal is disrupted, whether unintentionally or as the result of an Act of Radio Jamming, Act of Radio Spoofing, or similar Planned Act."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001127
 cco:ont00001127 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000865 ;
-                 rdfs:label "Loss of Quality"@en ;
-                 skos:definition "A Loss of Specifically Dependent Continuant in which some Independent Continuant ceases to be the bearer of some Quality."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000865 ;
+                rdfs:label "Loss of Quality"@en ;
+                skos:definition "A Loss of Specifically Dependent Continuant in which some Independent Continuant ceases to be the bearer of some Quality."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001128
 cco:ont00001128 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000676 ;
-                 rdfs:label "Act of Residing"@en ;
-                 skos:definition "An Act of Inhabitancy in which a Person lives in a dwelling permanently or for an extended period of time."@en ;
-                 cco:ont00001754 "http://www.thefreedictionary.com/reside" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000676 ;
+                rdfs:label "Act of Residing"@en ;
+                skos:definition "An Act of Inhabitancy in which a Person lives in a dwelling permanently or for an extended period of time."@en ;
+                cco:ont00001754 "http://www.thefreedictionary.com/reside" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001132
 cco:ont00001132 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000246 ;
-                 rdfs:label "Stasis of Mission Capability"@en ;
-                 skos:definition "A Stasis of Realizable Entity that holds during a temporal interval when a Continuant's capability (or lack thereof) to perform its intended Functions, tasks, or Objectives remains at a relatively constant level."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000246 ;
+                rdfs:label "Stasis of Mission Capability"@en ;
+                skos:definition "A Stasis of Realizable Entity that holds during a temporal interval when a Continuant's capability (or lack thereof) to perform its intended Functions, tasks, or Objectives remains at a relatively constant level."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001133
 cco:ont00001133 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000007 ;
-                 rdfs:label "Motion"@en ;
-                 skos:definition "A Natural Process in which a Continuant changes its Location or Spatial Orientation over some Temporal Interval."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000007 ;
+                rdfs:label "Motion"@en ;
+                skos:definition "A Natural Process in which a Continuant changes its Location or Spatial Orientation over some Temporal Interval."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001136
 cco:ont00001136 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000008 ;
-                 rdfs:label "Ultrasonic Frequency"@en ;
-                 skos:definition "A Sound Frequency that is greater than 20 kHz."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000008 ;
+                rdfs:label "Ultrasonic Frequency"@en ;
+                skos:definition "A Sound Frequency that is greater than 20 kHz."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001143
 cco:ont00001143 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000517 ;
-                 rdfs:label "Facsimile Transmission"@en ;
-                 skos:altLabel "Act of Facsimile Transmission"@en ,
-                               "Act of Faxing"@en ;
-                 skos:definition "An Act of Communication by Media in which the Information Content Entity that inheres in a Document is transmitted over a Telephone Network."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Fax&oldid=1054674158"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000517 ;
+                rdfs:label "Facsimile Transmission"@en ;
+                skos:altLabel "Act of Facsimile Transmission"@en ,
+                              "Act of Faxing"@en ;
+                skos:definition "An Act of Communication by Media in which the Information Content Entity that inheres in a Document is transmitted over a Telephone Network."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Fax&oldid=1054674158"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001144
 cco:ont00001144 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Act of Entertainment"@en ;
-                 skos:definition "A Planned Act consisting of any activity which provides a diversion or permits people to amuse themselves."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Entertainment&oldid=1061851778"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Act of Entertainment"@en ;
+                skos:definition "A Planned Act consisting of any activity which provides a diversion or permits people to amuse themselves."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Entertainment&oldid=1061851778"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001147
 cco:ont00001147 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Act of Violence"@en ;
-                 skos:definition "A Planned Act of causing harm to oneself or to another through the use of physical or verbal force."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Violence&oldid=1063681926"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Act of Violence"@en ;
+                skos:definition "A Planned Act of causing harm to oneself or to another through the use of physical or verbal force."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Violence&oldid=1063681926"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001158
 cco:ont00001158 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000366 ;
-                 rdfs:label "Act of Data Transformation"@en ;
-                 skos:definition "An Act of Information Processing in which an algorithm is executed to act upon one or more input Information Content Entities into one or more output Information Content Entities."@en ;
-                 skos:scopeNote "It is not a requirement that the output Information Content Entity(ies) be qualitatively distinct from the input(s) as a result of an Act of Data Transformation, though doing so is typically the goal of performing this Act. Consider, for example, selecting a column in an Excel spreadsheet then executing the \\\"Remove Duplicates\\\" Algorithm on it. The intent is to remove rows in that column containing duplicate content. If no duplicate values are present, the information in the column remains unchanged but an Act of Data Transformation was nonetheless performed."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000366 ;
+                rdfs:label "Act of Data Transformation"@en ;
+                skos:definition "An Act of Information Processing in which an algorithm is executed to act upon one or more input Information Content Entities into one or more output Information Content Entities."@en ;
+                skos:scopeNote "It is not a requirement that the output Information Content Entity(ies) be qualitatively distinct from the input(s) as a result of an Act of Data Transformation, though doing so is typically the goal of performing this Act. Consider, for example, selecting a column in an Excel spreadsheet then executing the \\\"Remove Duplicates\\\" Algorithm on it. The intent is to remove rows in that column containing duplicate content. If no duplicate values are present, the information in the column remains unchanged but an Act of Data Transformation was nonetheless performed."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001162
 cco:ont00001162 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000402 ;
-                 rdfs:comment "Examples: agreeing, betting, guaranteeing, inviting, offering, promising, swearing, volunteering"@en ;
-                 rdfs:label "Act of Commissive Communication"@en ;
-                 skos:definition "An Act of Communication in which an Agent commits themselves to doing, or refraining from doing, some future action."@en ;
-                 cco:ont00001754 "Derived (loosely) from: John Searle's Speech Acts: An Essay in the Philosophy of Language" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000402 ;
+                rdfs:comment "Examples: agreeing, betting, guaranteeing, inviting, offering, promising, swearing, volunteering"@en ;
+                rdfs:label "Act of Commissive Communication"@en ;
+                skos:definition "An Act of Communication that commits a speaker to some future action."@en ;
+                cco:ont00001754 "Derived (loosely) from: John Searle's Speech Acts: An Essay in the Philosophy of Language" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001167
 cco:ont00001167 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000530 ;
-                 rdfs:label "Midrange Frequency"@en ;
-                 skos:definition "A Sonic Frequency that is between 500 Hz and 2 kHz."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000530 ;
+                rdfs:label "Midrange Frequency"@en ;
+                skos:definition "A Sonic Frequency that is between 500 Hz and 2 kHz."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001170
 cco:ont00001170 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000490 ;
-                 rdfs:label "Hard X-ray Frequency"@en ;
-                 skos:definition "An X-Ray Frequency that is between 3 and 30 exahertz."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000490 ;
+                rdfs:label "Hard X-ray Frequency"@en ;
+                skos:definition "An X-Ray Frequency that is between 3 and 30 exahertz."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001171
 cco:ont00001171 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001190 ;
-                 rdfs:label "Wireless Network Telephone Call"@en ;
-                 skos:definition "A Telephone Call transmitted over a network where the telephones are mobile and can move anywhere within the coverage area."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telephone_network&oldid=1046265527"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001190 ;
+                rdfs:label "Wireless Network Telephone Call"@en ;
+                skos:definition "A Telephone Call transmitted over a network where the telephones are mobile and can move anywhere within the coverage area."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telephone_network&oldid=1046265527"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001184
 cco:ont00001184 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000368 ;
-                 rdfs:label "Spinning Motion"@en ;
-                 skos:definition "A Rotational Motion of an Object around an Axis of Rotation that passes through the Object's Center of Mass."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000368 ;
+                rdfs:label "Spinning Motion"@en ;
+                skos:definition "A Rotational Motion of an Object around an Axis of Rotation that passes through the Object's Center of Mass."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001190
 cco:ont00001190 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000517 ;
-                 rdfs:label "Telephone Call"@en ;
-                 skos:altLabel "Act of Telephone Calling"@en ;
-                 skos:definition "An Act of Communciation by Media transmitted over a telephone network to two or more Persons."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telephone_network&oldid=1046265527"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000517 ;
+                rdfs:label "Telephone Call"@en ;
+                skos:altLabel "Act of Telephone Calling"@en ;
+                skos:definition "An Act of Communciation by Media transmitted over a telephone network to two or more Persons."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telephone_network&oldid=1046265527"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001191
 cco:ont00001191 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001213 ;
-                 rdfs:label "Operational Stasis"@en ;
-                 skos:definition "A Stasis of Artifact Operationality that holds during a Temporal Interval when an Artifact maintains its designed set of Artifact Functions (or at least maintains its primary functions)."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001213 ;
+                rdfs:label "Operational Stasis"@en ;
+                skos:definition "A Stasis of Artifact Operationality that holds during a Temporal Interval when an Artifact maintains its designed set of Artifact Functions (or at least maintains its primary functions)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001194
 cco:ont00001194 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000642 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:BFO_0000057 ;
-                                   owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000004
-                                                                             [ rdf:type owl:Restriction ;
-                                                                               owl:onProperty obo:BFO_0000196 ;
-                                                                               owl:someValuesFrom obo:BFO_0000023
-                                                                             ]
-                                                                           ) ;
-                                                        rdf:type owl:Class
-                                                      ]
-                                 ] ;
-                 rdfs:comment "This class should be used to demarcate the start of the temporal interval (through the occurs_on property) that the Entity bears the Role."@en ;
-                 rdfs:label "Gain of Role"@en ;
-                 skos:definition "A Gain of Realizable Entity in which some Independent Continuant becomes bearer of some Role."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000642 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000057 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000004
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:BFO_0000196 ;
+                                                                              owl:someValuesFrom obo:BFO_0000023
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                rdfs:comment "This class should be used to demarcate the start of the temporal interval (through the occurs_on property) that the Entity bears the Role."@en ;
+                rdfs:label "Gain of Role"@en ;
+                skos:definition "A Gain of Realizable Entity in which some Independent Continuant becomes bearer of some Role."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001196
 cco:ont00001196 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000908 ;
-                 rdfs:comment "Many Acts of Manufacturing and Construction involve one or more Acts of Artifact Assembly, but Acts of Artifact Assembly can also occur in isolation from these activities."@en ;
-                 rdfs:label "Act of Artifact Assembly"@en ;
-                 skos:definition "An Act of Artifact Processing wherein a new Artifact is created by fitting component parts together."@en ;
-                 skos:example "putting together a piece of furniture purchased from Ikea" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000908 ;
+                rdfs:comment "Many Acts of Manufacturing and Construction involve one or more Acts of Artifact Assembly, but Acts of Artifact Assembly can also occur in isolation from these activities."@en ;
+                rdfs:label "Act of Artifact Assembly"@en ;
+                skos:definition "An Act of Artifact Processing wherein a new Artifact is created by fitting component parts together."@en ;
+                skos:example "putting together a piece of furniture purchased from Ikea" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001208
 cco:ont00001208 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000150 ;
-                 rdfs:comment "The corresponding Wavelength range is 100–10 m"@en ;
-                 rdfs:label "High Frequency"@en ;
-                 skos:altLabel "ITU Band Number 7"@en ;
-                 skos:definition "A Radio Frequency that is between 3 and 30 MHz."@en ;
-                 cco:ont00001753 "HF" ;
-                 cco:ont00001754 "International Telecommunication Union (ITU) and IEEE 521-2002 - IEEE Standard Letter Designations for Radar-Frequency Bands" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000150 ;
+                rdfs:comment "The corresponding Wavelength range is 100–10 m"@en ;
+                rdfs:label "High Frequency"@en ;
+                skos:altLabel "ITU Band Number 7"@en ;
+                skos:definition "A Radio Frequency that is between 3 and 30 MHz."@en ;
+                cco:ont00001753 "HF" ;
+                cco:ont00001754 "International Telecommunication Union (ITU) and IEEE 521-2002 - IEEE Standard Letter Designations for Radar-Frequency Bands" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001213
 cco:ont00001213 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000246 ;
-                 rdfs:label "Stasis of Artifact Operationality"@en ;
-                 skos:definition "A Stasis of Realizable Entity that holds during a Temporal Interval when an Artifact's designed set of Artifact Functions (or at least its primary functions) or the realizations of those functions remain unchanged."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000246 ;
+                rdfs:label "Stasis of Artifact Operationality"@en ;
+                skos:definition "A Stasis of Realizable Entity that holds during a Temporal Interval when an Artifact's designed set of Artifact Functions (or at least its primary functions) or the realizations of those functions remain unchanged."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001214
 cco:ont00001214 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001048 ;
-                 rdfs:label "Increase of Specifically Dependent Continuant"@en ;
-                 skos:definition "An Increase of Dependent Continuant in which some Independent Continuant has an increase of some Specifically Dependent Continuant that it bears."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001048 ;
+                rdfs:label "Increase of Specifically Dependent Continuant"@en ;
+                skos:definition "An Increase of Dependent Continuant in which some Independent Continuant has an increase of some Specifically Dependent Continuant that it bears."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001215
 cco:ont00001215 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000455 ;
-                 rdfs:label "Funeral"@en ;
-                 skos:altLabel "Act of Funeral Ceremony"@en ;
-                 skos:definition "An Act of Ceremony in which the Life of a Person who has died is celebrated, sanctified, or remembered."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Funeral&oldid=1060270978"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000455 ;
+                rdfs:label "Funeral"@en ;
+                skos:altLabel "Act of Funeral Ceremony"@en ;
+                skos:definition "An Act of Ceremony in which the Life of a Person who has died is celebrated, sanctified, or remembered."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Funeral&oldid=1060270978"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001219
 cco:ont00001219 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000144 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001777 ;
-                                   owl:someValuesFrom cco:ont00000763
-                                 ] ;
-                 rdfs:comment "Delta-v is not equivalent to and should not be confused with Acceleration, which is the rate of change of Velocity."@en ;
-                 rdfs:label "Delta-v"@en ;
-                 skos:altLabel "Change in Velocity"@en ,
-                               "DeltaV"@en ;
-                 skos:definition "A Process Profile that is the total change in Velocity of an object's Motion."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000144 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000117 ;
+                                  owl:someValuesFrom cco:ont00000763
+                                ] ;
+                rdfs:comment "Delta-v is not equivalent to and should not be confused with Acceleration, which is the rate of change of Velocity."@en ;
+                rdfs:label "Delta-v"@en ;
+                skos:altLabel "Change in Velocity"@en ,
+                              "DeltaV"@en ;
+                skos:definition "A Process Profile that is the total change in Velocity of an object's Motion."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001226
 cco:ont00001226 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000433 ;
-                 rdfs:label "Act of Employment"@en ;
-                 skos:definition "An Act of Association wherein an Organization assigns a set of activities to some Person to be performed in exchange for financial compensation."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000433 ;
+                rdfs:label "Act of Employment"@en ;
+                skos:definition "An Act of Association wherein an Organization assigns a set of activities to some Person to be performed in exchange for financial compensation."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001227
 cco:ont00001227 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000752 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001857 ;
-                                   owl:someValuesFrom cco:ont00001028
-                                 ] ;
-                 rdfs:label "Longitudinal Wave Profile"@en ;
-                 skos:altLabel "Compression Wave"@en ,
-                               "Longitudinal Wave"@en ;
-                 skos:definition "A Wave Process Profile in which the displacement of participating particles is parallel to the direction of the Wave Process' propogation such that the particles alternate between participating in processes of compression and rarefaction as they participate in individual Wave Processes."@en ;
-                 cco:ont00001754 "http://www.acs.psu.edu/drussell/Demos/waves/wavemotion.html" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000752 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000132 ;
+                                  owl:someValuesFrom cco:ont00001028
+                                ] ;
+                rdfs:label "Longitudinal Wave Profile"@en ;
+                skos:altLabel "Compression Wave"@en ,
+                              "Longitudinal Wave"@en ;
+                skos:definition "A Wave Process Profile in which the displacement of participating particles is parallel to the direction of the Wave Process' propogation such that the particles alternate between participating in processes of compression and rarefaction as they participate in individual Wave Processes."@en ;
+                cco:ont00001754 "http://www.acs.psu.edu/drussell/Demos/waves/wavemotion.html" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001231
 cco:ont00001231 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000530 ;
-                 rdfs:label "Brilliance Frequency"@en ;
-                 skos:definition "A Sonic Frequency that is between 6 and 20 kHz."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000530 ;
+                rdfs:label "Brilliance Frequency"@en ;
+                skos:definition "A Sonic Frequency that is between 6 and 20 kHz."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001232
 cco:ont00001232 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:comment "In all cases, to possess something, an agent must have an intention to possess it."@en ;
-                 rdfs:label "Act of Possession"@en ;
-                 skos:definition "A Planned Act in which an agent intentionally exercises control towards a thing."@en ;
-                 cco:ont00001754 "http://en.wikipedia.org/wiki/Possession_(law)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:comment "In all cases, to possess something, an agent must have an intention to possess it."@en ;
+                rdfs:label "Act of Possession"@en ;
+                skos:definition "A Planned Act in which an agent intentionally exercises control towards a thing."@en ;
+                cco:ont00001754 "http://en.wikipedia.org/wiki/Possession_(law)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001236
 cco:ont00001236 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001147 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001803 ;
-                                   owl:someValuesFrom cco:ont00000920
-                                 ] ;
-                 rdfs:label "Act of Suicide"@en ;
-                 skos:altLabel "Suicide"@en ;
-                 skos:definition "An Act of Violence in which some Agent intentionally and voluntarily causes their own death."@en ;
-                 cco:ont00001754 "http://www.merriam-webster.com/dictionary/suicide" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001147 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty cco:ont00001803 ;
+                                  owl:someValuesFrom cco:ont00000920
+                                ] ;
+                rdfs:label "Act of Suicide"@en ;
+                skos:altLabel "Suicide"@en ;
+                skos:definition "An Act of Violence in which some Agent intentionally and voluntarily causes their own death."@en ;
+                cco:ont00001754 "http://www.merriam-webster.com/dictionary/suicide" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001237
 cco:ont00001237 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000007 ;
-                 rdfs:label "Birth"@en ;
-                 skos:definition "A Natural Process of bringing forth offspring."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Birth&oldid=1063718655"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000007 ;
+                rdfs:label "Birth"@en ;
+                skos:definition "A Natural Process of bringing forth offspring."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Birth&oldid=1063718655"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001244
 cco:ont00001244 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000588 ;
-                 rdfs:label "Act of Issuing Mass Media Article"@en ;
-                 skos:definition "An Act of Mass Media Communication involving sending forth, distributing, or putting into circulation a non-fictional essay, especially one included with others in a newspaper, magazine, or journal."@en ;
-                 cco:ont00001754 "JC3IEDM-MIRD-DMWG-Edition_3.0.2_20090514" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000588 ;
+                rdfs:label "Act of Issuing Mass Media Article"@en ;
+                skos:definition "An Act of Mass Media Communication involving sending forth, distributing, or putting into circulation a non-fictional essay, especially one included with others in a newspaper, magazine, or journal."@en ;
+                cco:ont00001754 "JC3IEDM-MIRD-DMWG-Edition_3.0.2_20090514" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001246
 cco:ont00001246 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000847 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001777 ;
-                                   owl:someValuesFrom cco:ont00000566
-                                 ] ;
-                 rdfs:label "Under Active Control"@en ;
-                 skos:definition "An Active Stasis during which an Artifact participates in an Act of Artifact Employment."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000847 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty cco:ont00001777 ;
+                                  owl:someValuesFrom cco:ont00000566
+                                ] ;
+                rdfs:label "Under Active Control"@en ;
+                skos:definition "An Active Stasis during which an Artifact participates in an Act of Artifact Employment."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001251
 cco:ont00001251 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Act of Intelligence Gathering"@en ;
-                 skos:definition "A Planned Act of producing and/or gathering information by a government or other Organization to guide decisions and actions by answering questions or obtaining advance warning of events and movements deemed to be important or otherwise relevant."@en ;
-                 cco:ont00001754 "http://en.wikipedia.org/wiki/Intelligence_(information_gathering)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Act of Intelligence Gathering"@en ;
+                skos:definition "A Planned Act of producing and/or gathering information by a government or other Organization to guide decisions and actions by answering questions or obtaining advance warning of events and movements deemed to be important or otherwise relevant."@en ;
+                cco:ont00001754 "http://en.wikipedia.org/wiki/Intelligence_(information_gathering)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001261
 cco:ont00001261 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000379 ;
-                 rdfs:label "Act of Identifying"@en ;
-                 skos:definition "An Act of Representative Communication performed by asserting who or what a particular person or thing is."@en ;
-                 cco:ont00001754 "http://www.dictionary.com/browse/identify" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000379 ;
+                rdfs:label "Act of Identifying"@en ;
+                skos:definition "An Act of Representative Communication performed by asserting who or what a particular person or thing is."@en ;
+                cco:ont00001754 "http://www.dictionary.com/browse/identify" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001263
 cco:ont00001263 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000588 ;
-                 rdfs:label "Act of Issuing Mass Media Documentary"@en ;
-                 skos:definition "An Act of Mass Media Communication involving sending forth, distributing, or putting into circulation information that provides a factual record or report."@en ;
-                 cco:ont00001754 "JC3IEDM-MIRD-DMWG-Edition_3.0.2_20090514" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000588 ;
+                rdfs:label "Act of Issuing Mass Media Documentary"@en ;
+                skos:definition "An Act of Mass Media Communication involving sending forth, distributing, or putting into circulation information that provides a factual record or report."@en ;
+                cco:ont00001754 "JC3IEDM-MIRD-DMWG-Edition_3.0.2_20090514" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001266
 cco:ont00001266 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001075 ;
-                 rdfs:label "Act of Vocational Training Instruction"@en ;
-                 skos:definition "An Act of Training Instruction performed by an Agent who realizes a capacity derived from the Agent's affiliation with a Vocational School, Technical School, Trade Organization, or Industry Educational Program Provider by imparting skills required for a specific occupation in industry, agriculture or trade to an Agent either directly or indirectly through some communication medium."@en ;
-                 cco:ont00001754 "http://wordnetweb.princeton.edu/perl/webwn?s=vocational%20training" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001075 ;
+                rdfs:label "Act of Vocational Training Instruction"@en ;
+                skos:definition "An Act of Training Instruction performed by an Agent who realizes a capacity derived from the Agent's affiliation with a Vocational School, Technical School, Trade Organization, or Industry Educational Program Provider by imparting skills required for a specific occupation in industry, agriculture or trade to an Agent either directly or indirectly through some communication medium."@en ;
+                cco:ont00001754 "http://wordnetweb.princeton.edu/perl/webwn?s=vocational%20training" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001267
 cco:ont00001267 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000971 ;
-                 rdfs:label "Act of Propaganda"@en ;
-                 skos:definition "An Act of Deceptive Communication Propaganda intended to influence the attitude of a mass audience toward some cause or position by presenting facts selectively (thus possibly lying by omission) or by using loaded messages to produce an emotional rather than rational response to the information presented."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Propaganda&oldid=1062472484"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000971 ;
+                rdfs:label "Act of Propaganda"@en ;
+                skos:definition "An Act of Deceptive Communication Propaganda intended to influence the attitude of a mass audience toward some cause or position by presenting facts selectively (thus possibly lying by omission) or by using loaded messages to produce an emotional rather than rational response to the information presented."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Propaganda&oldid=1062472484"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001269
 cco:ont00001269 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000133 ;
-                 rdfs:label "Act of Warning"@en ;
-                 skos:definition "An Act of Directive Communication performed by indicating a possible or impending danger, problem, or other unpleasant situation."@en ;
-                 cco:ont00001754 "http://www.merriam-webster.com/dictionary/warning" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000133 ;
+                rdfs:label "Act of Warning"@en ;
+                skos:definition "An Act of Directive Communication performed by indicating a possible or impending danger, problem, or other unpleasant situation."@en ;
+                cco:ont00001754 "http://www.merriam-webster.com/dictionary/warning" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001272
 cco:ont00001272 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000191 ;
-                 rdfs:label "Act of Murder"@en ;
-                 skos:definition "An Act of Homicide with malice aforethought."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000191 ;
+                rdfs:label "Act of Murder"@en ;
+                skos:definition "An Act of Homicide with malice aforethought."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001274
 cco:ont00001274 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000008 ;
-                 rdfs:label "Infrasonic Frequency"@en ;
-                 skos:definition "A Sound Frequency that is below 20 Hz."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000008 ;
+                rdfs:label "Infrasonic Frequency"@en ;
+                skos:definition "A Sound Frequency that is below 20 Hz."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001279
 cco:ont00001279 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001133 ;
-                 rdfs:label "Vibration Motion"@en ;
-                 skos:altLabel "Mechanical Oscillation"@en ,
-                               "Oscillation Motion"@en ,
-                               "Vibration"@en ;
-                 skos:definition "A Motion wherein some participant repetitively deviates from a central location to two surrounding locations."@en ;
-                 cco:ont00001754 "https://physicsabout.com/motion/"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001133 ;
+                rdfs:label "Vibration Motion"@en ;
+                skos:altLabel "Mechanical Oscillation"@en ,
+                              "Oscillation Motion"@en ,
+                              "Vibration"@en ;
+                skos:definition "A Motion wherein some participant repetitively deviates from a central location to two surrounding locations."@en ;
+                cco:ont00001754 "https://physicsabout.com/motion/"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001285
 cco:ont00001285 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000368 ;
-                 rdfs:label "Revolving Motion"@en ;
-                 skos:definition "A Rotational Motion of an Object around an Axis of Rotation that is located externally to the Site occupied by the Object."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000368 ;
+                rdfs:label "Revolving Motion"@en ;
+                skos:definition "A Rotational Motion of an Object around an Axis of Rotation that is located externally to the Site occupied by the Object."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001286
 cco:ont00001286 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000752 ;
-                 rdfs:label "Waveform"@en ;
-                 skos:definition "A Wave Process Profile that is the shape of the Wave Cycles of the Wave Process when depicted in a visual graph."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000752 ;
+                rdfs:label "Waveform"@en ;
+                skos:definition "A Wave Process Profile that is the shape of the Wave Cycles of the Wave Process when depicted in a visual graph."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001289
 cco:ont00001289 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000135 ;
-                 rdfs:label "Damaged Stasis"@en ;
-                 skos:altLabel "Compromised"@en ,
-                               "Damaged"@en ,
-                               "Injured"@en ;
-                 skos:definition "A Stasis of Specifically Dependent Continuant in which some Independent Continuant bears a Quality or Realizable Entity that has suffered impairment (i.e., a decrease or loss) due to a previous action or event such that the Independent Continuant is now of lesser value, usefulness, or functionality."@en ;
-                 skos:scopeNote "This class can be used to instantiate instances that might otherwise be treated by defined classes such as Damaged Vehicle or Wounded Person. The Independent Continuant and Quality or Realizable Entity are participants of the stasis which can in turn be related to the temporal interval via the occurs on property. "@en ;
-                 cco:ont00001754 "http://www.thefreedictionary.com/damaged" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000135 ;
+                rdfs:label "Damaged Stasis"@en ;
+                skos:altLabel "Compromised"@en ,
+                              "Damaged"@en ,
+                              "Injured"@en ;
+                skos:definition "A Stasis of Specifically Dependent Continuant in which some Independent Continuant bears a Quality or Realizable Entity that has suffered impairment (i.e., a decrease or loss) due to a previous action or event such that the Independent Continuant is now of lesser value, usefulness, or functionality."@en ;
+                skos:scopeNote "This class can be used to instantiate instances that might otherwise be treated by defined classes such as Damaged Vehicle or Wounded Person. The Independent Continuant and Quality or Realizable Entity are participants of the stasis which can in turn be related to the temporal interval via the occurs on property. "@en ;
+                cco:ont00001754 "http://www.thefreedictionary.com/damaged" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001305
 cco:ont00001305 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001066 ;
-                 rdfs:label "Loss of Function"@en ;
-                 skos:definition "A Loss of Disposition in which some Independent Continuant ceases to be the bearer of some Function."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001066 ;
+                rdfs:label "Loss of Function"@en ;
+                skos:definition "A Loss of Disposition in which some Independent Continuant ceases to be the bearer of some Function."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001314
 cco:ont00001314 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Legal System Act"@en ;
-                 skos:definition "A Planned Act performed by an Agent that realizes their role within the context of a legal system of some jurisdiction."@en ;
-                 cco:ont00001754 "http://www.id.uscourts.gov/glossary.htm" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Legal System Act"@en ;
+                skos:definition "A Planned Act performed by an Agent that realizes their role within the context of a legal system of some jurisdiction."@en ;
+                cco:ont00001754 "http://www.id.uscourts.gov/glossary.htm" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001322
 cco:ont00001322 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000726 ;
-                 rdfs:comment "For the most part Generically Dependent Continuants do not inhere in their bearers over some continuous scale. The primary exception is religion and this class allows annotation of those cases where an Agent is described as becoming less religious. Other cases would include the decrease of an organization's bearing of some objective."@en ;
-                 rdfs:label "Decrease of Generically Dependent Continuant"@en ;
-                 skos:definition "A Decrease of Dependent Continuant in which some Independent Continuant has a decrease in the level of a Generically Dependent Continuant that it bears."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000726 ;
+                rdfs:comment "For the most part Generically Dependent Continuants do not inhere in their bearers over some continuous scale. The primary exception is religion and this class allows annotation of those cases where an Agent is described as becoming less religious. Other cases would include the decrease of an organization's bearing of some objective."@en ;
+                rdfs:label "Decrease of Generically Dependent Continuant"@en ;
+                skos:definition "A Decrease of Dependent Continuant in which some Independent Continuant has a decrease in the level of a Generically Dependent Continuant that it bears."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001325
 cco:ont00001325 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001334 ;
-                 rdfs:label "Act of Renting"@en ;
-                 skos:definition "An Act of Purchasing wherein a Financial Instrument is used by an Agent (the Renter) as a payment to acquire temporary possession or use of a good or property that is owned or controlled by another Agent (the Seller)."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001334 ;
+                rdfs:label "Act of Renting"@en ;
+                skos:definition "An Act of Purchasing wherein a Financial Instrument is used by an Agent (the Renter) as a payment to acquire temporary possession or use of a good or property that is owned or controlled by another Agent (the Seller)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001327
 cco:ont00001327 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000228 ;
-                 rdfs:label "Social Act"@en ;
-                 skos:definition "A Planned Act having an objective that affects, is performed by, or is performed on behalf of, a community or group of Persons."@en ;
-                 cco:ont00001754 "http://en.wiktionary.org/wiki/commually" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000228 ;
+                rdfs:label "Social Act"@en ;
+                skos:definition "A Planned Act having an objective that affects, is performed by, or is performed on behalf of, a community or group of Persons."@en ;
+                cco:ont00001754 "http://en.wiktionary.org/wiki/commually" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001330
 cco:ont00001330 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000110 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001777 ;
-                                   owl:someValuesFrom cco:ont00000345
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001777 ;
-                                   owl:someValuesFrom cco:ont00000517
-                                 ] ;
-                 rdfs:label "Telemetry Process"@en ;
-                 skos:definition "A Mechanical Process that is highly automated and in which measurements are made or other data is collected and transmitted to receiving equipment to facilitate the monitoring of environmental conditions or equipment parameters at a remote or inaccessible location."@en ;
-                 skos:example "using a GPS tag to track a shark's migratory pattern" ,
-                              "using a portable cardiac monitor to remotely collect data on a patient's heart activity (biotelemetry)" ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telemetry&oldid=1061697851"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000110 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty cco:ont00001777 ;
+                                  owl:someValuesFrom cco:ont00000345
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty cco:ont00001777 ;
+                                  owl:someValuesFrom cco:ont00000517
+                                ] ;
+                rdfs:label "Telemetry Process"@en ;
+                skos:definition "A Mechanical Process that is highly automated and in which measurements are made or other data is collected and transmitted to receiving equipment to facilitate the monitoring of environmental conditions or equipment parameters at a remote or inaccessible location."@en ;
+                skos:example "using a GPS tag to track a shark's migratory pattern" ,
+                             "using a portable cardiac monitor to remotely collect data on a patient's heart activity (biotelemetry)" ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telemetry&oldid=1061697851"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001332
 cco:ont00001332 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000610 ;
-                 rdfs:label "Extreme Ultraviolet Light Frequency"@en ;
-                 skos:definition "An Ultraviolet Light Frequency that is between 3 and 30 petahertz."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ultraviolet&oldid=1062593453"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000610 ;
+                rdfs:label "Extreme Ultraviolet Light Frequency"@en ;
+                skos:definition "An Ultraviolet Light Frequency that is between 3 and 30 petahertz."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ultraviolet&oldid=1062593453"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001334
 cco:ont00001334 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000836 ;
-                 rdfs:label "Act of Purchasing"@en ;
-                 skos:definition "An Act of Financial Instrument Use wherein a Financial Instrument is used by an Agent (the Purchaser) to acquire a good or service from another Agent (the Provider)."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Purchasing&oldid=1050163120"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000836 ;
+                rdfs:label "Act of Purchasing"@en ;
+                skos:definition "An Act of Financial Instrument Use wherein a Financial Instrument is used by an Agent (the Purchaser) to acquire a good or service from another Agent (the Provider)."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Purchasing&oldid=1050163120"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001336
 cco:ont00001336 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001232 ;
-                 rdfs:comment "The relation between the owner and property may be private, collective, or common and the property may be objects, land, real estate, or intellectual property."@en ;
-                 rdfs:label "Act of Ownership"@en ;
-                 skos:definition "An Act of Possession that includes an agent having certain rights and duties over the property owned."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ownership&oldid=1058224617"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001232 ;
+                rdfs:comment "The relation between the owner and property may be private, collective, or common and the property may be objects, land, real estate, or intellectual property."@en ;
+                rdfs:label "Act of Ownership"@en ;
+                skos:definition "An Act of Possession that includes an agent having certain rights and duties over the property owned."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ownership&oldid=1058224617"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001337
 cco:ont00001337 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000754 ;
-                 rdfs:label "Infrared Light Frequency"@en ;
-                 skos:definition "An Electromagnetic Radiation Frequency of some Electromagnetic Wave that is between 300 gigahertz and 430 tetrahertz."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Infrared&oldid=1064111319"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000754 ;
+                rdfs:label "Infrared Light Frequency"@en ;
+                skos:definition "An Electromagnetic Radiation Frequency of some Electromagnetic Wave that is between 300 gigahertz and 430 tetrahertz."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Infrared&oldid=1064111319"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001338
 cco:ont00001338 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000862 ;
-                 rdfs:label "Timbre"@en ;
-                 skos:definition "A Sound Process Profile that is characterized by the variation, spectrum, or envelope of translated sound waves, typically on a continuum from dull or dark to bright."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000862 ;
+                rdfs:label "Timbre"@en ;
+                skos:definition "A Sound Process Profile that is characterized by the variation, spectrum, or envelope of translated sound waves, typically on a continuum from dull or dark to bright."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001339
 cco:ont00001339 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000890 ;
-                 rdfs:label "Act of Walking"@en ;
-                 skos:definition "An Act of Travel that proceeds by foot."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000890 ;
+                rdfs:label "Act of Walking"@en ;
+                skos:definition "An Act of Travel that proceeds by foot."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001347
 cco:ont00001347 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000005 ;
-                 rdfs:label "Behavior"@en ;
-                 skos:definition "An Act in which an Independent Continuant participates as an Agent in response to external or internal stimuli and following some pattern which is dependent upon some combination of that Independent Continuant's internal state and external conditions."@en ;
-                 cco:ont00001754 "http://purl.obolibrary.org/obo/GO_0007610" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000005 ;
+                rdfs:label "Behavior"@en ;
+                skos:definition "An Act in which an Independent Continuant participates as an Agent in response to external or internal stimuli and following some pattern which is dependent upon some combination of that Independent Continuant's internal state and external conditions."@en ;
+                cco:ont00001754 "http://purl.obolibrary.org/obo/GO_0007610" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001356
 cco:ont00001356 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000611 ;
-                 rdfs:label "Increase of Disposition"@en ;
-                 skos:definition "An Increase of Realizable Entity in which some Independent Continuant has an increase of some Disposition that it bears."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000611 ;
+                rdfs:label "Increase of Disposition"@en ;
+                skos:definition "An Increase of Realizable Entity in which some Independent Continuant has an increase of some Disposition that it bears."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001359
 cco:ont00001359 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000908 ;
-                 rdfs:comment "An Act of Manufacturing typically involves the mass production of goods."@en ;
-                 rdfs:label "Act of Manufacturing"@en ;
-                 skos:definition "An Act of Artifact Processing wherein Artifacts are created in a Facility for the purpose of being sold to consumers."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000908 ;
+                rdfs:comment "An Act of Manufacturing typically involves the mass production of goods."@en ;
+                rdfs:label "Act of Manufacturing"@en ;
+                skos:definition "An Act of Artifact Processing wherein Artifacts are created in a Facility for the purpose of being sold to consumers."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001374
 cco:ont00001374 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000402 ;
-                 rdfs:comment "Examples: Baptism, Sentencing a person to imprisonment, Pronouncing a couple husband and wife, Declaring war"@en ;
-                 rdfs:label "Act of Declarative Communication"@en ;
-                 skos:definition "An Act of Communication that changes the reality in accord with the proposition of the declaration."@en ;
-                 cco:ont00001754 "Derived (loosely) from: John Searle's Speech Acts: An Essay in the Philosophy of Language" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000402 ;
+                rdfs:comment "Examples: Baptism, Sentencing a person to imprisonment, Pronouncing a couple husband and wife, Declaring war"@en ;
+                rdfs:label "Act of Declarative Communication"@en ;
+                skos:definition "An Act of Communication that changes the reality in accord with the proposition of the declaration."@en ;
+                cco:ont00001754 "Derived (loosely) from: John Searle's Speech Acts: An Essay in the Philosophy of Language" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001376
 cco:ont00001376 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000570 ;
-                 rdfs:label "Torque"@en ;
-                 skos:altLabel "Moment of Force"@en ;
-                 skos:definition "A Force that is applied to an object in a direction that would tend to cause the object to rotate around an Axis of Rotation and is the rate of change of an object's Angular Momentum."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Torque&oldid=1063339484"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000570 ;
+                rdfs:label "Torque"@en ;
+                skos:altLabel "Moment of Force"@en ;
+                skos:definition "A Force that is applied to an object in a direction that would tend to cause the object to rotate around an Axis of Rotation and is the rate of change of an object's Angular Momentum."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Torque&oldid=1063339484"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 
-###  Generated by the OWL API (version 4.5.29) https://github.com/owlcs/owlapi
+###  Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi


### PR DESCRIPTION
I saved as in turtle syntax and the diff is still oversized.