### PR TITLE
#564 and #620 - ICE-IBA Refactor

### DIFF
--- a/src/cco-modules/ArtifactOntology.ttl
+++ b/src/cco-modules/ArtifactOntology.ttl
@@ -5369,8 +5369,8 @@ cco:ont00001999 rdf:type owl:Class ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
-###  https://www.commoncoreontologies.org/ont00002049
-cco:ont00002049 rdf:type owl:Class ;
+###  https://www.commoncoreontologies.org/ont00001209
+cco:ont00001209 rdf:type owl:Class ;
                 rdfs:subClassOf cco:ont00000326 ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty obo:BFO_0000101 ;

--- a/src/cco-modules/ArtifactOntology.ttl
+++ b/src/cco-modules/ArtifactOntology.ttl
@@ -96,7 +96,7 @@ cco:ont00000014 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Aztec Code"@en ;
                 skos:altLabel "Aztec Code"@en ;
-                skos:definition "A Two-Dimensional Barcode that is used by the transportation industry to scan tickets."@en ;
+                skos:definition "A Material Copy of a Two-Dimensional Barcode that is used by the transportation industry to scan tickets."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -325,7 +325,7 @@ cco:ont00000064 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Book"@en ;
                 skos:altLabel "Book"@en ;
-                skos:definition "An Information Bearing Artifact that is designed to bear some specific Information Content Entity by means of ink, paper, parchment, or other materials fastened together to hinge at one side."@en ;
+                skos:definition "A Material Copy of a Document that is designed to carry some specific Information Content Entity by means of ink, paper, parchment, or other materials fastened together to hinge at one side."@en ;
                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Book&oldid=1063132471"^^xsd:anyURI ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
@@ -348,7 +348,7 @@ cco:ont00000069 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Transcript"@en ;
                 skos:altLabel "Transcript"@en ;
-                skos:definition "A Document that is designed to bear some specific Information Content Entity that was originally recorded in a different medium."@en ;
+                skos:definition "A Material Copy of a Document that is designed to carry some specific Information Content Entity that was originally recorded in a different medium."@en ;
                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Transcript&oldid=1038510063"^^xsd:anyURI ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
@@ -651,7 +651,7 @@ cco:ont00000159 rdf:type owl:Class ;
                 rdfs:subClassOf cco:ont00000798 ;
                 rdfs:label "Material Copy of a Timekeeping Instrument"@en ;
                 skos:altLabel "Timekeeping Instrument"@en ;
-                skos:definition "An Information Bearing Artifact that is designed to bear some specific Information Content Entity that is about some temporal region."@en ;
+                skos:definition "An Information Bearing Artifact that is designed to carry some specific Information Content Entity that is about some temporal region."@en ;
                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Timekeeper&oldid=1061681902"^^xsd:anyURI ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
@@ -914,7 +914,7 @@ cco:ont00000241 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Two-Dimensional Barcode"@en ;
                 skos:altLabel "Two-Dimensional Barcode"@en ;
-                skos:definition "A Barcode that is designed to bear lines of varying widths, spacing, height, and color that concretize some Directive Information Content Entity."@en ;
+                skos:definition "A Material Copy of a Barcode that is designed to bear lines of varying widths, spacing, height, and color that concretize some Directive Information Content Entity."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -927,7 +927,7 @@ cco:ont00000242 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Data Matrix Code"@en ;
                 skos:altLabel "Data Matrix Code"@en ;
-                skos:definition "A Two-Dimensional Barcode that consists of cells arranged in rectangular patterns and is used for marking small items in logistics and operations."@en ;
+                skos:definition "A Material Copy of a Two-Dimensional Barcode that consists of cells arranged in rectangular patterns and is used for marking small items in logistics and operations."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -1013,7 +1013,7 @@ cco:ont00000258 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a One-Dimensional Barcode"@en ;
                 skos:altLabel "One-Dimensional Barcode"@en ;
-                skos:definition "A Barcode that is designed to bear parallel lines of varying widths and spacing that concretize some Directive Information Content Entity."@en ;
+                skos:definition "A Material Copy of a Barcode that is designed to carry parallel lines of varying widths and spacing that concretize some Directive Information Content Entity."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -1335,7 +1335,7 @@ cco:ont00000326 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a UPC Barcode"@en ;
                 skos:altLabel "UPC Barcode"@en ;
-                skos:definition "A One-Dimensional Barcode that consists of 6 or 12 numerical digits and is used to scan consumer goods."@en ;
+                skos:definition "A Material Copy of a One-Dimensional Barcode that consists of 6 or 12 numerical digits and is used to scan consumer goods."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -1556,7 +1556,7 @@ cco:ont00000382 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Spreadsheet"@en ;
                 skos:altLabel "Spreadsheet"@en ;
-                skos:definition "An Information Bearing Artifact that is designed to bear some Information Content Entity in an interactive, tabular form."@en ;
+                skos:definition "A Material Copy of a Document that is designed to carry some Information Content Entity in an interactive, tabular form."@en ;
                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Spreadsheet&oldid=1064060503"^^xsd:anyURI ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
@@ -1694,7 +1694,7 @@ cco:ont00000429 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Codabar Barcode"@en ;
                 skos:altLabel "Codabar Barcode"@en ;
-                skos:definition "A One-Dimensional Barcode that consists of numbers 0-9 and the characters -$:/.+ and is used by logistics and healthcare professionals."@en ;
+                skos:definition "A Material Copy of a One-Dimensional Barcode that consists of numbers 0-9 and the characters -$:/.+ and is used by logistics and healthcare professionals."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -1829,7 +1829,7 @@ cco:ont00000461 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a ISSN Barcode"@en ;
                 skos:altLabel "ISSN Barcode"@en ;
-                skos:definition "An EAN Barcode that is used to designate periodicals."@en ;
+                skos:definition "A Material Copy of an EAN Barcode that is used to designate periodicals."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -1860,7 +1860,7 @@ cco:ont00000470 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Academic Degree"@en ;
                 skos:altLabel "Academic Degree"@en ;
-                skos:definition "A Certificate issued by an Educational Organization to a Person to indicate that the Person has satisfactorily completed a course of study, or as an honorary recognition of the Person's achievement."@en ;
+                skos:definition "A Material Copy of a Certificate that is issued by an Educational Organization to a Person to indicate that the Person has satisfactorily completed a course of study, or as an honorary recognition of the Person's achievement."@en ;
                 cco:ont00001754 "http://www.dictionary.com/browse/degree" ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
@@ -1874,7 +1874,7 @@ cco:ont00000471 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Warning Message"@en ;
                 skos:altLabel "Warning Message"@en ;
-                skos:definition "A Notification Message that is designed to bear an Information Content Entity that describes a possible or impending threat."@en ;
+                skos:definition "A Material Copy of a Notification Message that is designed to carry an Information Content Entity that describes a possible or impending threat."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -1948,7 +1948,7 @@ cco:ont00000493 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Code List"@en ;
                 skos:altLabel "Code List"@en ;
-                skos:definition "A List that contains an ordered sequence of Information Bearing Entities that carry Code Identifiers."@en ;
+                skos:definition "A Material Copy of a List that contains an ordered sequence of Information Bearing Entities that carry Code Identifiers."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -2106,7 +2106,7 @@ cco:ont00000559 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a QR Code"@en ;
                 skos:altLabel "QR Code"@en ;
-                skos:definition "A Two-Dimensional Barcode that consists of numeric, alphanumeric, binary, or kanji information and is used primarily for tracking and marketing."@en ;
+                skos:definition "A Material Copy of a Two-Dimensional Barcode that consists of numeric, alphanumeric, binary, or kanji information and is used primarily for tracking and marketing."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -2180,7 +2180,7 @@ cco:ont00000582 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Code 93 Barcode"@en ;
                 skos:altLabel "Code 93 Barcode"@en ;
-                skos:definition "A One-Dimensional Barcode that consists of up to 93 ASCII characters and is used in logistics to identify packages in retail inventory, lable electornic components, and provide supplementary delivery information."@en ;
+                skos:definition "A Material Copy of a One-Dimensional Barcode that consists of up to 93 ASCII characters and is used in logistics to identify packages in retail inventory, lable electornic components, and provide supplementary delivery information."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -2227,7 +2227,7 @@ cco:ont00000596 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a JAN-13 Barcode"@en ;
                 skos:altLabel "JAN-13 Barcode"@en ;
-                skos:definition "An EAN Barcode that consists of 13 numerical digits and is used primarily in Japan to designate products at the point of sale."@en ;
+                skos:definition "A Material Copy of an EAN Barcode that consists of 13 numerical digits and is used primarily in Japan to designate products at the point of sale."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -2236,7 +2236,7 @@ cco:ont00000597 rdf:type owl:Class ;
                 rdfs:subClassOf cco:ont00000798 ;
                 rdfs:label "Material Copy of a Instrument Display Panel"@en ;
                 skos:altLabel "Instrument Display Panel"@en ;
-                skos:definition "An Information Bearing Artifact that is designed to bear information about some Artifact that is derived by the instrumentation Sensors of that Artifact."@en ;
+                skos:definition "An Information Bearing Artifact that is designed to carry information about some Artifact that is derived by the instrumentation Sensors of that Artifact."@en ;
                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Flight_instruments&oldid=1062972990"^^xsd:anyURI ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
@@ -2276,7 +2276,7 @@ cco:ont00000602 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a ITF Barcode"@en ;
                 skos:altLabel "ITF Barcode"@en ;
-                skos:definition "A One-Dimensional Barcode that consists of an even number of numerical characters and is used primarily in packaging and distribution."@en ;
+                skos:definition "A Material Copy of a One-Dimensional Barcode that consists of an even number of numerical characters and is used primarily in packaging and distribution."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -2335,7 +2335,7 @@ cco:ont00000624 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Report"@en ;
                 skos:altLabel "Report"@en ;
-                skos:definition "A Document that is designed to bear some specific Information Content Entity that conveys an account of some event, situation, or the result of some observation or inquiry."@en ;
+                skos:definition "A Material Copy of a Document that is designed to carry some specific Information Content Entity that conveys an account of some event, situation, or the result of some observation or inquiry."@en ;
                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Report&oldid=1063765657"^^xsd:anyURI ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
@@ -2415,7 +2415,7 @@ cco:ont00000640 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Email Message"@en ;
                 skos:altLabel "Email Message"@en ;
-                skos:definition "A Message that is transmitted to the recipient's Email Box."@en ;
+                skos:definition "A Material Copy of a Message that is transmitted to the recipient's Email Box."@en ;
                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Email&oldid=1063646749"^^xsd:anyURI ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
@@ -2659,7 +2659,7 @@ cco:ont00000702 rdf:type owl:Class ;
                                   owl:onProperty obo:BFO_0000101 ;
                                   owl:someValuesFrom cco:ont00002004
                                 ] ;
-                rdfs:label "Material Copy of a Image"@en ;
+                rdfs:label "Material Copy of an Image"@en ;
                 skos:altLabel "Image"@en ;
                 skos:definition "An Information Bearing Artifact that is designed to carry an Information Content Entity that represents some entity owing to a visual isomorphism between the carrying artifact and the entity."@en ;
                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Image&oldid=1062709732"^^xsd:anyURI ;
@@ -2671,7 +2671,7 @@ cco:ont00000703 rdf:type owl:Class ;
                 rdfs:subClassOf cco:ont00000159 ;
                 rdfs:label "Material Copy of a System Clock"@en ;
                 skos:altLabel "System Clock"@en ;
-                skos:definition "A Timekeeping Instrument that is part of a computer an is designed to issue a steady high-frequency signal that is used to synchronize all of the computer's internal components."@en ;
+                skos:definition "A Material Copy of a Timekeeping Instrument that is part of a computer and is designed to issue a steady high-frequency signal that is used to synchronize all of the computer's internal components."@en ;
                 cco:ont00001754 "http://www.thefreedictionary.com/system+clock" ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
@@ -2875,7 +2875,7 @@ cco:ont00000743 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Chart"@en ;
                 skos:altLabel "Chart"@en ;
-                skos:definition "An Image that is designed to carry some Representational Information Content Entity that is prescribed by some canonical visual format."@en ;
+                skos:definition "A Material Copy of an Image that is designed to carry some Representational Information Content Entity that is prescribed by some canonical visual format."@en ;
                 cco:ont00001754 "Adapted from “Chart.” Merriam-Webster.com Dictionary, Merriam-Webster, https://www.merriam-webster.com/dictionary/chart. Accessed 4 Aug. 2024." ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
@@ -2915,7 +2915,7 @@ cco:ont00000756 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Database"@en ;
                 skos:altLabel "Database"@en ;
-                skos:definition "An Information Bearing Artifact that is designed to bear some set of specific Information Content Entities and to be rapidly searchable and retrievable."@en ;
+                skos:definition "An Information Bearing Artifact that is designed to carry some set of specific Information Content Entities and to be rapidly searchable and retrievable."@en ;
                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Database&oldid=1057024641"^^xsd:anyURI ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
@@ -3346,7 +3346,7 @@ cco:ont00000874 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Video"@en ;
                 skos:altLabel "Video"@en ;
-                skos:definition "An Information Bearing Artifact that is designed to bear some specific Information Content Entity in the form of a sequence of representations that are presented sufficiently rapidly to create the appearance of motion and continuity."@en ;
+                skos:definition "An Information Bearing Artifact that is designed to carry some specific Information Content Entity in the form of a sequence of representations that are presented sufficiently rapidly to create the appearance of motion and continuity."@en ;
                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Video&oldid=1049376249"^^xsd:anyURI ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
@@ -3426,7 +3426,7 @@ cco:ont00000899 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a MSI Plessey Barcode"@en ;
                 skos:altLabel "MSI Plessey Barcode"@en ;
-                skos:definition "A One-Dimensional Barcode that consists of an indefinite number of numerical characters and is used for inventory control and marking storage containers and shelves in warehouse environments."@en ;
+                skos:definition "A Material Copy of a One-Dimensional Barcode that consists of an indefinite number of numerical characters and is used for inventory control and marking storage containers and shelves in warehouse environments."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -3544,7 +3544,7 @@ cco:ont00000931 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a UPC-A Barcode"@en ;
                 skos:altLabel "UPC-A Barcode"@en ;
-                skos:definition "A UPC Barcode that consists of 12 numerical digits."@en ;
+                skos:definition "A Material Copy of a UPC Barcode that consists of 12 numerical digits."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -3694,7 +3694,7 @@ cco:ont00000966 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a EAN Barcode"@en ;
                 skos:altLabel "EAN Barcode"@en ;
-                skos:definition "A One-Dimensional Barcode that consists of 8 or 13 numerical digits and is used to scan consumer goods."@en ;
+                skos:definition "A Material Copy of a One-Dimensional Barcode that consists of 8 or 13 numerical digits and is used to scan consumer goods."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -3716,7 +3716,7 @@ cco:ont00000972 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a EAN-13 Barcode"@en ;
                 skos:altLabel "EAN-13 Barcode"@en ;
-                skos:definition "An EAN Barcode that consists of 13 numerical digits and is used to designate products at the point of sale."@en ;
+                skos:definition "A Material Copy of an EAN Barcode that consists of 13 numerical digits and is used to designate products at the point of sale."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -3805,7 +3805,7 @@ cco:ont00001002 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Message"@en ;
                 skos:altLabel "Message"@en ;
-                skos:definition "An Information Bearing Artifact that is designed to bear some specific Information Content Entity that is relatively brief and to be transmitted from a sender to a recipient."@en ;
+                skos:definition "An Information Bearing Artifact that is designed to carry some specific Information Content Entity that is relatively brief and to be transmitted from a sender to a recipient."@en ;
                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Message&oldid=1060098631"^^xsd:anyURI ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
@@ -3874,7 +3874,7 @@ cco:ont00001012 rdf:type owl:Class ;
                 rdfs:comment "Further variants of GS1 DataBar have not been defined here."@en ;
                 rdfs:label "Material Copy of a GS1 DataBar Barcode"@en ;
                 skos:altLabel "GS1 DataBar Barcode"@en ;
-                skos:definition "A One-Dimensional Barcode that consists of 12-14 numerical digits and is used in retail and healthcare."@en ;
+                skos:definition "A Material Copy of a One-Dimensional Barcode that consists of 12-14 numerical digits and is used in retail and healthcare."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -4038,7 +4038,7 @@ cco:ont00001046 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Notification Message"@en ;
                 skos:altLabel "Notification Message"@en ;
-                skos:definition "A Message that is designed to bear an Information Content Entity that describes a scenario that has been determined to merit attention by the recipient."@en ;
+                skos:definition "A Material Copy of a Message that is designed to carry an Information Content Entity that describes a scenario that has been determined to merit attention by the recipient."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -4107,7 +4107,7 @@ cco:ont00001064 rdf:type owl:Class ;
                 rdfs:comment "For information on types of barcodes, see: https://www.scandit.com/types-barcodes-choosing-right-barcode/"@en ;
                 rdfs:label "Material Copy of a Barcode"@en ;
                 skos:altLabel "Barcode"@en ;
-                skos:definition "An Information Bearing Artifact that is designed to bear one or more geometric shapes that concretize some Directive Information Content Entity."@en ;
+                skos:definition "An Information Bearing Artifact that is designed to carry one or more geometric shapes that concretize some Directive Information Content Entity."@en ;
                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Barcode&oldid=1059844765"^^xsd:anyURI ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
@@ -4319,7 +4319,9 @@ cco:ont00001119 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Form Document"@en ;
                 skos:altLabel "Document Form"@en ;
-                skos:definition "A Document having Document Fields as parts in which to write or select prescribed content."@en ;
+                skos:definition "A Material Copy of a Document that has one or more Material Copy of a Document Field as parts in which to write or select prescribed content."@en ;
+                skos:example "A spreadsheet template" ,
+                             "A survey" ;
                 cco:ont00001754 "https://en.wikipedia.org/wiki/Form_(document)" ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
@@ -4371,7 +4373,7 @@ cco:ont00001131 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a EAN-8 Barcode"@en ;
                 skos:altLabel "EAN-8 Barcode"@en ;
-                skos:definition "An EAN Barcode that consists of 8 numerical digits and is used to designate products at the point of sale."@en ;
+                skos:definition "A Material Copy of an EAN Barcode that consists of 8 numerical digits and is used to designate products at the point of sale."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -4759,7 +4761,7 @@ cco:ont00001228 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Journal Article"@en ;
                 skos:altLabel "Journal Article"@en ;
-                skos:definition "An Information Bearing Artifact that is designed to bear a specific brief composition on a specific topic as part of a Journal Issue."@en ;
+                skos:definition "A Material Copy of a Document that is designed to carry a specific brief composition on a specific topic as part of a Journal Issue."@en ;
                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Academic_journal&oldid=1059723283"^^xsd:anyURI ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
@@ -4835,7 +4837,7 @@ cco:ont00001243 rdf:type owl:Class ;
                                   owl:someValuesFrom cco:ont00002038
                                 ] ;
                 rdfs:label "Material Copy of a Document Field"@en ;
-                skos:definition "An Information Bearing Entity that is a part of some document into which bearers of prescribed information can be written or selected."@en ;
+                skos:definition "An Information Bearing Entity that is a part of some document into which carriers of prescribed information can be written or selected."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -4848,7 +4850,7 @@ cco:ont00001245 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a PDF417 Code"@en ;
                 skos:altLabel "PDF417 Code"@en ;
-                skos:definition "A Two-Dimensional Barcode that is used in applications that require the storage of huge amounts of data."@en ;
+                skos:definition "A Material Copy of a Two-Dimensional Barcode that is used in applications that require the storage of huge amounts of data."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -4933,7 +4935,7 @@ cco:ont00001260 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Code 39 Barcode"@en ;
                 skos:altLabel "Code 39 Barcode"@en ;
-                skos:definition "A One-Dimensional Barcode that consists of 39 characters that are numbers 0-9, capital letters A-Z, or the symbols -.$/+% and space and is used primarily in automotive and defense industries."@en ;
+                skos:definition "A Material Copy of a One-Dimensional Barcode that consists of 39 characters that are numbers 0-9, capital letters A-Z, or the symbols -.$/+% and space and is used primarily in automotive and defense industries."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -4946,7 +4948,7 @@ cco:ont00001264 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Code 128 Barcode"@en ;
                 skos:altLabel "Code 128 Barcode"@en ;
-                skos:definition "A One-Dimensional Barcode that consists of up to 128 ASCII characters and is used primarily in supply chains."@en ;
+                skos:definition "A Material Copy of a One-Dimensional Barcode that consists of up to 128 ASCII characters and is used primarily in supply chains."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -4969,7 +4971,7 @@ cco:ont00001268 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a ISBN Barcode"@en ;
                 skos:altLabel "ISBN Barcode"@en ;
-                skos:definition "An EAN Barcode that is used to designate books."@en ;
+                skos:definition "A Material Copy of an EAN Barcode that is used to designate books."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
@@ -5064,7 +5066,7 @@ cco:ont00001298 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a Document"@en ;
                 skos:altLabel "Document"@en ;
-                skos:definition "An Information Bearing Artifact that is designed to bear some specific Information Content Entity in a series of paragraphs of text or diagrams in the form of physical pieces of paper or an electronic word processor file."@en ;
+                skos:definition "An Information Bearing Artifact that is designed to carry some specific Information Content Entity in a series of paragraphs of text or diagrams in the form of physical pieces of paper or an electronic word processor file."@en ;
                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Document&oldid=1057829688"^^xsd:anyURI ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
@@ -5383,7 +5385,7 @@ cco:ont00002049 rdf:type owl:Class ;
                                 ] ;
                 rdfs:label "Material Copy of a UPC-E Barcode"@en ;
                 skos:altLabel "UPC-E Barcode"@en ;
-                skos:definition "A UPC Barcode that consists of 6 numerical digits."@en ;
+                skos:definition "A Material Copy of a UPC Barcode that consists of 6 numerical digits."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 

--- a/src/cco-modules/ArtifactOntology.ttl
+++ b/src/cco-modules/ArtifactOntology.ttl
@@ -1,23 +1,23 @@
 @prefix : <https://www.commoncoreontologies.org/ArtifactOntology#> .
+@prefix cco: <https://www.commoncoreontologies.org/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix cco: <https://www.commoncoreontologies.org/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@base <https://www.commoncoreontologies.org/ArtifactOntology> .
+@base <https://www.commoncoreontologies.org/ArtifactOntology#> .
 
 <https://www.commoncoreontologies.org/ArtifactOntology> rdf:type owl:Ontology ;
-                                                                               owl:versionIRI <https://www.commoncoreontologies.org/2024-11-06/ArtifactOntology> ;
-                                                                               owl:imports <https://www.commoncoreontologies.org/InformationEntityOntology> ;
-                                                                               dcterms:license "BSD 3-Clause: https://github.com/CommonCoreOntology/CommonCoreOntologies/blob/master/LICENSE"@en ;
-                                                                               dcterms:rights "CUBRC Inc., see full license."@en ;
-                                                                               rdfs:comment "This ontology is designed to represent artifacts that are common to multiple domains along with their models, specifications, and functions."@en ;
-                                                                               rdfs:label "Artifact Ontology"@en ;
-                                                                               owl:versionInfo "Version 2.0"@en .
+                                                         owl:versionIRI <https://www.commoncoreontologies.org/2024-11-06/ArtifactOntology> ;
+                                                         owl:imports cco:InformationEntityOntology ;
+                                                         dcterms:license "BSD 3-Clause: https://github.com/CommonCoreOntology/CommonCoreOntologies/blob/master/LICENSE"@en ;
+                                                         dcterms:rights "CUBRC Inc., see full license."@en ;
+                                                         rdfs:comment "This ontology is designed to represent artifacts that are common to multiple domains along with their models, specifications, and functions."@en ;
+                                                         rdfs:label "Artifact Ontology"@en ;
+                                                         owl:versionInfo "Version 2.0"@en .
 
 #################################################################
 #    Annotation properties
@@ -65,605 +65,621 @@ cco:ont00001944 rdf:type owl:ObjectProperty .
 
 ###  https://www.commoncoreontologies.org/ont00000001
 cco:ont00000001 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000804 ;
-                 rdfs:label "Deflecting Prism"@en ;
-                 skos:definition "A Prism designed to deflect a beam of light entering the Prism by a fixed angle."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000804 ;
+                rdfs:label "Deflecting Prism"@en ;
+                skos:definition "A Prism designed to deflect a beam of light entering the Prism by a fixed angle."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000002
 cco:ont00000002 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Cooling Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in a process in which the thermal energy of a system decreases."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Cooling Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in a process in which the thermal energy of a system decreases."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000012
 cco:ont00000012 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000781 ;
-                 rdfs:label "Propulsion Control System"@en ;
-                 skos:definition "A Control System that consists of control devices, displays, indicators, or modules designed to control a Propulsion System."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000781 ;
+                rdfs:label "Propulsion Control System"@en ;
+                skos:definition "A Control System that consists of control devices, displays, indicators, or modules designed to control a Propulsion System."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000014
 cco:ont00000014 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000241 ;
-                 rdfs:label "Aztec Code"@en ;
-                 skos:definition "A Two-Dimensional Barcode that is used by the transportation industry to scan tickets."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000241 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002016
+                                ] ;
+                rdfs:label "Material Copy of a Aztec Code"@en ;
+                skos:altLabel "Aztec Code"@en ;
+                skos:definition "A Two-Dimensional Barcode that is used by the transportation industry to scan tickets."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000015
 cco:ont00000015 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001104 ;
-                 rdfs:label "Shotgun"@en ;
-                 skos:definition "A Long Gun that fires packets of shot, a single slug, a sabot, or a specialty round (such as tear gas, bolo shell, or a breaching round) over shorter ranges than that of Rifles and with less accuracy."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Shotgun&oldid=1062571691"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001104 ;
+                rdfs:label "Shotgun"@en ;
+                skos:definition "A Long Gun that fires packets of shot, a single slug, a sabot, or a specialty round (such as tear gas, bolo shell, or a breaching round) over shorter ranges than that of Rifles and with less accuracy."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Shotgun&oldid=1062571691"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000018
 cco:ont00000018 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001346 ;
-                 rdfs:label "Title Document"@en ;
-                 skos:definition "A Legal Instrument that is designed as evidence of ownership."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Title_(property)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001346 ;
+                rdfs:label "Title Document"@en ;
+                skos:definition "A Legal Instrument that is designed as evidence of ownership."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Title_(property)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000019
 cco:ont00000019 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000961 ;
-                 rdfs:label "Power Inverting Artifact Function"@en ;
-                 skos:definition "A Current Conversion Artifact Function that is realized by processes in which some Artifact is used to convert direct current (DC) to alternating current (AC)."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000961 ;
+                rdfs:label "Power Inverting Artifact Function"@en ;
+                skos:definition "A Current Conversion Artifact Function that is realized by processes in which some Artifact is used to convert direct current (DC) to alternating current (AC)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000020
 cco:ont00000020 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Container"@en ;
-                 skos:definition "A Material Artifact that is designed to contain (wholly or partially) some material entity."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Container"@en ;
+                skos:definition "A Material Artifact that is designed to contain (wholly or partially) some material entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000021
 cco:ont00000021 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Sensor Platform"@en ;
-                 skos:definition "A Material Artifact that is designed to support, and in some cases transport, a Sensor during its deployment and functioning."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Sensor Platform"@en ;
+                skos:definition "A Material Artifact that is designed to support, and in some cases transport, a Sensor during its deployment and functioning."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000022
 cco:ont00000022 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000422 ;
-                 rdfs:label "Radio Communication Reception Artifact Function"@en ;
-                 skos:definition "A Communication Reception Artifact Function that is realized during events in which an Artifact receives information transmitted from another Artifact, where the transmission of information occurs using radio waves."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000422 ;
+                rdfs:label "Radio Communication Reception Artifact Function"@en ;
+                skos:definition "A Communication Reception Artifact Function that is realized during events in which an Artifact receives information transmitted from another Artifact, where the transmission of information occurs using radio waves."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000023
 cco:ont00000023 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Sensor Deployment Artifact Function"@en ;
-                 skos:definition "An Artifact Function that inheres in Artifacts that are designed to support or convey one or more Sensors while the Sensors are realizing their own Artifact Functions."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Sensor Deployment Artifact Function"@en ;
+                skos:definition "An Artifact Function that inheres in Artifacts that are designed to support or convey one or more Sensors while the Sensors are realizing their own Artifact Functions."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000025
 cco:ont00000025 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001278 ;
-                 rdfs:label "Electronic Stock"@en ;
-                 skos:definition "Stock that consists of Bytes."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001278 ;
+                rdfs:label "Electronic Stock"@en ;
+                skos:definition "Stock that consists of Bytes."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000028
 cco:ont00000028 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000804 ;
-                 rdfs:label "Dispersive Prism"@en ;
-                 skos:definition "A Prism designed to break up a beam of light entering the Prism into its constituent spectral colors by leveraging the refractive index of light based on its Frequency."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000804 ;
+                rdfs:label "Dispersive Prism"@en ;
+                skos:definition "A Prism designed to break up a beam of light entering the Prism into its constituent spectral colors by leveraging the refractive index of light based on its Frequency."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000030
 cco:ont00000030 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000288 ;
-                 rdfs:label "Nuclear Reactor"@en ;
-                 skos:definition "A Power Source that is designed to initiate and control a self-sustained nuclear chain reaction to produce power in the form of heat, which can be transferred to a working fluid for further conversion to mechanical or electrical energy."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Nuclear_reactor&oldid=1063370273"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000288 ;
+                rdfs:label "Nuclear Reactor"@en ;
+                skos:definition "A Power Source that is designed to initiate and control a self-sustained nuclear chain reaction to produce power in the form of heat, which can be transferred to a working fluid for further conversion to mechanical or electrical energy."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Nuclear_reactor&oldid=1063370273"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000034
 cco:ont00000034 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000448 ;
-                 rdfs:label "Conveyance Artifact Function"@en ;
-                 skos:definition "A Motion Artifact Function that is realized in a process in which the bearer of the function conveys entities from one location to another."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Vehicle&oldid=1063682179"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000448 ;
+                rdfs:label "Conveyance Artifact Function"@en ;
+                skos:definition "A Motion Artifact Function that is realized in a process in which the bearer of the function conveys entities from one location to another."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Vehicle&oldid=1063682179"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000036
 cco:ont00000036 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001301 ;
-                 rdfs:label "Waste Management Artifact Function"@en ;
-                 skos:definition "A Service Artifact Function that is realized in processes of collecting, transporting, processing, recycling, monitoring, or disposing of waste materials."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Waste_management&oldid=1062844209"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001301 ;
+                rdfs:label "Waste Management Artifact Function"@en ;
+                skos:definition "A Service Artifact Function that is realized in processes of collecting, transporting, processing, recycling, monitoring, or disposing of waste materials."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Waste_management&oldid=1062844209"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000038
 cco:ont00000038 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000023 ;
-                 rdfs:label "System Role"@en ;
-                 skos:definition "A Role that inheres in an entity in virtue of its parts or elements being arranged in such a way that they together exhibit behavior or meaning that they do not exhibit individually."@en ;
-                 cco:ont00001754 "https://www.incose.org/about-systems-engineering/system-and-se-definition/general-system-definition"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000023 ;
+                rdfs:label "System Role"@en ;
+                skos:definition "A Role that inheres in an entity in virtue of its parts or elements being arranged in such a way that they together exhibit behavior or meaning that they do not exhibit individually."@en ;
+                cco:ont00001754 "https://www.incose.org/about-systems-engineering/system-and-se-definition/general-system-definition"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000039
 cco:ont00000039 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000838 ;
-                 rdfs:label "Portion of Solid Fuel"@en ;
-                 skos:definition "A Portion of Fuel that is stored in a solid state."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000838 ;
+                rdfs:label "Portion of Solid Fuel"@en ;
+                skos:definition "A Portion of Fuel that is stored in a solid state."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000043
 cco:ont00000043 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000593 ;
-                 rdfs:label "Portion of Solid Propellant"@en ;
-                 skos:definition "A Portion of Propellant that is stored in a solid state."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000593 ;
+                rdfs:label "Portion of Solid Propellant"@en ;
+                skos:definition "A Portion of Propellant that is stored in a solid state."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000047
 cco:ont00000047 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000598 ;
-                 rdfs:comment "Flow Control Valves are often more complex than a simple Valve and typically include an Actuator that is capable of automatically adjusting the state of the valve in response to signals from a connected Sensor or Controller."@en ;
-                 rdfs:label "Flow Control Valve"@en ;
-                 skos:definition "A Valve that is designed to regulate the flow or Pressure of a fluid."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Flow_control_valve&oldid=1013438085"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000598 ;
+                rdfs:comment "Flow Control Valves are often more complex than a simple Valve and typically include an Actuator that is capable of automatically adjusting the state of the valve in response to signals from a connected Sensor or Controller."@en ;
+                rdfs:label "Flow Control Valve"@en ;
+                skos:definition "A Valve that is designed to regulate the flow or Pressure of a fluid."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Flow_control_valve&oldid=1013438085"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000048
 cco:ont00000048 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000499 ;
-                 rdfs:label "Random Wire Antenna"@en ;
-                 skos:definition "A Wire Antenna that consists of a long wire suspended above the ground with a length that does not bear a relation to the wavelength of the radio waves used and which is typically used as a receiving antenna on the long, medium, and short wave bands."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Random_wire_antenna&oldid=1058546356"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000499 ;
+                rdfs:label "Random Wire Antenna"@en ;
+                skos:definition "A Wire Antenna that consists of a long wire suspended above the ground with a length that does not bear a relation to the wavelength of the radio waves used and which is typically used as a receiving antenna on the long, medium, and short wave bands."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Random_wire_antenna&oldid=1058546356"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000049
 cco:ont00000049 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000475 ;
-                 rdfs:label "Banknote"@en ;
-                 skos:definition "A Portion of Cash that consists of a portable slips of paper or fabric designed to bear some specified Financial Value."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000475 ;
+                rdfs:label "Banknote"@en ;
+                skos:definition "A Portion of Cash that consists of a portable slips of paper or fabric designed to bear some specified Financial Value."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000050
 cco:ont00000050 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000903 ;
-                 rdfs:label "Very High Frequency Communication Instrument"@en ;
-                 skos:definition "A Radio Communication Instrument that is designed to participate in some process that has process part some Very High Frequency."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000903 ;
+                rdfs:label "Very High Frequency Communication Instrument"@en ;
+                skos:definition "A Radio Communication Instrument that is designed to participate in some process that has process part some Very High Frequency."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000053
 cco:ont00000053 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000618 ;
-                 rdfs:label "Ground Motor Vehicle"@en ;
-                 skos:definition "A Ground Vehicle that is designed to receive its motive power from an Engine and is not designed to travel on rails."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Motor_vehicle&oldid=1063627395"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000618 ;
+                rdfs:label "Ground Motor Vehicle"@en ;
+                skos:definition "A Ground Vehicle that is designed to receive its motive power from an Engine and is not designed to travel on rails."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Motor_vehicle&oldid=1063627395"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000054
 cco:ont00000054 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000431 ;
-                 rdfs:label "Stirling Engine"@en ;
-                 skos:definition "An External Combusion Engine that is designed to compress and expand some working fluid at different temperatures, such that there is a net conversion of heat energy to mechanical work."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Stirling_engine&oldid=1061164490"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000431 ;
+                rdfs:label "Stirling Engine"@en ;
+                skos:definition "An External Combusion Engine that is designed to compress and expand some working fluid at different temperatures, such that there is a net conversion of heat energy to mechanical work."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Stirling_engine&oldid=1061164490"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000056
 cco:ont00000056 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000210 ;
-                 rdfs:label "Reaction Engine"@en ;
-                 skos:altLabel "Reaction Motor"@en ;
-                 skos:definition "An Engine that provides propulsion by expelling Reaction Mass."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Reaction_engine&oldid=1046981784"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000210 ;
+                rdfs:label "Reaction Engine"@en ;
+                skos:altLabel "Reaction Motor"@en ;
+                skos:definition "An Engine that provides propulsion by expelling Reaction Mass."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Reaction_engine&oldid=1046981784"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000057
 cco:ont00000057 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000907 ;
-                 rdfs:label "Mobile Telephone"@en ;
-                 skos:definition "A Telephone that is connected to a Telephone Network by radio waves."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Mobile_phone&oldid=1061800841"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000907 ;
+                rdfs:label "Mobile Telephone"@en ;
+                skos:definition "A Telephone that is connected to a Telephone Network by radio waves."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Mobile_phone&oldid=1061800841"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000059
 cco:ont00000059 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000825 ;
-                 rdfs:label "Telephone Line"@en ;
-                 skos:altLabel "Telephone Circuit"@en ;
-                 skos:definition "A Telecommunication Network Line that consists of a physical wire or other signaling medium that is designed to be part of a Telephone Network."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telephone_line&oldid=1063429738"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000825 ;
+                rdfs:label "Telephone Line"@en ;
+                skos:altLabel "Telephone Circuit"@en ;
+                skos:definition "A Telecommunication Network Line that consists of a physical wire or other signaling medium that is designed to be part of a Telephone Network."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telephone_line&oldid=1063429738"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000062
 cco:ont00000062 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001100 ;
-                 rdfs:label "Frequency Measurement Artifact Function"@en ;
-                 skos:definition "A Measurement Artifact Function that is realized during events in which an Artifact is used to measure the Frequency of a specified object or class of objects."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001100 ;
+                rdfs:label "Frequency Measurement Artifact Function"@en ;
+                skos:definition "A Measurement Artifact Function that is realized during events in which an Artifact is used to measure the Frequency of a specified object or class of objects."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000064
 cco:ont00000064 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000798 ;
-                 rdfs:label "Book"@en ;
-                 skos:definition "An Information Bearing Artifact that is designed to bear some specific Information Content Entity by means of ink, paper, parchment, or other materials fastened together to hinge at one side."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Book&oldid=1063132471"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001298 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002040
+                                ] ;
+                rdfs:label "Material Copy of a Book"@en ;
+                skos:altLabel "Book"@en ;
+                skos:definition "An Information Bearing Artifact that is designed to bear some specific Information Content Entity by means of ink, paper, parchment, or other materials fastened together to hinge at one side."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Book&oldid=1063132471"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000066
 cco:ont00000066 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001301 ;
-                 rdfs:label "Military Artifact Function"@en ;
-                 skos:definition "A Service Artifact Function that is realized in processes related to the armed services."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Military&oldid=1063431234"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001301 ;
+                rdfs:label "Military Artifact Function"@en ;
+                skos:definition "A Service Artifact Function that is realized in processes related to the armed services."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Military&oldid=1063431234"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000069
 cco:ont00000069 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001298 ;
-                 rdfs:label "Transcript"@en ;
-                 skos:definition "A Document that is designed to bear some specific Information Content Entity that was originally recorded in a different medium."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Transcript&oldid=1038510063"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001298 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002041
+                                ] ;
+                rdfs:label "Material Copy of a Transcript"@en ;
+                skos:altLabel "Transcript"@en ;
+                skos:definition "A Document that is designed to bear some specific Information Content Entity that was originally recorded in a different medium."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Transcript&oldid=1038510063"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000075
 cco:ont00000075 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000304 ;
-                 rdfs:label "Optical Microscope"@en ;
-                 skos:altLabel "Light Microscope"@en ;
-                 skos:definition "A Microscope that is designed to use visible light and a system of Optical Lenses to produce a significantly enlarged image of the Object."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Optical_microscope&oldid=1063131242"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000304 ;
+                rdfs:label "Optical Microscope"@en ;
+                skos:altLabel "Light Microscope"@en ;
+                skos:definition "A Microscope that is designed to use visible light and a system of Optical Lenses to produce a significantly enlarged image of the Object."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Optical_microscope&oldid=1063131242"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000076
 cco:ont00000076 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000727 ;
-                 rdfs:label "Wired Communication Artifact Function"@en ;
-                 skos:definition "A Communication Artifact Function that is realized in a process that conveys meaningful signs by means of a (usually cylindrical) flexible strand or rod of metal."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telecommunications&oldid=1061143810"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000727 ;
+                rdfs:label "Wired Communication Artifact Function"@en ;
+                skos:definition "A Communication Artifact Function that is realized in a process that conveys meaningful signs by means of a (usually cylindrical) flexible strand or rod of metal."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telecommunications&oldid=1061143810"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000081
 cco:ont00000081 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000445 ;
-                 rdfs:label "Cutting Weapon"@en ;
-                 skos:definition "A Weapon that is designed to inflict harm, damage, or incapacity by means of separating some portion of its target into two or more portions through the application of acutely directed force."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Cutting&oldid=1058846915"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000445 ;
+                rdfs:label "Cutting Weapon"@en ;
+                skos:definition "A Weapon that is designed to inflict harm, damage, or incapacity by means of separating some portion of its target into two or more portions through the application of acutely directed force."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Cutting&oldid=1058846915"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000086
 cco:ont00000086 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000723 ;
-                 rdfs:label "Autopilot System"@en ;
-                 skos:altLabel "Autopilot"@en ;
-                 skos:definition "A Vehicle Control System that is designed to enable some Agent to control the trajectory of a Vehicle without constant 'hands-on' control."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Autopilot&oldid=1063382206"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000723 ;
+                rdfs:label "Autopilot System"@en ;
+                skos:altLabel "Autopilot"@en ;
+                skos:definition "A Vehicle Control System that is designed to enable some Agent to control the trajectory of a Vehicle without constant 'hands-on' control."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Autopilot&oldid=1063382206"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000088
 cco:ont00000088 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001051 ;
-                 rdfs:label "Firearm"@en ;
-                 skos:definition "A Projectile Launcher that is designed to launch Bullets or Cartridges."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Firearm&oldid=1061216363"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001051 ;
+                rdfs:label "Firearm"@en ;
+                skos:definition "A Projectile Launcher that is designed to launch Bullets or Cartridges."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Firearm&oldid=1061216363"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000090
 cco:ont00000090 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000547 ;
-                 rdfs:label "Infrared Telescope"@en ;
-                 skos:definition "A Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing infrared light to form an enhanced image of the Object."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Infrared_telescope&oldid=1062918090"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000547 ;
+                rdfs:label "Infrared Telescope"@en ;
+                skos:definition "A Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing infrared light to form an enhanced image of the Object."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Infrared_telescope&oldid=1062918090"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000091
 cco:ont00000091 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000457 ;
-                 rdfs:label "Portion of Coolant"@en ;
-                 skos:definition "A Portion of Material that is designed to be used in a thermal control system to reduce or maintain the temperature of an object to or at a specified level."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000457 ;
+                rdfs:label "Portion of Coolant"@en ;
+                skos:definition "A Portion of Material that is designed to be used in a thermal control system to reduce or maintain the temperature of an object to or at a specified level."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000092
 cco:ont00000092 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000736 ;
-                 rdfs:label "Bidirectional Transducer"@en ;
-                 skos:definition "A Transducer that is designed to receive a signal in the form of physical phenomena and convert it into an electrical signal, and vice versa."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Transducer&oldid=1053290948"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000736 ;
+                rdfs:label "Bidirectional Transducer"@en ;
+                skos:definition "A Transducer that is designed to receive a signal in the form of physical phenomena and convert it into an electrical signal, and vice versa."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Transducer&oldid=1053290948"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000093
 cco:ont00000093 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001278 ;
-                 rdfs:label "Preferred Stock"@en ;
-                 skos:definition "Stock that entitles its holder to receive a certain level of dividend payments before any dividends can be issued to other holders."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001278 ;
+                rdfs:label "Preferred Stock"@en ;
+                skos:definition "Stock that entitles its holder to receive a certain level of dividend payments before any dividends can be issued to other holders."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000095
 cco:ont00000095 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Control Surface"@en ;
-                 skos:definition "A Material Artifact that is designed to deflect air, water, or another medium around its surface in order to change the Attitude of a Vehicle by rotating the Vehicle on one or more of its Axes of Rotation."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Flight_control_surfaces&oldid=1019271264"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Control Surface"@en ;
+                skos:definition "A Material Artifact that is designed to deflect air, water, or another medium around its surface in order to change the Attitude of a Vehicle by rotating the Vehicle on one or more of its Axes of Rotation."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Flight_control_surfaces&oldid=1019271264"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000096
 cco:ont00000096 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Propulsion System"@en ;
-                 skos:definition "A Material Artifact that is designed to facilitate the movement of material entities from one location to another and which consists of a source of mechanical power and a means of converting this power into propulsive force to generate the movement."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Propulsion&oldid=1022034059"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Propulsion System"@en ;
+                skos:definition "A Material Artifact that is designed to facilitate the movement of material entities from one location to another and which consists of a source of mechanical power and a means of converting this power into propulsive force to generate the movement."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Propulsion&oldid=1022034059"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000097
 cco:ont00000097 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001207 ;
-                 rdfs:label "Complex Optical Lens"@en ;
-                 skos:altLabel "Lens System"@en ;
-                 skos:definition "An Optical Lens consisting of more than one Simple Optical Lenses."@en ;
-                 cco:ont00001754 "Hecht, Eugene (1987). Optics (2nd ed.). Addison Wesley. ISBN 978-0-201-11609-0. Chapters 5 & 6."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001207 ;
+                rdfs:label "Complex Optical Lens"@en ;
+                skos:altLabel "Lens System"@en ;
+                skos:definition "An Optical Lens consisting of more than one Simple Optical Lenses."@en ;
+                cco:ont00001754 "Hecht, Eugene (1987). Optics (2nd ed.). Addison Wesley. ISBN 978-0-201-11609-0. Chapters 5 & 6."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000098
 cco:ont00000098 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Electrical Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized during events in which an Artifact is used to perform a process involving electrical power."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Electrical Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized during events in which an Artifact is used to perform a process involving electrical power."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000101
 cco:ont00000101 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000255 ;
-                 rdfs:label "Portion of Liquid Oxygen"@en ;
-                 skos:definition "A Portion of Cryogenic Material that is composed (almost) entirely of liquid oxygen."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000255 ;
+                rdfs:label "Portion of Liquid Oxygen"@en ;
+                skos:definition "A Portion of Cryogenic Material that is composed (almost) entirely of liquid oxygen."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000103
 cco:ont00000103 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Vehicle Compartment"@en ;
-                 skos:altLabel "Compartment"@en ;
-                 skos:definition "A Material Artifact that is designed to partition a Vehicle into subdivisions for various purposes."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Vehicle Compartment"@en ;
+                skos:altLabel "Compartment"@en ;
+                skos:definition "A Material Artifact that is designed to partition a Vehicle into subdivisions for various purposes."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000111
 cco:ont00000111 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000256 ;
-                 rdfs:label "Air Inlet"@en ;
-                 skos:altLabel "Air Intake"@en ;
-                 skos:definition "A Fluid Control Artifact that consists of an opening that is designed to capture and direct the flow of air into the system it is part of."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000256 ;
+                rdfs:label "Air Inlet"@en ;
+                skos:altLabel "Air Intake"@en ;
+                skos:definition "A Fluid Control Artifact that consists of an opening that is designed to capture and direct the flow of air into the system it is part of."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000113
 cco:ont00000113 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Ventilation Control Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in processes in which some Artifact is used to control the quality of air in some space."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Ventilation Control Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in processes in which some Artifact is used to control the quality of air in some space."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000116
 cco:ont00000116 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000256 ;
-                 rdfs:label "Pump"@en ;
-                 skos:definition "A Fluid Control Artifact that is designed to impart motion to a portion of fluid to transport it within a system through the use of mechanical action."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000256 ;
+                rdfs:label "Pump"@en ;
+                skos:definition "A Fluid Control Artifact that is designed to impart motion to a portion of fluid to transport it within a system through the use of mechanical action."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000117
 cco:ont00000117 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Information Processing Artifact"@en ;
-                 skos:definition "A Material Artifact that is designed to use algorithms to transform some Information Content Entity into another Information Content Entity."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Information Processing Artifact"@en ;
+                skos:definition "A Material Artifact that is designed to use algorithms to transform some Information Content Entity into another Information Content Entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000118
 cco:ont00000118 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00000965
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001942 ;
-                                                              owl:someValuesFrom cco:ont00000323
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00000965 ;
-                 rdfs:label "Artifact Function Specification"@en ;
-                 skos:definition "A Directive Information Content Entity that prescribes some Artifact Function and which is part of some Artifact Model."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000965
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001942 ;
+                                                             owl:someValuesFrom cco:ont00000323
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000965 ;
+                rdfs:label "Artifact Function Specification"@en ;
+                skos:definition "A Directive Information Content Entity that prescribes some Artifact Function and which is part of some Artifact Model."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000122
 cco:ont00000122 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000170 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001944 ;
-                                   owl:someValuesFrom cco:ont00000904
-                                 ] ;
-                 rdfs:label "Vehicle Track Point"@en ;
-                 skos:definition "An Object Track Point that is where a Vehicle is or was located during some motion."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000170 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty cco:ont00001944 ;
+                                  owl:someValuesFrom cco:ont00000904
+                                ] ;
+                rdfs:label "Vehicle Track Point"@en ;
+                skos:definition "An Object Track Point that is where a Vehicle is or was located during some motion."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000128
 cco:ont00000128 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000255 ;
-                 rdfs:label "Portion of Liquid Hydrogen"@en ;
-                 skos:definition "A Portion of Cryogenic Material that is composed (almost) entirely of liquid hydrogen."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000255 ;
+                rdfs:label "Portion of Liquid Hydrogen"@en ;
+                skos:definition "A Portion of Cryogenic Material that is composed (almost) entirely of liquid hydrogen."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000130
 cco:ont00000130 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Power Transformer"@en ;
-                 skos:definition "A Material Artifact that is designed to transfer electrical energy between two or more circuits through electromagnetic induction."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Transformer&oldid=1062163369"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Power Transformer"@en ;
+                skos:definition "A Material Artifact that is designed to transfer electrical energy between two or more circuits through electromagnetic induction."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Transformer&oldid=1062163369"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000132
 cco:ont00000132 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000117 ;
-                 rdfs:label "Recording Device"@en ;
-                 skos:definition "An Information Processing Artifact that is designed to capture some information and store it in some recording format on some storage medium."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Record&oldid=1062776450"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000117 ;
+                rdfs:label "Recording Device"@en ;
+                skos:definition "An Information Processing Artifact that is designed to capture some information and store it in some recording format on some storage medium."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Record&oldid=1062776450"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000136
 cco:ont00000136 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:comment "Optical Instruments are typically constructed for the purpose of being used to aid in vision or the analysis of light."@en ;
-                 rdfs:label "Optical Instrument"@en ;
-                 skos:definition "A Material Artifact that is designed to process light waves."@en ;
-                 skos:scopeNote "Light waves can be processed in a variety of ways including via reflection, refraction, diffraction, deflection, focusing, collimation, dispersion, and interference."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Optical_instrument&oldid=1061981216"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:comment "Optical Instruments are typically constructed for the purpose of being used to aid in vision or the analysis of light."@en ;
+                rdfs:label "Optical Instrument"@en ;
+                skos:definition "A Material Artifact that is designed to process light waves."@en ;
+                skos:scopeNote "Light waves can be processed in a variety of ways including via reflection, refraction, diffraction, deflection, focusing, collimation, dispersion, and interference."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Optical_instrument&oldid=1061981216"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000143
 cco:ont00000143 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000103 ;
-                 rdfs:label "Cargo Cabin"@en ;
-                 skos:definition "A Vehicle Compartment that is used to store goods or materials during transportation."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000103 ;
+                rdfs:label "Cargo Cabin"@en ;
+                skos:definition "A Vehicle Compartment that is used to store goods or materials during transportation."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000145
 cco:ont00000145 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000445 ;
-                 rdfs:label "Incendiary Weapon"@en ;
-                 skos:definition "A Weapon that is designed to inflict harm, damage, or incapacity by means of starting a fire."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Incendiary_device&oldid=1055642422"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000445 ;
+                rdfs:label "Incendiary Weapon"@en ;
+                skos:definition "A Weapon that is designed to inflict harm, damage, or incapacity by means of starting a fire."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Incendiary_device&oldid=1055642422"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000147
 cco:ont00000147 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000325 ;
-                 rdfs:label "Flight Transponder"@en ;
-                 skos:definition "A Radio Transponder that is designed to produce a specified response (typically for identification, location, or status update purposes) when it receives a radio-frequency interrogation."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Transponder_(aeronautics)&oldid=1052688836"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000325 ;
+                rdfs:label "Flight Transponder"@en ;
+                skos:definition "A Radio Transponder that is designed to produce a specified response (typically for identification, location, or status update purposes) when it receives a radio-frequency interrogation."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Transponder_(aeronautics)&oldid=1052688836"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000152
 cco:ont00000152 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000998 ;
-                 rdfs:label "Telephone Network"@en ;
-                 skos:definition "A Telecommunication Network that is designed to allow telephone calls to be made between two or more parties connected to the network."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telephone_network&oldid=1046265527"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000998 ;
+                rdfs:label "Telephone Network"@en ;
+                skos:definition "A Telecommunication Network that is designed to allow telephone calls to be made between two or more parties connected to the network."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telephone_network&oldid=1046265527"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000153
 cco:ont00000153 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000781 ;
-                 rdfs:label "Generator Control Unit"@en ;
-                 skos:definition "A Control System that is designed to regulate the voltage of some Electrical Power Source."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000781 ;
+                rdfs:label "Generator Control Unit"@en ;
+                skos:definition "A Control System that is designed to regulate the voltage of some Electrical Power Source."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000156
 cco:ont00000156 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000088 ;
-                 rdfs:label "Hand Gun"@en ;
-                 skos:definition "A Firearm that is designed to have a relatively short barrel and to be held in one or two hands and to be fired without being braced against the shoulder."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Handgun&oldid=1060570395"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000088 ;
+                rdfs:label "Hand Gun"@en ;
+                skos:definition "A Firearm that is designed to have a relatively short barrel and to be held in one or two hands and to be fired without being braced against the shoulder."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Handgun&oldid=1060570395"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000158
 cco:ont00000158 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001105 ;
-                 rdfs:label "Lithium-ion Electric Battery"@en ;
-                 skos:definition "A Secondary Cell Electric Battery that produces electricity when lithium ions move from anode to cathode."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Lithium-ion_battery&oldid=1064099588"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001105 ;
+                rdfs:label "Lithium-ion Electric Battery"@en ;
+                skos:definition "A Secondary Cell Electric Battery that produces electricity when lithium ions move from anode to cathode."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Lithium-ion_battery&oldid=1064099588"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000159
 cco:ont00000159 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000798 ;
-                 rdfs:label "Timekeeping Instrument"@en ;
-                 skos:definition "An Information Bearing Artifact that is designed to bear some specific Information Content Entity that is about some temporal region."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Timekeeper&oldid=1061681902"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000798 ;
+                rdfs:label "Material Copy of a Timekeeping Instrument"@en ;
+                skos:altLabel "Timekeeping Instrument"@en ;
+                skos:definition "An Information Bearing Artifact that is designed to bear some specific Information Content Entity that is about some temporal region."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Timekeeper&oldid=1061681902"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000160
 cco:ont00000160 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000581 ;
-                 rdfs:label "Manual Tool"@en ;
-                 skos:altLabel "Hand Tool"@en ;
-                 skos:definition "A Tool that is designed to be powered by manual labor rather than by an engine."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Hand_tool&oldid=1060741381"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000581 ;
+                rdfs:label "Manual Tool"@en ;
+                skos:altLabel "Hand Tool"@en ;
+                skos:definition "A Tool that is designed to be powered by manual labor rather than by an engine."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Hand_tool&oldid=1060741381"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000162
 cco:ont00000162 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000795 ;
-                 rdfs:label "Electrical Connector Artifact Function"@en ;
-                 skos:definition "An Electrical Conduction Artifact Function that is realized by processes in which some Artifact is used to join electrical terminations to create an electrical circuit."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000795 ;
+                rdfs:label "Electrical Connector Artifact Function"@en ;
+                skos:definition "An Electrical Conduction Artifact Function that is realized by processes in which some Artifact is used to join electrical terminations to create an electrical circuit."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000167
 cco:ont00000167 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001173 ;
-                 rdfs:label "Large-Scale Rocket Launcher"@en ;
-                 skos:definition "A Rocket Launcher that is designed to contain multiple Rocket Launchers."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001173 ;
+                rdfs:label "Large-Scale Rocket Launcher"@en ;
+                skos:definition "A Rocket Launcher that is designed to contain multiple Rocket Launchers."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000170
@@ -672,102 +688,107 @@ cco:ont00000170 rdf:type owl:Class .
 
 ###  https://www.commoncoreontologies.org/ont00000171
 cco:ont00000171 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000344 ;
-                 rdfs:label "Detergent Artifact Function"@en ;
-                 skos:definition "A Surfactant Artifact Function that is realized in a process that cleans substances in dilute solutions."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Detergent&oldid=1064079329"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000344 ;
+                rdfs:label "Detergent Artifact Function"@en ;
+                skos:definition "A Surfactant Artifact Function that is realized in a process that cleans substances in dilute solutions."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Detergent&oldid=1064079329"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000174
 cco:ont00000174 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000547 ;
-                 rdfs:label "Ultraviolet Telescope"@en ;
-                 skos:altLabel "UV Telescope"@en ;
-                 skos:definition "A Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing ultraviolet light to form an enhanced image of the Object."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000547 ;
+                rdfs:label "Ultraviolet Telescope"@en ;
+                skos:altLabel "UV Telescope"@en ;
+                skos:definition "A Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing ultraviolet light to form an enhanced image of the Object."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000178
 cco:ont00000178 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001150 ;
-                 rdfs:label "Arrow"@en ;
-                 skos:definition "A Portion of Ammunition that is designed to be fired from a Bow and consists of a long straight stiff shaft with stabilizers (fletchings) and a slot (the nock) on one end and a weighted tip (the arrowhead) on the other end."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Arrow&oldid=1058445874"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001150 ;
+                rdfs:label "Arrow"@en ;
+                skos:definition "A Portion of Ammunition that is designed to be fired from a Bow and consists of a long straight stiff shaft with stabilizers (fletchings) and a slot (the nock) on one end and a weighted tip (the arrowhead) on the other end."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Arrow&oldid=1058445874"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000183
 cco:ont00000183 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Fragrance Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in processes of perceiving a pleasant or sweet odor."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Perfume&oldid=1062785740"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Fragrance Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in processes of perceiving a pleasant or sweet odor."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Perfume&oldid=1062785740"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000189
 cco:ont00000189 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000798 ;
-                 rdfs:label "Certificate"@en ;
-                 skos:definition "An Information Bearing Artifact that bears an Information Content Entity which attests to certain demonstrated characteristics of an Object, Person, or Organization."@en ;
-                 cco:ont00001754 "http://www.dictionary.com/browse/degree" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000798 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002002
+                                ] ;
+                rdfs:label "Material Copy of a Certificate"@en ;
+                skos:altLabel "Certificate"@en ;
+                skos:definition "An Information Bearing Artifact that bears an Information Content Entity which attests to certain demonstrated characteristics of an Object, Person, or Organization."@en ;
+                cco:ont00001754 "http://www.dictionary.com/browse/degree" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000190
 cco:ont00000190 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001353 ;
-                 rdfs:label "Minimum Speed Artifact Function"@en ;
-                 skos:definition "A Speed Artifact Function that is realized in some process in which the Artifact bearing the Artifact Function attains the lowest speed at which that Artifact is designed to operate."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001353 ;
+                rdfs:label "Minimum Speed Artifact Function"@en ;
+                skos:definition "A Speed Artifact Function that is realized in some process in which the Artifact bearing the Artifact Function attains the lowest speed at which that Artifact is designed to operate."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000192
 cco:ont00000192 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:BFO_0000171 ;
-                                   owl:someValuesFrom cco:ont00001341
-                                 ] ;
-                 rdfs:label "Facility"@en ;
-                 skos:definition "A Material Artifact that is designed as a building or campus dedicated to some specific purpose."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000171 ;
+                                  owl:someValuesFrom cco:ont00001341
+                                ] ;
+                rdfs:label "Facility"@en ;
+                skos:definition "A Material Artifact that is designed as a building or campus dedicated to some specific purpose."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000193
 cco:ont00000193 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000059 ;
-                 rdfs:label "Telephone Subscriber Line"@en ;
-                 skos:definition "A Telephone Line that connects a Communication Endpoint to another node in a Telecommunication Network to enable service to a user's Telephone."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telephone_line&oldid=1063429738"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000059 ;
+                rdfs:label "Telephone Subscriber Line"@en ;
+                skos:definition "A Telephone Line that connects a Communication Endpoint to another node in a Telecommunication Network to enable service to a user's Telephone."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telephone_line&oldid=1063429738"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000194
 cco:ont00000194 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000795 ;
-                 rdfs:label "Electrical Contact Artifact Function"@en ;
-                 skos:definition "An Electrical Conduction Artifact Function that is realized by processes in which some Artifact is used as an endpoint of an electrical circuit from which an electrical current is passed via physical contact with the endpoint."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000795 ;
+                rdfs:label "Electrical Contact Artifact Function"@en ;
+                skos:definition "An Electrical Conduction Artifact Function that is realized by processes in which some Artifact is used as an endpoint of an electrical circuit from which an electrical current is passed via physical contact with the endpoint."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000199
 cco:ont00000199 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000771 ;
-                 rdfs:label "Camera"@en ;
-                 skos:definition "An Imaging Instrument that is designed to form and digitally or physically record an image of an entity."@en ;
-                 cco:ont00001754 "http://www.dictionary.com/browse/camera" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000771 ;
+                rdfs:label "Camera"@en ;
+                skos:definition "An Imaging Instrument that is designed to form and digitally or physically record an image of an entity."@en ;
+                cco:ont00001754 "http://www.dictionary.com/browse/camera" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000204
 cco:ont00000204 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001104 ;
-                 rdfs:label "Rifle"@en ;
-                 skos:definition "A Long Gun that is designed to have a rifled barrel and to fire single Bullets over long ranges with high accuracy."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rifle&oldid=1056172452"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001104 ;
+                rdfs:label "Rifle"@en ;
+                skos:definition "A Long Gun that is designed to have a rifled barrel and to fire single Bullets over long ranges with high accuracy."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rifle&oldid=1056172452"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000205
@@ -776,173 +797,183 @@ cco:ont00000205 rdf:type owl:Class .
 
 ###  https://www.commoncoreontologies.org/ont00000206
 cco:ont00000206 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Friction Reduction Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in processes of reducing the force resisting the relative motion of surfaces in contact."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Friction&oldid=1061569068"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Friction Reduction Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in processes of reducing the force resisting the relative motion of surfaces in contact."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Friction&oldid=1061569068"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000210
 cco:ont00000210 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Engine"@en ;
-                 skos:altLabel "Motor"@en ;
-                 skos:definition "A Material Artifact that is designed to convert one form of energy into mechanical energy."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Engine&oldid=1063879193"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Engine"@en ;
+                skos:altLabel "Motor"@en ;
+                skos:definition "A Material Artifact that is designed to convert one form of energy into mechanical energy."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Engine&oldid=1063879193"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000212
 cco:ont00000212 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000445 ;
-                 rdfs:label "Chemical Weapon"@en ;
-                 skos:definition "A Weapon that is designed to inflict harm, damage, or incapacity by means of releasing toxic chemicals."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Chemical_weapon&oldid=1054342645"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000445 ;
+                rdfs:label "Chemical Weapon"@en ;
+                skos:definition "A Weapon that is designed to inflict harm, damage, or incapacity by means of releasing toxic chemicals."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Chemical_weapon&oldid=1054342645"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000214
 cco:ont00000214 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000289 ;
-                 rdfs:label "Moving Target Indication Artifact Function"@en ;
-                 skos:definition "A Radar Imaging Artifact Function that inheres in Artifacts that are designed to identify and produce visual representations of moving entities by using a radar to emit successive phase coherent pulses, which are sampled and added to the subsequent pulse to cancel out signals from non-moving entities such that only signals from moving entities remain and are displayed."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000289 ;
+                rdfs:label "Moving Target Indication Artifact Function"@en ;
+                skos:definition "A Radar Imaging Artifact Function that inheres in Artifacts that are designed to identify and produce visual representations of moving entities by using a radar to emit successive phase coherent pulses, which are sampled and added to the subsequent pulse to cancel out signals from non-moving entities such that only signals from moving entities remain and are displayed."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000215
 cco:ont00000215 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000547 ;
-                 rdfs:comment "A Radio Telescope consists of a specialized Antenna and a Radio Receiver and is typically used to receive radio waves from sources in outer space."@en ;
-                 rdfs:label "Radio Telescope"@en ;
-                 skos:definition "A Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing radio waves to form an enhanced image of the Object."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Radio_telescope&oldid=1052819190"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000547 ;
+                rdfs:comment "A Radio Telescope consists of a specialized Antenna and a Radio Receiver and is typically used to receive radio waves from sources in outer space."@en ;
+                rdfs:label "Radio Telescope"@en ;
+                skos:definition "A Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing radio waves to form an enhanced image of the Object."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Radio_telescope&oldid=1052819190"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000216
 cco:ont00000216 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001150 ;
-                 rdfs:label "Shell"@en ;
-                 skos:definition "A Portion of Ammunition that is designed to be a non-self-propelled projectile and to carry a payload (explosive or other) over a relatively short distance."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Shell_(projectile)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001150 ;
+                rdfs:label "Shell"@en ;
+                skos:definition "A Portion of Ammunition that is designed to be a non-self-propelled projectile and to carry a payload (explosive or other) over a relatively short distance."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Shell_(projectile)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000219
 cco:ont00000219 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001009 ;
-                 rdfs:label "Reflecting Optical Telescope"@en ;
-                 skos:altLabel "Reflecting Telescope"@en ,
-                               "Reflector"@en ;
-                 skos:definition "An Optical Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing visible light via reflection through the use of one or more curved Mirrors to form an enhanced image of the Object."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Reflecting_telescope&oldid=1062982683"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001009 ;
+                rdfs:label "Reflecting Optical Telescope"@en ;
+                skos:altLabel "Reflecting Telescope"@en ,
+                              "Reflector"@en ;
+                skos:definition "An Optical Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing visible light via reflection through the use of one or more curved Mirrors to form an enhanced image of the Object."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Reflecting_telescope&oldid=1062982683"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000230
 cco:ont00000230 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000136 ;
-                 rdfs:label "Diffraction Grating"@en ;
-                 skos:definition "An Optical Instrument with a periodic structure that is designed to split and defract a beam of light into several beams travelling in different directions."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Diffraction_grating&oldid=1060463366"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000136 ;
+                rdfs:label "Diffraction Grating"@en ;
+                skos:definition "An Optical Instrument with a periodic structure that is designed to split and defract a beam of light into several beams travelling in different directions."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Diffraction_grating&oldid=1060463366"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000231
 cco:ont00000231 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001051 ;
-                 rdfs:label "Torpedo Tube"@en ;
-                 skos:definition "A Projectile Launcher that is designed to launch Torpedoes."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Torpedo_tube&oldid=1063672665"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001051 ;
+                rdfs:label "Torpedo Tube"@en ;
+                skos:definition "A Projectile Launcher that is designed to launch Torpedoes."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Torpedo_tube&oldid=1063672665"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000233
 cco:ont00000233 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001278 ;
-                 rdfs:label "Stock Certificate"@en ;
-                 skos:definition "Stock that consists of a Certificate."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001278 ;
+                rdfs:label "Stock Certificate"@en ;
+                skos:definition "Stock that consists of a Certificate."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000236
 cco:ont00000236 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Lighting System"@en ;
-                 skos:definition "A Material Artifact that is designed to emit light within some area."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Lighting System"@en ;
+                skos:definition "A Material Artifact that is designed to emit light within some area."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000238
 cco:ont00000238 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Propeller"@en ;
-                 skos:altLabel "Propelling Screw"@en ;
-                 skos:definition "A Material Artifact that is designed to convert rotary motion from an Engine or other mechanical Power Source into propulsive Force."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Propeller_(aeronautics)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Propeller"@en ;
+                skos:altLabel "Propelling Screw"@en ;
+                skos:definition "A Material Artifact that is designed to convert rotary motion from an Engine or other mechanical Power Source into propulsive Force."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Propeller_(aeronautics)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000241
 cco:ont00000241 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001064 ;
-                 rdfs:label "Two-Dimensional Barcode"@en ;
-                 skos:definition "A Barcode that is designed to bear lines of varying widths, spacing, height, and color that concretize some Directive Information Content Entity."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001064 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002015
+                                ] ;
+                rdfs:label "Material Copy of a Two-Dimensional Barcode"@en ;
+                skos:altLabel "Two-Dimensional Barcode"@en ;
+                skos:definition "A Barcode that is designed to bear lines of varying widths, spacing, height, and color that concretize some Directive Information Content Entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000242
 cco:ont00000242 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000241 ;
-                 rdfs:label "Data Matrix Code"@en ;
-                 skos:definition "A Two-Dimensional Barcode that consists of cells arranged in rectangular patterns and is used for marking small items in logistics and operations."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000241 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002017
+                                ] ;
+                rdfs:label "Material Copy of a Data Matrix Code"@en ;
+                skos:altLabel "Data Matrix Code"@en ;
+                skos:definition "A Two-Dimensional Barcode that consists of cells arranged in rectangular patterns and is used for marking small items in logistics and operations."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000243
 cco:ont00000243 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Heat Sink"@en ;
-                 skos:definition "A Material Artifact that is designed to regulate the temperature of a computer by the passive transfer of heat away from other components in the computer."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Heat_sink&oldid=1062822080"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Heat Sink"@en ;
+                skos:definition "A Material Artifact that is designed to regulate the temperature of a computer by the passive transfer of heat away from other components in the computer."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Heat_sink&oldid=1062822080"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000244
 cco:ont00000244 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001153 ;
-                 rdfs:label "Fragmentation Artifact Function"@en ;
-                 skos:definition "A Damaging Artifact Function that is realized in a process in which the structural integrity of an entity is impaired because of a detonation which causes fragmentation."@en ;
-                 cco:ont00001754 "http://www.dictionary.com/browse/fragmentation" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001153 ;
+                rdfs:label "Fragmentation Artifact Function"@en ;
+                skos:definition "A Damaging Artifact Function that is realized in a process in which the structural integrity of an entity is impaired because of a detonation which causes fragmentation."@en ;
+                cco:ont00001754 "http://www.dictionary.com/browse/fragmentation" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000247
 cco:ont00000247 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001326 ;
-                 rdfs:label "Road"@en ;
-                 skos:definition "A Land Transportation Artifact that is designed to enable Ground Vehicles to travel from one location to another."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Road&oldid=1063402841" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001326 ;
+                rdfs:label "Road"@en ;
+                skos:definition "A Land Transportation Artifact that is designed to enable Ground Vehicles to travel from one location to another."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Road&oldid=1063402841" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000249
 cco:ont00000249 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:comment "A Shaft is usually used to connect other components of a drive train that cannot be connected directly either because of the distance between them or the need to allow for relative movement between those components."@en ;
-                 rdfs:label "Shaft"@en ;
-                 skos:definition "A Material Artifact that is designed to rotate and transmit Torque, Power, or Rotational Motion from one machine element to another."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Shaft&oldid=1023963656"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:comment "A Shaft is usually used to connect other components of a drive train that cannot be connected directly either because of the distance between them or the need to allow for relative movement between those components."@en ;
+                rdfs:label "Shaft"@en ;
+                skos:definition "A Material Artifact that is designed to rotate and transmit Torque, Power, or Rotational Motion from one machine element to another."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Shaft&oldid=1023963656"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000252
 cco:ont00000252 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000256 ;
-                 rdfs:label "Nozzle"@en ;
-                 skos:definition "A Fluid Control Artifact that is designed to control the speed, direction, rate, shape, or pressure of the flow of fluid exiting it."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000256 ;
+                rdfs:label "Nozzle"@en ;
+                skos:definition "A Fluid Control Artifact that is designed to control the speed, direction, rate, shape, or pressure of the flow of fluid exiting it."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000253
@@ -951,1519 +982,1590 @@ cco:ont00000253 rdf:type owl:Class .
 
 ###  https://www.commoncoreontologies.org/ont00000254
 cco:ont00000254 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Transportation Artifact"@en ;
-                 skos:definition "A Material Artifact that is fixed in place and designed to bear a Function, the realization of which is sometimes part of a process moving Vehicles and Agents from one location to another."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Transportation Artifact"@en ;
+                skos:definition "A Material Artifact that is fixed in place and designed to bear a Function, the realization of which is sometimes part of a process moving Vehicles and Agents from one location to another."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000255
 cco:ont00000255 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000457 ;
-                 rdfs:label "Portion of Cryogenic Material"@en ;
-                 skos:definition "A Portion of Material that has been reduced to a very low temperature (below -180 degrees Celcius)."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000457 ;
+                rdfs:label "Portion of Cryogenic Material"@en ;
+                skos:definition "A Portion of Material that has been reduced to a very low temperature (below -180 degrees Celcius)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000256
 cco:ont00000256 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Fluid Control Artifact"@en ;
-                 skos:definition "A Material Artifact that is designed to manipulate the flow of a fluid (i.e. a liquid or a gas)."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Fluid Control Artifact"@en ;
+                skos:definition "A Material Artifact that is designed to manipulate the flow of a fluid (i.e. a liquid or a gas)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000258
 cco:ont00000258 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001064 ;
-                 rdfs:label "One-Dimensional Barcode"@en ;
-                 skos:definition "A Barcode that is designed to bear parallel lines of varying widths and spacing that concretize some Directive Information Content Entity."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001064 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002020
+                                ] ;
+                rdfs:label "Material Copy of a One-Dimensional Barcode"@en ;
+                skos:altLabel "One-Dimensional Barcode"@en ;
+                skos:definition "A Barcode that is designed to bear parallel lines of varying widths and spacing that concretize some Directive Information Content Entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000264
 cco:ont00000264 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000020 ;
-                 rdfs:label "Hydraulic Fluid Reservoir"@en ;
-                 skos:definition "A Container that is designed to store some hydraulic fluid for use in some Hyrdraulic Power Source."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000020 ;
+                rdfs:label "Hydraulic Fluid Reservoir"@en ;
+                skos:definition "A Container that is designed to store some hydraulic fluid for use in some Hyrdraulic Power Source."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000266
 cco:ont00000266 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001381 ;
-                 rdfs:label "Hearing Aid"@en ;
-                 skos:definition "A Medical Artifact that is designed to improve hearing for its user."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Hearing_aid&oldid=1062688647"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001381 ;
+                rdfs:label "Hearing Aid"@en ;
+                skos:definition "A Medical Artifact that is designed to improve hearing for its user."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Hearing_aid&oldid=1062688647"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000267
 cco:ont00000267 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000791 ;
-                 rdfs:label "Catalyst Artifact Function"@en ;
-                 skos:definition "A Chemical Reaction Artifact Function that is realized in a process in which the rate of a chemical reaction is increased due to the participation of an additional substance, without that substance being consumed in the reaction."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Catalysis&oldid=1063864001"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000791 ;
+                rdfs:label "Catalyst Artifact Function"@en ;
+                skos:definition "A Chemical Reaction Artifact Function that is realized in a process in which the rate of a chemical reaction is increased due to the participation of an additional substance, without that substance being consumed in the reaction."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Catalysis&oldid=1063864001"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000268
 cco:ont00000268 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001051 ;
-                 rdfs:label "Cannon"@en ;
-                 skos:definition "A Projectile Launcher that is designed to use a controlled explosion to launch a relatively large Portion of Ammunition, such as a Round Shot or a Shell, at a significant Velocity."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Cannon&oldid=1063792906"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001051 ;
+                rdfs:label "Cannon"@en ;
+                skos:definition "A Projectile Launcher that is designed to use a controlled explosion to launch a relatively large Portion of Ammunition, such as a Round Shot or a Shell, at a significant Velocity."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Cannon&oldid=1063792906"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000269
 cco:ont00000269 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000903 ;
-                 rdfs:label "Radio Transmitter"@en ;
-                 skos:definition "A Radio Communication Instrument that is an electronic device that is designed to generate a radio frequency alternating current, which can be applied to a Radio Antenna to be transmitted as radio waves."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Transmitter&oldid=1061735586"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000903 ;
+                rdfs:label "Radio Transmitter"@en ;
+                skos:definition "A Radio Communication Instrument that is an electronic device that is designed to generate a radio frequency alternating current, which can be applied to a Radio Antenna to be transmitted as radio waves."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Transmitter&oldid=1061735586"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000273
 cco:ont00000273 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Communication Interference Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized during events in which an Artifact is used to interfere with the transmission of information for the purpose of preventing communication."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Communication Interference Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized during events in which an Artifact is used to interfere with the transmission of information for the purpose of preventing communication."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000277
 cco:ont00000277 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000445 ;
-                 rdfs:label "Nuclear Weapon"@en ;
-                 skos:definition "A Weapon that is designed to inflict harm, damage, or incapacity by means of a destructive nuclear reaction, either through fission or through a combination of fission and fusion."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Nuclear_weapon&oldid=1060854171"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000445 ;
+                rdfs:label "Nuclear Weapon"@en ;
+                skos:definition "A Weapon that is designed to inflict harm, damage, or incapacity by means of a destructive nuclear reaction, either through fission or through a combination of fission and fusion."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Nuclear_weapon&oldid=1060854171"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000280
 cco:ont00000280 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001124 ;
-                 rdfs:label "Torpedo"@en ;
-                 skos:definition "A Precision-Guided Missile that is designed to be fired into a body of water, be self-propelled through the water, and carry an explosive payload."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Torpedo&oldid=1062609830"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001124 ;
+                rdfs:label "Torpedo"@en ;
+                skos:definition "A Precision-Guided Missile that is designed to be fired into a body of water, be self-propelled through the water, and carry an explosive payload."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Torpedo&oldid=1062609830"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000282
 cco:ont00000282 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000719 ;
-                 rdfs:label "Counterfeit Financial Instrument"@en ;
-                 skos:definition "A Counterfeit Instrument that is designed to be a fake replica of some legally sanctioned Financial Instrument."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Counterfeit_money&oldid=1064052318"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000719 ;
+                rdfs:label "Counterfeit Financial Instrument"@en ;
+                skos:definition "A Counterfeit Instrument that is designed to be a fake replica of some legally sanctioned Financial Instrument."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Counterfeit_money&oldid=1064052318"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000285
 cco:ont00000285 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000269 ;
-                 rdfs:label "Emergency Locator Transmitter"@en ;
-                 skos:definition "A Radio Transmitter that is designed to signal distress and provide positional data for the entity it is located on."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Emergency_position-indicating_radiobeacon&oldid=1063407242"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000269 ;
+                rdfs:label "Emergency Locator Transmitter"@en ;
+                skos:definition "A Radio Transmitter that is designed to signal distress and provide positional data for the entity it is located on."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Emergency_position-indicating_radiobeacon&oldid=1063407242"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000287
 cco:ont00000287 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001187 ;
-                 rdfs:label "Inertial Navigation System"@en ;
-                 skos:altLabel "INS"@en ;
-                 skos:definition "A Navigation System that is designed to continuously calculate via dead reckoning the position, orientation, and velocity of a moving object without the need for external references."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Inertial_navigation_system&oldid=1063682725"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001187 ;
+                rdfs:label "Inertial Navigation System"@en ;
+                skos:altLabel "INS"@en ;
+                skos:definition "A Navigation System that is designed to continuously calculate via dead reckoning the position, orientation, and velocity of a moving object without the need for external references."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Inertial_navigation_system&oldid=1063682725"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000288
 cco:ont00000288 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Power Source"@en ;
-                 skos:definition "A Material Artifact that is designed to supply power to some other Artifact."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Power_source&oldid=1032888635"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Power Source"@en ;
+                skos:definition "A Material Artifact that is designed to supply power to some other Artifact."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Power_source&oldid=1032888635"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000289
 cco:ont00000289 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000601 ;
-                 rdfs:label "Radar Imaging Artifact Function"@en ;
-                 skos:definition "An Imaging Artifact Function that inheres in Artifacts that are designed to produce visual representations of entities using radio waves."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000601 ;
+                rdfs:label "Radar Imaging Artifact Function"@en ;
+                skos:definition "An Imaging Artifact Function that inheres in Artifacts that are designed to produce visual representations of entities using radio waves."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000292
 cco:ont00000292 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00000686
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001916 ;
-                                                              owl:someValuesFrom cco:ont00000995
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00000686 ;
-                 rdfs:label "Artifact Identifier"@en ;
-                 skos:definition "A Designative Information Content Entity which designates some Artifact."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000686
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001916 ;
+                                                             owl:someValuesFrom cco:ont00000995
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000686 ;
+                rdfs:label "Artifact Identifier"@en ;
+                skos:definition "A Designative Information Content Entity which designates some Artifact."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000294
 cco:ont00000294 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000533 ;
-                 rdfs:label "Air-Breathing Jet Engine"@en ;
-                 skos:altLabel "Ducted Jet Engine"@en ;
-                 skos:definition "A Jet Engine that is propelled by a jet of hot exhaust gases formed from air that is drawn into the Engine via an Air Inlet."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Airbreathing_jet_engine&oldid=1062364308"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000533 ;
+                rdfs:label "Air-Breathing Jet Engine"@en ;
+                skos:altLabel "Ducted Jet Engine"@en ;
+                skos:definition "A Jet Engine that is propelled by a jet of hot exhaust gases formed from air that is drawn into the Engine via an Air Inlet."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Airbreathing_jet_engine&oldid=1062364308"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000298
 cco:ont00000298 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001173 ;
-                 rdfs:label "Shoulder-Fired Rocket Launcher"@en ;
-                 skos:definition "A Rocket Launcher that is designed to be small enough to be carried by a single person and fired while supported on the person's shoulder."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001173 ;
+                rdfs:label "Shoulder-Fired Rocket Launcher"@en ;
+                skos:definition "A Rocket Launcher that is designed to be small enough to be carried by a single person and fired while supported on the person's shoulder."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000299
 cco:ont00000299 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000715 ;
-                 rdfs:label "Prosthetic Leg"@en ;
-                 skos:definition "A Prosthesis that is designed to replace a missing leg."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Prosthesis&oldid=1063749698"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000715 ;
+                rdfs:label "Prosthetic Leg"@en ;
+                skos:definition "A Prosthesis that is designed to replace a missing leg."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Prosthesis&oldid=1063749698"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000301
 cco:ont00000301 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000663 ;
-                 rdfs:label "Vehicle Transmission"@en ;
-                 skos:altLabel "Gearbox"@en ,
-                               "Transmission"@en ;
-                 skos:definition "A Power Transmission Artifact that is designed to vary the output speed and torque in a rotating power transfer system."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Transmission_(mechanics)"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000663 ;
+                rdfs:label "Vehicle Transmission"@en ;
+                skos:altLabel "Gearbox"@en ,
+                              "Transmission"@en ;
+                skos:definition "A Power Transmission Artifact that is designed to vary the output speed and torque in a rotating power transfer system."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Transmission_(mechanics)"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000302
 cco:ont00000302 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001049 ;
-                 rdfs:label "Alternating Current Power Source"@en ;
-                 skos:definition "An Electrical Power Source that is designed to transfer electrical power in the form of alternating current."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001049 ;
+                rdfs:label "Alternating Current Power Source"@en ;
+                skos:definition "An Electrical Power Source that is designed to transfer electrical power in the form of alternating current."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000303
 cco:ont00000303 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001036 ;
-                 rdfs:label "Intercommunication System"@en ;
-                 skos:definition "A Communication System that is designed to enable some Act of Communication between end points within a building, small collection of buildings, or within a small area of service."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Intercom&oldid=1055934442"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001036 ;
+                rdfs:label "Intercommunication System"@en ;
+                skos:definition "A Communication System that is designed to enable some Act of Communication between end points within a building, small collection of buildings, or within a small area of service."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Intercom&oldid=1055934442"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000304
 cco:ont00000304 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000771 ;
-                 rdfs:label "Microscope"@en ;
-                 skos:definition "An Imaging Instrument that is designed to enable users to see Objects that are otherwise too small to be seen by the naked eye by producing a significantly enlarged image of the Object."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Microscope&oldid=1059024357"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000771 ;
+                rdfs:label "Microscope"@en ;
+                skos:definition "An Imaging Instrument that is designed to enable users to see Objects that are otherwise too small to be seen by the naked eye by producing a significantly enlarged image of the Object."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Microscope&oldid=1059024357"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000306
 cco:ont00000306 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001370 ;
-                 rdfs:label "Hinge"@en ;
-                 skos:definition "A Machine Bearing that is designed to limit the angle of Rotation between two solid objects."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Hinge&oldid=1059935559"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001370 ;
+                rdfs:label "Hinge"@en ;
+                skos:definition "A Machine Bearing that is designed to limit the angle of Rotation between two solid objects."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Hinge&oldid=1059935559"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000307
 cco:ont00000307 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001084 ;
-                 rdfs:label "Portion of Food"@en ;
-                 skos:definition "A Portion of Processed Material that is designed to be consumed and ingested for nutrition or taste."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Food&oldid=1062824590"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001084 ;
+                rdfs:label "Portion of Food"@en ;
+                skos:definition "A Portion of Processed Material that is designed to be consumed and ingested for nutrition or taste."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Food&oldid=1062824590"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000309
 cco:ont00000309 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001301 ;
-                 rdfs:label "Healthcare Artifact Function"@en ;
-                 skos:definition "A Service Artifact Function that is realized in processes of treating and preventing illness."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Health_care&oldid=1064015344"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001301 ;
+                rdfs:label "Healthcare Artifact Function"@en ;
+                skos:definition "A Service Artifact Function that is realized in processes of treating and preventing illness."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Health_care&oldid=1064015344"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000310
 cco:ont00000310 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000552 ;
-                 rdfs:label "Grenade"@en ;
-                 skos:altLabel "Hand Grenade"@en ;
-                 skos:definition "An Explosive Weapon that is designed to be relatively small and to be thrown by hand."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Grenade&oldid=1060366148"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000552 ;
+                rdfs:label "Grenade"@en ;
+                skos:altLabel "Hand Grenade"@en ;
+                skos:definition "An Explosive Weapon that is designed to be relatively small and to be thrown by hand."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Grenade&oldid=1060366148"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000311
 cco:ont00000311 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001999 ;
-                 rdfs:label "Filtration Artifact Function"@en ;
-                 skos:definition "A Filter Function that is realized in a process in which some solid entity is prevented from moving along with some quantity of liquid."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Filtration&oldid=1061655528"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001999 ;
+                rdfs:label "Filtration Artifact Function"@en ;
+                skos:definition "A Filter Function that is realized in a process in which some solid entity is prevented from moving along with some quantity of liquid."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Filtration&oldid=1061655528"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000315
 cco:ont00000315 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000918 ;
-                 rdfs:label "Telecommunication Switching Node"@en ;
-                 skos:definition "A Telecommunication Network Node that is capable of redirecting a communication transmission to another Telecommunication Network Node."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telecommunications_network&oldid=1063347482"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000918 ;
+                rdfs:label "Telecommunication Switching Node"@en ;
+                skos:definition "A Telecommunication Network Node that is capable of redirecting a communication transmission to another Telecommunication Network Node."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telecommunications_network&oldid=1063347482"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000316
 cco:ont00000316 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000255 ;
-                 rdfs:label "Portion of Liquid Helium"@en ;
-                 skos:definition "A Portion of Cryogenic Material that is composed (almost) entirely of liquid helium."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000255 ;
+                rdfs:label "Portion of Liquid Helium"@en ;
+                skos:definition "A Portion of Cryogenic Material that is composed (almost) entirely of liquid helium."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000317
 cco:ont00000317 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001218 ;
-                 rdfs:label "Electronic Signal Processing Artifact Function"@en ;
-                 skos:definition "A Signal Processing Artifact Function that inheres in Artifacts that are designed to process or transfer information contained in electronic signals."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001218 ;
+                rdfs:label "Electronic Signal Processing Artifact Function"@en ;
+                skos:definition "A Signal Processing Artifact Function that inheres in Artifacts that are designed to process or transfer information contained in electronic signals."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000319
 cco:ont00000319 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000965 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001942 ;
-                                   owl:someValuesFrom cco:ont00000995
-                                 ] ;
-                 rdfs:label "Artifact Design"@en ;
-                 skos:definition "A Directive Information Content Entity that is a specification of an object, manifested by an agent, intended to accomplish goals, in a particular environment, using a set of primitive components, satisfying a set of requirements, subject to constraints."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Design&oldid=1063941625"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000965 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty cco:ont00001942 ;
+                                  owl:someValuesFrom cco:ont00000995
+                                ] ;
+                rdfs:label "Artifact Design"@en ;
+                skos:definition "A Directive Information Content Entity that is a specification of an object, manifested by an agent, intended to accomplish goals, in a particular environment, using a set of primitive components, satisfying a set of requirements, subject to constraints."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Design&oldid=1063941625"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000321
 cco:ont00000321 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001301 ;
-                 rdfs:label "Residential Artifact Function"@en ;
-                 skos:definition "A Service Artifact Function that is realized in processes of residing in a dwelling or home."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Residence&oldid=1019728937"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001301 ;
+                rdfs:label "Residential Artifact Function"@en ;
+                skos:definition "A Service Artifact Function that is realized in processes of residing in a dwelling or home."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Residence&oldid=1019728937"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000323
 cco:ont00000323 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000034 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:BFO_0000197 ;
-                                   owl:someValuesFrom cco:ont00000995
-                                 ] ;
-                 rdfs:label "Artifact Function"@en ;
-                 skos:definition "A Function that inheres in some Artifact in virtue of that Artifact being designed to be used in processes that require that Function to be realized."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000034 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000197 ;
+                                  owl:someValuesFrom cco:ont00000995
+                                ] ;
+                rdfs:label "Artifact Function"@en ;
+                skos:definition "A Function that inheres in some Artifact in virtue of that Artifact being designed to be used in processes that require that Function to be realized."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000325
 cco:ont00000325 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000903 ;
-                 rdfs:label "Radio Transponder"@en ;
-                 skos:altLabel "Transmitter-Responder"@en ;
-                 skos:definition "A Radio Communication Instrument that is an electronic device that acts as both a Radio Transmitter and responder and is used to wirelessly receive and transmit electrical signals."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000903 ;
+                rdfs:label "Radio Transponder"@en ;
+                skos:altLabel "Transmitter-Responder"@en ;
+                skos:definition "A Radio Communication Instrument that is an electronic device that acts as both a Radio Transmitter and responder and is used to wirelessly receive and transmit electrical signals."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000326
 cco:ont00000326 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000258 ;
-                 rdfs:label "UPC Barcode"@en ;
-                 skos:definition "A One-Dimensional Barcode that consists of 6 or 12 numerical digits and is used to scan consumer goods."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000258 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002034
+                                ] ;
+                rdfs:label "Material Copy of a UPC Barcode"@en ;
+                skos:altLabel "UPC Barcode"@en ;
+                skos:definition "A One-Dimensional Barcode that consists of 6 or 12 numerical digits and is used to scan consumer goods."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000328
 cco:ont00000328 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000870 ;
-                 rdfs:label "Transportation Infrastructure"@en ;
-                 skos:definition "An Infrastructure System that is designed to facilitate the movement of material entities from one location to another by providing the necessary structures for Persons to travel or for Vehicles to transport material entities."@en ;
-                 cco:ont00001754 "http://www.cfr.org/infrastructure/transportation-infrastructure-moving-america/p18611" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000870 ;
+                rdfs:label "Transportation Infrastructure"@en ;
+                skos:definition "An Infrastructure System that is designed to facilitate the movement of material entities from one location to another by providing the necessary structures for Persons to travel or for Vehicles to transport material entities."@en ;
+                cco:ont00001754 "http://www.cfr.org/infrastructure/transportation-infrastructure-moving-america/p18611" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000333
 cco:ont00000333 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000394 ;
-                 rdfs:label "Gas Turbine"@en ;
-                 skos:altLabel "Combustion Turbine"@en ;
-                 skos:definition "An Internal Combustion Engine that has a rotating compressor and a turbine and is designed to operate utilizing continous Combustion to produce Thrust, either directly via exhaust or indirectly via a prop."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Gas_turbine&oldid=1062398125"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000394 ;
+                rdfs:label "Gas Turbine"@en ;
+                skos:altLabel "Combustion Turbine"@en ;
+                skos:definition "An Internal Combustion Engine that has a rotating compressor and a turbine and is designed to operate utilizing continous Combustion to produce Thrust, either directly via exhaust or indirectly via a prop."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Gas_turbine&oldid=1062398125"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000334
 cco:ont00000334 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000303 ;
-                 rdfs:label "Interphone"@en ;
-                 skos:definition "An Intercommunication System that that is designed to facilitate some Act of Communication between agents by means of audio messages."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000303 ;
+                rdfs:label "Interphone"@en ;
+                skos:definition "An Intercommunication System that that is designed to facilitate some Act of Communication between agents by means of audio messages."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000337
 cco:ont00000337 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001029 ;
-                 rdfs:label "Rocket-Propelled Grenade"@en ;
-                 skos:definition "An Unguided Rocket that is designed to contain an explosive warhead, be fired from a Shoulder-Fired Rocket Launcher, and be used against Tanks."@en ;
-                 cco:ont00001753 "RPG" ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rocket-propelled_grenade&oldid=1063641548"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001029 ;
+                rdfs:label "Rocket-Propelled Grenade"@en ;
+                skos:definition "An Unguided Rocket that is designed to contain an explosive warhead, be fired from a Shoulder-Fired Rocket Launcher, and be used against Tanks."@en ;
+                cco:ont00001753 "RPG" ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rocket-propelled_grenade&oldid=1063641548"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000338
 cco:ont00000338 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000256 ;
-                 rdfs:label "Fan"@en ;
-                 skos:definition "A Fluid Control Artifact that consists of a rotating arrangement of vanes or blades that are designed to act on a portion of fluid to create flow within it."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Fan_(machine)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000256 ;
+                rdfs:label "Fan"@en ;
+                skos:definition "A Fluid Control Artifact that consists of a rotating arrangement of vanes or blades that are designed to act on a portion of fluid to create flow within it."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Fan_(machine)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000340
 cco:ont00000340 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000268 ;
-                 rdfs:label "Mortar"@en ;
-                 skos:definition "A Cannon that is designed to fire projectiles at relatively low velocities over relatively short ranges."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Mortar_(weapon)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000268 ;
+                rdfs:label "Mortar"@en ;
+                skos:definition "A Cannon that is designed to fire projectiles at relatively low velocities over relatively short ranges."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Mortar_(weapon)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000341
 cco:ont00000341 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000715 ;
-                 rdfs:label "Prosthetic Arm"@en ;
-                 skos:definition "A Prosthesis that is designed to replace a missing arm."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Prosthesis&oldid=1063749698"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000715 ;
+                rdfs:label "Prosthetic Arm"@en ;
+                skos:definition "A Prosthesis that is designed to replace a missing arm."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Prosthesis&oldid=1063749698"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000342
 cco:ont00000342 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Brake"@en ;
-                 skos:definition "A Material Artifact that is designed to inhibit the Vehicle's Motion by absorbing energy from a moving system."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Brake&oldid=1047693009"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Brake"@en ;
+                skos:definition "A Material Artifact that is designed to inhibit the Vehicle's Motion by absorbing energy from a moving system."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Brake&oldid=1047693009"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000343
 cco:ont00000343 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000634 ;
-                 rdfs:label "Reciprocating Steam Engine"@en ;
-                 skos:definition "A Steam Engine that is designed to use one or more reciprocating pistons to convert pressure into a rotating motion."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Reciprocating_engine&oldid=1057783145"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000634 ;
+                rdfs:label "Reciprocating Steam Engine"@en ;
+                skos:definition "A Steam Engine that is designed to use one or more reciprocating pistons to convert pressure into a rotating motion."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Reciprocating_engine&oldid=1057783145"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000344
 cco:ont00000344 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001281 ;
-                 rdfs:label "Surfactant Artifact Function"@en ;
-                 skos:definition "An Emulsifier Artifact Function that is realized in a process that lowers the surface tension between two liquids or between a liquid and a solid."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Surfactant&oldid=1063693411"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001281 ;
+                rdfs:label "Surfactant Artifact Function"@en ;
+                skos:definition "An Emulsifier Artifact Function that is realized in a process that lowers the surface tension between two liquids or between a liquid and a solid."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Surfactant&oldid=1063693411"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000346
 cco:ont00000346 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Communication Instrument"@en ;
-                 skos:definition "A Material Artifact that is designed to facilitate communication between at least two entities."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Communication Instrument"@en ;
+                skos:definition "A Material Artifact that is designed to facilitate communication between at least two entities."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000347
 cco:ont00000347 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001159 ;
-                 rdfs:label "Electronic Bond"@en ;
-                 skos:definition "A Bond that consists of Bytes."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001159 ;
+                rdfs:label "Electronic Bond"@en ;
+                skos:definition "A Bond that consists of Bytes."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000348
 cco:ont00000348 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00000995
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty obo:BFO_0000196 ;
-                                                              owl:someValuesFrom cco:ont00001999
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Filter"@en ;
-                 skos:definition "A Material Artifact that bears a Filter Function."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000995
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:BFO_0000196 ;
+                                                             owl:someValuesFrom cco:ont00001999
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Filter"@en ;
+                skos:definition "A Material Artifact that bears a Filter Function."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000350
 cco:ont00000350 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000453 ;
-                 rdfs:label "Cooling System"@en ;
-                 skos:definition "An Environment Control System that is designed to cool the air or objects in a Site."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000453 ;
+                rdfs:label "Cooling System"@en ;
+                skos:definition "An Environment Control System that is designed to cool the air or objects in a Site."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000352
 cco:ont00000352 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001139 ;
-                 rdfs:label "Satellite Artifact"@en ;
-                 skos:definition "A Spacecraft that is designed to Orbit a Space Object (typically Earth)."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001139 ;
+                rdfs:label "Satellite Artifact"@en ;
+                skos:definition "A Spacecraft that is designed to Orbit a Space Object (typically Earth)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000353
 cco:ont00000353 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Research Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized during events in which an Artifact is used to perform research on a specified entity or class of entities."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Research Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized during events in which an Artifact is used to perform research on a specified entity or class of entities."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000355
 cco:ont00000355 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001009 ;
-                 rdfs:label "Refracting Optical Telescope"@en ;
-                 skos:altLabel "Refracting Telescope"@en ,
-                               "Refractor"@en ;
-                 skos:definition "An Optical Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing visible light via refraction through the use of one or more Lenses to form an enhanced image of the Object."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Refracting_telescope&oldid=1059975066"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001009 ;
+                rdfs:label "Refracting Optical Telescope"@en ;
+                skos:altLabel "Refracting Telescope"@en ,
+                              "Refractor"@en ;
+                skos:definition "An Optical Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing visible light via refraction through the use of one or more Lenses to form an enhanced image of the Object."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Refracting_telescope&oldid=1059975066"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000362
 cco:ont00000362 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000533 ;
-                 rdfs:comment "Most rocket engines are also Internal Combustion Engines, however non-combusting forms also exist. For example, an untied balloon full of air that is released and allowed to zoom around the room may be both a Rocket Engine and a Physically Powered Engine."@en ;
-                 rdfs:label "Rocket Engine"@en ;
-                 skos:altLabel "Thruster"@en ;
-                 skos:definition "A Jet Engine that is designed to use only stored Rocket Propellant to form a high speed propulsive jet in order to generate Thrust."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rocket_engine&oldid=1063879464"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000533 ;
+                rdfs:comment "Most rocket engines are also Internal Combustion Engines, however non-combusting forms also exist. For example, an untied balloon full of air that is released and allowed to zoom around the room may be both a Rocket Engine and a Physically Powered Engine."@en ;
+                rdfs:label "Rocket Engine"@en ;
+                skos:altLabel "Thruster"@en ;
+                skos:definition "A Jet Engine that is designed to use only stored Rocket Propellant to form a high speed propulsive jet in order to generate Thrust."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rocket_engine&oldid=1063879464"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000363
 cco:ont00000363 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000998 ;
-                 rdfs:label "Wireless Telecommunication Network"@en ;
-                 skos:altLabel "Wireless Network"@en ;
-                 skos:definition "A Telecommunication Network that uses wireless connections to connect Telecommunication Network Nodes."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Wireless_network&oldid=1060257041"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000998 ;
+                rdfs:label "Wireless Telecommunication Network"@en ;
+                skos:altLabel "Wireless Network"@en ;
+                skos:definition "A Telecommunication Network that uses wireless connections to connect Telecommunication Network Nodes."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Wireless_network&oldid=1060257041"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000364
 cco:ont00000364 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001221 ;
-                 rdfs:label "Pneumatic Motor"@en ;
-                 skos:altLabel "Air Motor"@en ,
-                               "Compressed Air Engine"@en ;
-                 skos:definition "A Physically Powered Engine that converts potential energy stored in a portion of compressed air into mechanical energy."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001221 ;
+                rdfs:label "Pneumatic Motor"@en ;
+                skos:altLabel "Air Motor"@en ,
+                              "Compressed Air Engine"@en ;
+                skos:definition "A Physically Powered Engine that converts potential energy stored in a portion of compressed air into mechanical energy."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000372
 cco:ont00000372 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Power Transformer Rectifier Unit"@en ;
-                 skos:altLabel "TRU"@en ;
-                 skos:definition "A Material Artifact that is designed to perform the functions of both a Rectifier and a Transformer."@en ;
-                 cco:ont00001754 "http://www.skybrary.aero/index.php/Transformer_Rectifier_Unit_(TRU)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Power Transformer Rectifier Unit"@en ;
+                skos:altLabel "TRU"@en ;
+                skos:definition "A Material Artifact that is designed to perform the functions of both a Rectifier and a Transformer."@en ;
+                cco:ont00001754 "http://www.skybrary.aero/index.php/Transformer_Rectifier_Unit_(TRU)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000376
 cco:ont00000376 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000457 ;
-                 rdfs:label "Portion of Gallium Arsenide"@en ;
-                 skos:altLabel "Portion of GaAs"@en ;
-                 skos:definition "A Portion of Material that is composed of a compound of the elements gallium and arsenic."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000457 ;
+                rdfs:label "Portion of Gallium Arsenide"@en ;
+                skos:altLabel "Portion of GaAs"@en ;
+                skos:definition "A Portion of Material that is composed of a compound of the elements gallium and arsenic."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000382
 cco:ont00000382 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000798 ;
-                 rdfs:label "Spreadsheet"@en ;
-                 skos:definition "An Information Bearing Artifact that is designed to bear some Information Content Entity in an interactive, tabular form."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Spreadsheet&oldid=1064060503"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001298 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002042
+                                ] ;
+                rdfs:label "Material Copy of a Spreadsheet"@en ;
+                skos:altLabel "Spreadsheet"@en ;
+                skos:definition "An Information Bearing Artifact that is designed to bear some Information Content Entity in an interactive, tabular form."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Spreadsheet&oldid=1064060503"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000394
 cco:ont00000394 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000746 ;
-                 rdfs:label "Internal Combustion Engine"@en ;
-                 skos:definition "A Combustion Engine that is designed to have an internal Combustion Chamber where portions of Fuel and Oxidizer mixture are burned to generate thermal energy that is then converted into mechanical energy."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Internal_combustion_engine&oldid=1063281505"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000746 ;
+                rdfs:label "Internal Combustion Engine"@en ;
+                skos:definition "A Combustion Engine that is designed to have an internal Combustion Chamber where portions of Fuel and Oxidizer mixture are burned to generate thermal energy that is then converted into mechanical energy."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Internal_combustion_engine&oldid=1063281505"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000397
 cco:ont00000397 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Combustion Chamber"@en ;
-                 skos:altLabel "Burner"@en ,
-                               "Combustor"@en ,
-                               "Flame Holder"@en ;
-                 skos:definition "A Material Artifact that is designed to wholly or partially bound an internal Site where a Combustion process is intended to occur."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Combustion Chamber"@en ;
+                skos:altLabel "Burner"@en ,
+                              "Combustor"@en ,
+                              "Flame Holder"@en ;
+                skos:definition "A Material Artifact that is designed to wholly or partially bound an internal Site where a Combustion process is intended to occur."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000403
 cco:ont00000403 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Diffraction Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized by an Artifact participating in a diffraction event in which the Artifact forces a wave to bend around the corners of an obstacle or aperture into the region of geometrical shadow of the obstacle."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Diffraction Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized by an Artifact participating in a diffraction event in which the Artifact forces a wave to bend around the corners of an obstacle or aperture into the region of geometrical shadow of the obstacle."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000407
 cco:ont00000407 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000098 ;
-                 rdfs:label "Electrical Resistance Artifact Function"@en ;
-                 skos:definition "An Electrical Artifact Function that is realized in processes in which an Artifact opposes the flow of an electric current."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electrical_resistivity_and_conductivity&oldid=1063749049"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000098 ;
+                rdfs:label "Electrical Resistance Artifact Function"@en ;
+                skos:definition "An Electrical Artifact Function that is realized in processes in which an Artifact opposes the flow of an electric current."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electrical_resistivity_and_conductivity&oldid=1063749049"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000409
 cco:ont00000409 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000742 ;
-                 rdfs:label "Spark Ignition System"@en ;
-                 skos:definition "An Ignition System that is designed to produce a spark in order to initiate an Ignition process."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000742 ;
+                rdfs:label "Spark Ignition System"@en ;
+                skos:definition "An Ignition System that is designed to produce a spark in order to initiate an Ignition process."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000411
 cco:ont00000411 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001100 ;
-                 rdfs:label "Speed Measurement Artifact Function"@en ;
-                 skos:definition "A Measurement Artifact Function that is realized during events in which an Artifact is used to measure the Speed of a specified object's or class of objects' Motion."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001100 ;
+                rdfs:label "Speed Measurement Artifact Function"@en ;
+                skos:definition "A Measurement Artifact Function that is realized during events in which an Artifact is used to measure the Speed of a specified object's or class of objects' Motion."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000412
 cco:ont00000412 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000791 ;
-                 rdfs:label "Oxidizer Artifact Function"@en ;
-                 skos:definition "A Chemical Reaction Artifact Function that is realized in a process in which electrons are removed from a reactant in a redox reaction."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Redox&oldid=1063866348"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000791 ;
+                rdfs:label "Oxidizer Artifact Function"@en ;
+                skos:definition "A Chemical Reaction Artifact Function that is realized in a process in which electrons are removed from a reactant in a redox reaction."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Redox&oldid=1063866348"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000413
 cco:ont00000413 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000304 ;
-                 rdfs:label "Electron Microscope"@en ;
-                 skos:definition "A Microscope that is designed to use a beam of accelerated electrons to illuminate the target and produce a significantly enlarged image of the Object."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electron_microscope&oldid=1060512240"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000304 ;
+                rdfs:label "Electron Microscope"@en ;
+                skos:definition "A Microscope that is designed to use a beam of accelerated electrons to illuminate the target and produce a significantly enlarged image of the Object."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electron_microscope&oldid=1060512240"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000415
 cco:ont00000415 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000828 ;
-                 rdfs:label "Anti-Microbial Artifact Function"@en ;
-                 skos:definition "A Pesticide Artifact Function that is realized in a process which causes illness in, or the death of, a microorganism."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Antimicrobial&oldid=1064100151"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000828 ;
+                rdfs:label "Anti-Microbial Artifact Function"@en ;
+                skos:definition "A Pesticide Artifact Function that is realized in a process which causes illness in, or the death of, a microorganism."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Antimicrobial&oldid=1064100151"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000417
 cco:ont00000417 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000715 ;
-                 rdfs:label "Prosthetic Hand"@en ;
-                 skos:definition "A Prosthesis that is designed to replace a missing hand."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Prosthesis&oldid=1063749698"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000715 ;
+                rdfs:label "Prosthetic Hand"@en ;
+                skos:definition "A Prosthesis that is designed to replace a missing hand."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Prosthesis&oldid=1063749698"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000420
 cco:ont00000420 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000117 ;
-                 rdfs:label "Computer"@en ;
-                 skos:definition "An Information Processing Artifact that is designed to execute an arbitrary set of arithmetic or logical operations automatically."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Computer&oldid=1061553332"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000117 ;
+                rdfs:label "Computer"@en ;
+                skos:definition "An Information Processing Artifact that is designed to execute an arbitrary set of arithmetic or logical operations automatically."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Computer&oldid=1061553332"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000422
 cco:ont00000422 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Communication Reception Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized during events in which an Artifact is used to receive information that has been transmitted for the purpose of communiction."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Communication Reception Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized during events in which an Artifact is used to receive information that has been transmitted for the purpose of communiction."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000427
 cco:ont00000427 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000053 ;
-                 rdfs:label "Armored Fighting Vehicle"@en ;
-                 skos:definition "A Ground Motor Vehicle that is designed to be armored and used to transport and support military personal in combat missions."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Armoured_fighting_vehicle&oldid=1063212018"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000053 ;
+                rdfs:label "Armored Fighting Vehicle"@en ;
+                skos:definition "A Ground Motor Vehicle that is designed to be armored and used to transport and support military personal in combat missions."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Armoured_fighting_vehicle&oldid=1063212018"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000428
 cco:ont00000428 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001326 ;
-                 rdfs:label "Railway Junction"@en ;
-                 skos:definition "A Land Transportation Artifact that is designed to enable a Train to switch between the tracks of two routes."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Junction_(rail)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001326 ;
+                rdfs:label "Railway Junction"@en ;
+                skos:definition "A Land Transportation Artifact that is designed to enable a Train to switch between the tracks of two routes."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Junction_(rail)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000429
 cco:ont00000429 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000258 ;
-                 rdfs:label "Codabar Barcode"@en ;
-                 skos:definition "A One-Dimensional Barcode that consists of numbers 0-9 and the characters -$:/.+ and is used by logistics and healthcare professionals."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000258 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002021
+                                ] ;
+                rdfs:label "Material Copy of a Codabar Barcode"@en ;
+                skos:altLabel "Codabar Barcode"@en ;
+                skos:definition "A One-Dimensional Barcode that consists of numbers 0-9 and the characters -$:/.+ and is used by logistics and healthcare professionals."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000431
 cco:ont00000431 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000746 ;
-                 rdfs:label "External Combustion Engine"@en ;
-                 skos:definition "A Combustion Engine that is designed to have an external Combustion Chamber where portions of Fuel and Oxidizer mixture are burned to generate thermal energy to heat the working fluid, which transfers energy to the Engine where it is converted into mechanical energy."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=External_combustion_engine&oldid=1063941809"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000746 ;
+                rdfs:label "External Combustion Engine"@en ;
+                skos:definition "A Combustion Engine that is designed to have an external Combustion Chamber where portions of Fuel and Oxidizer mixture are burned to generate thermal energy to heat the working fluid, which transfers energy to the Engine where it is converted into mechanical energy."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=External_combustion_engine&oldid=1063941809"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000434
 cco:ont00000434 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001207 ;
-                 rdfs:label "Simple Optical Lens"@en ;
-                 skos:definition "An Optical Lens consisting of a single piece of transparent material."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001207 ;
+                rdfs:label "Simple Optical Lens"@en ;
+                skos:definition "An Optical Lens consisting of a single piece of transparent material."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000436
 cco:ont00000436 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000304 ;
-                 rdfs:label "X-ray Microscope"@en ;
-                 skos:definition "A Microscope that is designed to use Electromagnetic Radiation in the soft X-ray band to produce a significantly enlarged image of the Object."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=X-ray_microscope&oldid=1046169107"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000304 ;
+                rdfs:label "X-ray Microscope"@en ;
+                skos:definition "A Microscope that is designed to use Electromagnetic Radiation in the soft X-ray band to produce a significantly enlarged image of the Object."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=X-ray_microscope&oldid=1046169107"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000437
 cco:ont00000437 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Enhancing Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in processes of intensifying, increainsg, or further improving the quality, value, or extent of some entity."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Enhancement&oldid=1003326590"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Enhancing Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in processes of intensifying, increainsg, or further improving the quality, value, or extent of some entity."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Enhancement&oldid=1003326590"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000440
 cco:ont00000440 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000713 ;
-                 rdfs:label "Watercraft"@en ;
-                 skos:definition "A Vehicle that is designed to convey passengers, cargo, or equipment from one location to another by water travel."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Watercraft&oldid=1054071067"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000713 ;
+                rdfs:label "Watercraft"@en ;
+                skos:definition "A Vehicle that is designed to convey passengers, cargo, or equipment from one location to another by water travel."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Watercraft&oldid=1054071067"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000445
 cco:ont00000445 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Weapon"@en ;
-                 skos:definition "A Material Artifact that is designed to destroy or inflict damage to structures or systems, or to kill or wound living things by creating specific lethal or nonlethal effects."@en ;
-                 skos:scopeNote "Nonlethal effects include all outcomes short of death or destruction. This is captured by the fact that Damaged Stasis and Wounded Stasis are defined in terms of impairment of the Independent Continuant that participates in them."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Weapon&oldid=1143263715"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Weapon"@en ;
+                skos:definition "A Material Artifact that is designed to destroy or inflict damage to structures or systems, or to kill or wound living things by creating specific lethal or nonlethal effects."@en ;
+                skos:scopeNote "Nonlethal effects include all outcomes short of death or destruction. This is captured by the fact that Damaged Stasis and Wounded Stasis are defined in terms of impairment of the Independent Continuant that participates in them."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Weapon&oldid=1143263715"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000448
 cco:ont00000448 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Motion Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in a process in which an entity changes its position with respect to time."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Motion_(physics)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Motion Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in a process in which an entity changes its position with respect to time."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Motion_(physics)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000451
 cco:ont00000451 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Collimation Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized by an Artifact participating in a collimation event in which the Artifact narrows a beam of particles or waves by either causing the spatial cross-section of the beam to become smaller or by causing the directions of motion of the beam's constituents to be aligned in a specifc direction of Motion."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Collimation Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized by an Artifact participating in a collimation event in which the Artifact narrows a beam of particles or waves by either causing the spatial cross-section of the beam to become smaller or by causing the directions of motion of the beam's constituents to be aligned in a specifc direction of Motion."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000452
 cco:ont00000452 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Timekeeping Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized during events in which an Artifact is used to keep track of and report the current time."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Timekeeping Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized during events in which an Artifact is used to keep track of and report the current time."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000453
 cco:ont00000453 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:comment "Controlling air quality typically involves temperature control, oxygen replenishment, and removal of moisture, odor, smoke, heat, dust, airborne bacteria, carbon dioxide, and other undesired gases or particulates."@en ;
-                 rdfs:label "Environment Control System"@en ;
-                 skos:definition "A Material Artifact that is designed to control the temperature, air quality, or other feature of a Site that is relevant to the comfort or operation of entities located within that Site."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:comment "Controlling air quality typically involves temperature control, oxygen replenishment, and removal of moisture, odor, smoke, heat, dust, airborne bacteria, carbon dioxide, and other undesired gases or particulates."@en ;
+                rdfs:label "Environment Control System"@en ;
+                skos:definition "A Material Artifact that is designed to control the temperature, air quality, or other feature of a Site that is relevant to the comfort or operation of entities located within that Site."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000454
 cco:ont00000454 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000742 ;
-                 rdfs:label "Compression Ignition System"@en ;
-                 skos:definition "An Ignition System that is designed to generate heat by compressing a portion of fuel and oxidizer mixture in order to initiate an Ignition process."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000742 ;
+                rdfs:label "Compression Ignition System"@en ;
+                skos:definition "An Ignition System that is designed to generate heat by compressing a portion of fuel and oxidizer mixture in order to initiate an Ignition process."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000456
 cco:ont00000456 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001326 ;
-                 rdfs:label "Railway"@en ;
-                 skos:definition "A Land Transportation Artifact that is designed to enable Trains to transport passengers and goods."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rail_transport&oldid=1063793805" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001326 ;
+                rdfs:label "Railway"@en ;
+                skos:definition "A Land Transportation Artifact that is designed to enable Trains to transport passengers and goods."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rail_transport&oldid=1063793805" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000457
 cco:ont00000457 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001084 ;
-                 rdfs:label "Portion of Material"@en ;
-                 skos:definition "A Portion of Processed Material that was produced to be used as the input for another Act of Artifact Processing."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001084 ;
+                rdfs:label "Portion of Material"@en ;
+                skos:definition "A Portion of Processed Material that was produced to be used as the input for another Act of Artifact Processing."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000458
 cco:ont00000458 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Coupling"@en ;
-                 skos:definition "A Material Artifact that is designed to connect two Shafts together at their ends for the purpose of transmitting power."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Coupling&oldid=1055718683"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Coupling"@en ;
+                skos:definition "A Material Artifact that is designed to connect two Shafts together at their ends for the purpose of transmitting power."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Coupling&oldid=1055718683"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000461
 cco:ont00000461 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000966 ;
-                 rdfs:label "ISSN Barcode"@en ;
-                 skos:definition "An EAN Barcode that is used to designate periodicals."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000966 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002026
+                                ] ;
+                rdfs:label "Material Copy of a ISSN Barcode"@en ;
+                skos:altLabel "ISSN Barcode"@en ;
+                skos:definition "An EAN Barcode that is used to designate periodicals."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000466
 cco:ont00000466 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Orientation Control Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized by processes in which some Artifact is used to control the Orientation of some object."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Orientation Control Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized by processes in which some Artifact is used to control the Orientation of some object."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000467
 cco:ont00000467 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000427 ;
-                 rdfs:label "Armored Personnel Carrier"@en ;
-                 skos:definition "An Armored Fighting Vehicle that is designed to transport infantry to the battlefield but which are not usually designed to take part in a direct-fire battle."@en ;
-                 cco:ont00001753 "APC" ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Armoured_personnel_carrier&oldid=1061608326"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000427 ;
+                rdfs:label "Armored Personnel Carrier"@en ;
+                skos:definition "An Armored Fighting Vehicle that is designed to transport infantry to the battlefield but which are not usually designed to take part in a direct-fire battle."@en ;
+                cco:ont00001753 "APC" ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Armoured_personnel_carrier&oldid=1061608326"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000470
 cco:ont00000470 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000189 ;
-                 rdfs:label "Academic Degree"@en ;
-                 skos:definition "A Certificate issued by an Educational Organization to a Person to indicate that the Person has satisfactorily completed a course of study, or as an honorary recognition of the Person's achievement."@en ;
-                 cco:ont00001754 "http://www.dictionary.com/browse/degree" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000189 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002003
+                                ] ;
+                rdfs:label "Material Copy of a Academic Degree"@en ;
+                skos:altLabel "Academic Degree"@en ;
+                skos:definition "A Certificate issued by an Educational Organization to a Person to indicate that the Person has satisfactorily completed a course of study, or as an honorary recognition of the Person's achievement."@en ;
+                cco:ont00001754 "http://www.dictionary.com/browse/degree" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000471
 cco:ont00000471 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001046 ;
-                 rdfs:label "Warning Message"@en ;
-                 skos:definition "A Notification Message that is designed to bear an Information Content Entity that describes a possible or impending threat."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001046 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002011
+                                ] ;
+                rdfs:label "Material Copy of a Warning Message"@en ;
+                skos:altLabel "Warning Message"@en ;
+                skos:definition "A Notification Message that is designed to bear an Information Content Entity that describes a possible or impending threat."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000475
 cco:ont00000475 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000537 ;
-                 rdfs:label "Portion of Cash"@en ;
-                 skos:definition "A Financial Instrument that is designed to be a ready medium of exchange."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000537 ;
+                rdfs:label "Portion of Cash"@en ;
+                skos:definition "A Financial Instrument that is designed to be a ready medium of exchange."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000477
 cco:ont00000477 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001049 ;
-                 rdfs:label "Fuel Cell"@en ;
-                 skos:definition "An Electrical Power Source that consists in part of an anode, a cathode, and an electrolyte; converts chemical energy from a fuel into electricity through a chemical reaction of positively charged hydrogen ions with an oxidizing agent (typically oxygen); and, if given a continuous source of fuel and oxidizing agent, can continuously produce electricity."@en ;
-                 skos:scopeNote "A Fuel Cell differs from a Battery in that it requires a continuous source of fuel and oxygen to sustain the chemical reaction, whereas a Battery only uses chemicals already stored inside it."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Fuel_cell&oldid=1063586731"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001049 ;
+                rdfs:label "Fuel Cell"@en ;
+                skos:definition "An Electrical Power Source that consists in part of an anode, a cathode, and an electrolyte; converts chemical energy from a fuel into electricity through a chemical reaction of positively charged hydrogen ions with an oxidizing agent (typically oxygen); and, if given a continuous source of fuel and oxidizing agent, can continuously produce electricity."@en ;
+                skos:scopeNote "A Fuel Cell differs from a Battery in that it requires a continuous source of fuel and oxygen to sustain the chemical reaction, whereas a Battery only uses chemicals already stored inside it."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Fuel_cell&oldid=1063586731"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000480
 cco:ont00000480 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Life Support Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized during events in which an Artifact materially affects an organism, where this causes that organism to continue living in a situation where death would otherwise occur."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Life Support Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized during events in which an Artifact materially affects an organism, where this causes that organism to continue living in a situation where death would otherwise occur."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000481
 cco:ont00000481 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001301 ;
-                 rdfs:label "Research and Development Artifact Function"@en ;
-                 skos:definition "A Service Artifact Function that is realized in processes of producing new knowledge or of devising new applications of existing knowledge."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Research_and_development&oldid=1062181110"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001301 ;
+                rdfs:label "Research and Development Artifact Function"@en ;
+                skos:definition "A Service Artifact Function that is realized in processes of producing new knowledge or of devising new applications of existing knowledge."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Research_and_development&oldid=1062181110"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000482
 cco:ont00000482 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000289 ;
-                 rdfs:label "Synthetic Aperture Radar Imaging Artifact Function"@en ;
-                 skos:definition "A Radar Imaging Artifact Function that inheres in Artifacts that are designed to produce visual representations of entities using the motion of a radar antenna over a targeted region to create a synthetic aperture."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000289 ;
+                rdfs:label "Synthetic Aperture Radar Imaging Artifact Function"@en ;
+                skos:definition "A Radar Imaging Artifact Function that inheres in Artifacts that are designed to produce visual representations of entities using the motion of a radar antenna over a targeted region to create a synthetic aperture."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000488
 cco:ont00000488 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Tripod"@en ;
-                 skos:definition "A Material Artifact that consists of three legs and a platform that joins them and which is designed to support the weight and maintain the stability of objects that are attached to or rested on the platform."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Tripod&oldid=1063988190"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Tripod"@en ;
+                skos:definition "A Material Artifact that consists of three legs and a platform that joins them and which is designed to support the weight and maintain the stability of objects that are attached to or rested on the platform."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Tripod&oldid=1063988190"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000491
 cco:ont00000491 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Detonating Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in processes of combustion involving a supersonic exothermic front accelerating through a medium that eventually drives a shock front propagating directly in front of it."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Detonation&oldid=1061553336"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Detonating Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in processes of combustion involving a supersonic exothermic front accelerating through a medium that eventually drives a shock front propagating directly in front of it."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Detonation&oldid=1061553336"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000493
 cco:ont00000493 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000799 ;
-                 rdfs:label "Code List"@en ;
-                 skos:definition "A List that contains an ordered sequence of Information Bearing Entities that carry Code Identifiers."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000799 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002008
+                                ] ;
+                rdfs:label "Material Copy of a Code List"@en ;
+                skos:altLabel "Code List"@en ;
+                skos:definition "A List that contains an ordered sequence of Information Bearing Entities that carry Code Identifiers."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000495
 cco:ont00000495 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000273 ;
-                 rdfs:label "Radio Communication Interference Artifact Function"@en ;
-                 skos:definition "A Communication Interference Artifact Function that is realized during events in which an Artifact is used to interfere with the transmission of information via radio waves."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000273 ;
+                rdfs:label "Radio Communication Interference Artifact Function"@en ;
+                skos:definition "A Communication Interference Artifact Function that is realized during events in which an Artifact is used to interfere with the transmission of information via radio waves."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000499
 cco:ont00000499 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001192 ;
-                 rdfs:label "Wire Antenna"@en ;
-                 skos:definition "A Radio Antenna that consists primarily of a length of wire."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001192 ;
+                rdfs:label "Wire Antenna"@en ;
+                skos:definition "A Radio Antenna that consists primarily of a length of wire."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000504
 cco:ont00000504 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Optical Processing Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized by an Artifact participating in a visible light processing event."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Optical Processing Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized by an Artifact participating in a visible light processing event."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000516
 cco:ont00000516 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000288 ;
-                 rdfs:label "Pneumatic Power Source"@en ;
-                 skos:definition "A Power Source that is designed to generate, control, or transmit power by means of compressed air or compressed inert gases."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000288 ;
+                rdfs:label "Pneumatic Power Source"@en ;
+                skos:definition "A Power Source that is designed to generate, control, or transmit power by means of compressed air or compressed inert gases."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000522
 cco:ont00000522 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000294 ;
-                 rdfs:label "Pulsejet Engine"@en ;
-                 skos:altLabel "Pulse Jet"@en ,
-                               "Pulsejet"@en ;
-                 skos:definition "An Air-Breathing Jet Engine that is capable of operating statically and uses intermittent (pulsing) Combustion of the fuel-oxidizer mixture before expelling the exhaust out through the rear Propelling Nozzle to generate Thrust."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Pulsejet&oldid=1050473545"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000294 ;
+                rdfs:label "Pulsejet Engine"@en ;
+                skos:altLabel "Pulse Jet"@en ,
+                              "Pulsejet"@en ;
+                skos:definition "An Air-Breathing Jet Engine that is capable of operating statically and uses intermittent (pulsing) Combustion of the fuel-oxidizer mixture before expelling the exhaust out through the rear Propelling Nozzle to generate Thrust."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Pulsejet&oldid=1050473545"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000524
 cco:ont00000524 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000350 ;
-                 rdfs:label "Air Conditioning Unit"@en ;
-                 skos:altLabel "AC Unit"@en ;
-                 skos:definition "A Cooling System that is designed to remove excess heat and humidity from the air in an enclosed space."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Air_conditioning&oldid=1063494896"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000350 ;
+                rdfs:label "Air Conditioning Unit"@en ;
+                skos:altLabel "AC Unit"@en ;
+                skos:definition "A Cooling System that is designed to remove excess heat and humidity from the air in an enclosed space."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Air_conditioning&oldid=1063494896"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000526
 cco:ont00000526 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000547 ;
-                 rdfs:label "Gamma-ray Telescope"@en ;
-                 skos:definition "A Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing Gamma-rays to form an enhanced image of the Object."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telescope&oldid=1057722342"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000547 ;
+                rdfs:label "Gamma-ray Telescope"@en ;
+                skos:definition "A Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing Gamma-rays to form an enhanced image of the Object."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telescope&oldid=1057722342"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000533
 cco:ont00000533 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000056 ;
-                 rdfs:comment "Some (most) jet engines utilize turbines, but some do not. Most rocket engines do not utilize turbines, but some do."@en ;
-                 rdfs:label "Jet Engine"@en ;
-                 skos:definition "A Reaction Engine that discharges a fast moving jet that generates Thrust by jet propulsion."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Jet_engine&oldid=1060157063"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000056 ;
+                rdfs:comment "Some (most) jet engines utilize turbines, but some do not. Most rocket engines do not utilize turbines, but some do."@en ;
+                rdfs:label "Jet Engine"@en ;
+                skos:definition "A Reaction Engine that discharges a fast moving jet that generates Thrust by jet propulsion."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Jet_engine&oldid=1060157063"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000534
 cco:ont00000534 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001153 ;
-                 rdfs:label "Cutting Artifact Function"@en ;
-                 skos:definition "A Damaging Artifact Function that is realized in a process in which the structural integrity of an entity is impaired by being opened or divided."@en ;
-                 cco:ont00001754 "http://www.dictionary.com/browse/cutting" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001153 ;
+                rdfs:label "Cutting Artifact Function"@en ;
+                skos:definition "A Damaging Artifact Function that is realized in a process in which the structural integrity of an entity is impaired by being opened or divided."@en ;
+                cco:ont00001754 "http://www.dictionary.com/browse/cutting" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000536
 cco:ont00000536 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001159 ;
-                 rdfs:label "Bond Certificate"@en ;
-                 skos:definition "A Bond that consists of a Certificate."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001159 ;
+                rdfs:label "Bond Certificate"@en ;
+                skos:definition "A Bond that consists of a Certificate."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000537
 cco:ont00000537 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Financial Instrument"@en ;
-                 skos:definition "A Material Artifact that is designed to be a tradeable asset and that is legally sanctioned."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Finance&oldid=1062402926"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Financial Instrument"@en ;
+                skos:definition "A Material Artifact that is designed to be a tradeable asset and that is legally sanctioned."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Finance&oldid=1062402926"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000538
 cco:ont00000538 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000831 ;
-                 rdfs:label "Defoliant Artifact Function"@en ;
-                 skos:definition "An Herbicide Artifact Function that is realized in a process that causes a plant to lose its leaves."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Defoliant&oldid=1059494225"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000831 ;
+                rdfs:label "Defoliant Artifact Function"@en ;
+                skos:definition "An Herbicide Artifact Function that is realized in a process that causes a plant to lose its leaves."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Defoliant&oldid=1059494225"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000547
 cco:ont00000547 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000771 ;
-                 rdfs:label "Telescope"@en ;
-                 skos:definition "An Imaging Instrument that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing Electromagnetic Radiation to form an enhanced image of the Object."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telescope&oldid=1057722342"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000771 ;
+                rdfs:label "Telescope"@en ;
+                skos:definition "An Imaging Instrument that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing Electromagnetic Radiation to form an enhanced image of the Object."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telescope&oldid=1057722342"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000549
 cco:ont00000549 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000254 ;
-                 rdfs:label "Water Transportation Artifact"@en ;
-                 skos:definition "A Transportation Artifact that is fixed in place and designed to bear a Function, the realization of which is sometimes part of a process of moving Vehicles and Agents from one location to another via water."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000254 ;
+                rdfs:label "Water Transportation Artifact"@en ;
+                skos:definition "A Transportation Artifact that is fixed in place and designed to bear a Function, the realization of which is sometimes part of a process of moving Vehicles and Agents from one location to another via water."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000552
 cco:ont00000552 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000445 ;
-                 rdfs:label "Explosive Weapon"@en ;
-                 skos:altLabel "Bomb"@en ;
-                 skos:definition "A Weapon that is designed to inflict harm, damage, or incapacity by means of a violent release of energy caused by the exothermic reaction of an explosive material."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Explosive_weapon&oldid=1062481268"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000445 ;
+                rdfs:label "Explosive Weapon"@en ;
+                skos:altLabel "Bomb"@en ;
+                skos:definition "A Weapon that is designed to inflict harm, damage, or incapacity by means of a violent release of energy caused by the exothermic reaction of an explosive material."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Explosive_weapon&oldid=1062481268"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000556
 cco:ont00000556 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000040 ;
-                 rdfs:comment "Depending on the nature of the Flight or Mission, the Payload of a Vehicle may include cargo, passengers, flight crew, munitions, scientific instruments or experiments, or other equipment. Extra fuel, when optionally carried, is also considered part of the payload."@en ;
-                 rdfs:label "Payload"@en ;
-                 skos:definition "A Material Entity that is transported by a Vehicle during an Act of Location Change for the purpose of being delivered to or performing one or more functions at a predefined location."@en ;
-                 skos:scopeNote "In each case, the Payload is what provides the immediate reason for performing the Act of Location Change (e.g. transporting the passengers of a commercial airline flight to their destination; transporting food, fuel, oxygen, research equipment, and spare parts to the International Space Station; or conveying an array of sensors, cameras, and communications systems so they can operate during a Sun-Synchronous Earth Orbit)."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Payload&oldid=1035953573"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000040 ;
+                rdfs:comment "Depending on the nature of the Flight or Mission, the Payload of a Vehicle may include cargo, passengers, flight crew, munitions, scientific instruments or experiments, or other equipment. Extra fuel, when optionally carried, is also considered part of the payload."@en ;
+                rdfs:label "Payload"@en ;
+                skos:definition "A Material Entity that is transported by a Vehicle during an Act of Location Change for the purpose of being delivered to or performing one or more functions at a predefined location."@en ;
+                skos:scopeNote "In each case, the Payload is what provides the immediate reason for performing the Act of Location Change (e.g. transporting the passengers of a commercial airline flight to their destination; transporting food, fuel, oxygen, research equipment, and spare parts to the International Space Station; or conveying an array of sensors, cameras, and communications systems so they can operate during a Sun-Synchronous Earth Orbit)."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Payload&oldid=1035953573"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000559
 cco:ont00000559 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000241 ;
-                 rdfs:label "QR Code"@en ;
-                 skos:definition "A Two-Dimensional Barcode that consists of numeric, alphanumeric, binary, or kanji information and is used primarily for tracking and marketing."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000241 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002018
+                                ] ;
+                rdfs:label "Material Copy of a QR Code"@en ;
+                skos:altLabel "QR Code"@en ;
+                skos:definition "A Two-Dimensional Barcode that consists of numeric, alphanumeric, binary, or kanji information and is used primarily for tracking and marketing."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000561
 cco:ont00000561 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Dam"@en ;
-                 skos:definition "A Material Artifact that is designed to impound surface water or underground streams."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Dam&oldid=1053601756" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Dam"@en ;
+                skos:definition "A Material Artifact that is designed to impound surface water or underground streams."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Dam&oldid=1053601756" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000569
 cco:ont00000569 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000736 ;
-                 rdfs:label "Sensor"@en ;
-                 skos:definition "A Transducer that is designed to convert incoming energy into a output signal which reliably corresponds to changes in that energy."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Sensor&oldid=1059883466"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000736 ;
+                rdfs:label "Sensor"@en ;
+                skos:definition "A Transducer that is designed to convert incoming energy into a output signal which reliably corresponds to changes in that energy."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Sensor&oldid=1059883466"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000571
 cco:ont00000571 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000980 ;
-                 rdfs:label "Article of Solid Waste"@en ;
-                 skos:definition "A Portion of Waste Material that has a low liquid content."@en ;
-                 cco:ont00001754 "https://stats.oecd.org/glossary/detail.asp?ID=2508" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000980 ;
+                rdfs:label "Article of Solid Waste"@en ;
+                skos:definition "A Portion of Waste Material that has a low liquid content."@en ;
+                cco:ont00001754 "https://stats.oecd.org/glossary/detail.asp?ID=2508" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000575
 cco:ont00000575 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00000965
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001942 ;
-                                                              owl:someValuesFrom obo:BFO_0000019
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00000965 ;
-                 rdfs:label "Quality Specification"@en ;
-                 skos:definition "A Directive Information Content Entity that prescribes some Quality."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000965
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001942 ;
+                                                             owl:someValuesFrom obo:BFO_0000019
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000965 ;
+                rdfs:label "Quality Specification"@en ;
+                skos:definition "A Directive Information Content Entity that prescribes some Quality."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000577
 cco:ont00000577 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Power Rectifier"@en ;
-                 skos:definition "A Material Artifact that is designed to convert alternating current (AC) to direct current (DC)."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rectifier&oldid=1049943028"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Power Rectifier"@en ;
+                skos:definition "A Material Artifact that is designed to convert alternating current (AC) to direct current (DC)."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rectifier&oldid=1049943028"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000581
 cco:ont00000581 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Tool"@en ;
-                 skos:definition "A Material Artifact that is designed to assist in the performance of manual or mechanical work and not to be consumed in that process."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Tool&oldid=1061967184"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Tool"@en ;
+                skos:definition "A Material Artifact that is designed to assist in the performance of manual or mechanical work and not to be consumed in that process."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Tool&oldid=1061967184"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000582
 cco:ont00000582 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000258 ;
-                 rdfs:label "Code 93 Barcode"@en ;
-                 skos:definition "A One-Dimensional Barcode that consists of up to 93 ASCII characters and is used in logistics to identify packages in retail inventory, lable electornic components, and provide supplementary delivery information."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000258 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002022
+                                ] ;
+                rdfs:label "Material Copy of a Code 93 Barcode"@en ;
+                skos:altLabel "Code 93 Barcode"@en ;
+                skos:definition "A One-Dimensional Barcode that consists of up to 93 ASCII characters and is used in logistics to identify packages in retail inventory, lable electornic components, and provide supplementary delivery information."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000586
 cco:ont00000586 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000238 ;
-                 rdfs:label "Controllable Pitch Propeller"@en ;
-                 skos:altLabel "Variable-Pitch Propeller"@en ;
-                 skos:definition "A Propeller whose blades are designed to be alterable by rotating the blades about their vertical axis by means of mechanical or hydraulic arrangement."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Variable-pitch_propeller&oldid=1041375492"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000238 ;
+                rdfs:label "Controllable Pitch Propeller"@en ;
+                skos:altLabel "Variable-Pitch Propeller"@en ;
+                skos:definition "A Propeller whose blades are designed to be alterable by rotating the blades about their vertical axis by means of mechanical or hydraulic arrangement."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Variable-pitch_propeller&oldid=1041375492"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000591
 cco:ont00000591 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000029
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty obo:BFO_0000124 ;
-                                                              owl:someValuesFrom cco:ont00000995
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf obo:BFO_0000029 ;
-                 rdfs:label "Artifact Location"@en ;
-                 skos:definition "A Site that is the location of some Artifact."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000029
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:BFO_0000124 ;
+                                                             owl:someValuesFrom cco:ont00000995
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:BFO_0000029 ;
+                rdfs:label "Artifact Location"@en ;
+                skos:definition "A Site that is the location of some Artifact."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000593
 cco:ont00000593 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000457 ;
-                 rdfs:label "Portion of Propellant"@en ;
-                 skos:definition "A Portion of Material that is designed to be used as an input in a Propulsion Process to produce Thrust."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000457 ;
+                rdfs:label "Portion of Propellant"@en ;
+                skos:definition "A Portion of Material that is designed to be used as an input in a Propulsion Process to produce Thrust."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000596
 cco:ont00000596 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000966 ;
-                 rdfs:label "JAN-13 Barcode"@en ;
-                 skos:definition "An EAN Barcode that consists of 13 numerical digits and is used primarily in Japan to designate products at the point of sale."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000966 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002027
+                                ] ;
+                rdfs:label "Material Copy of a JAN-13 Barcode"@en ;
+                skos:altLabel "JAN-13 Barcode"@en ;
+                skos:definition "An EAN Barcode that consists of 13 numerical digits and is used primarily in Japan to designate products at the point of sale."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000597
 cco:ont00000597 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000798 ;
-                 rdfs:label "Instrument Display Panel"@en ;
-                 skos:definition "An Information Bearing Artifact that is designed to bear information about some Artifact that is derived by the instrumentation Sensors of that Artifact."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Flight_instruments&oldid=1062972990"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000798 ;
+                rdfs:label "Material Copy of a Instrument Display Panel"@en ;
+                skos:altLabel "Instrument Display Panel"@en ;
+                skos:definition "An Information Bearing Artifact that is designed to bear information about some Artifact that is derived by the instrumentation Sensors of that Artifact."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Flight_instruments&oldid=1062972990"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000598
 cco:ont00000598 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000256 ;
-                 rdfs:label "Valve"@en ;
-                 skos:definition "A Fluid Control Artifact that is designed to regulate, direct, or control the flow of fluid by opening, closing, or partially obstructing the fluid from moving along a passageway."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Valve&oldid=1048906126"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000256 ;
+                rdfs:label "Valve"@en ;
+                skos:definition "A Fluid Control Artifact that is designed to regulate, direct, or control the flow of fluid by opening, closing, or partially obstructing the fluid from moving along a passageway."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Valve&oldid=1048906126"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000600
 cco:ont00000600 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001301 ;
-                 rdfs:label "Legal Artifact Function"@en ;
-                 skos:definition "A Service Artifact Function that is realized in processes of giving legal advice to clients drafting legal documents for clients and representing clients in legal negotiations and court proceedings such as lawsuits."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Law&oldid=1060821734"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001301 ;
+                rdfs:label "Legal Artifact Function"@en ;
+                skos:definition "A Service Artifact Function that is realized in processes of giving legal advice to clients drafting legal documents for clients and representing clients in legal negotiations and court proceedings such as lawsuits."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Law&oldid=1060821734"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000601
 cco:ont00000601 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Imaging Artifact Function"@en ;
-                 skos:definition "An Artifact Function that inheres in Artifacts that are designed to produce visual representations of entities."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Imaging Artifact Function"@en ;
+                skos:definition "An Artifact Function that inheres in Artifacts that are designed to produce visual representations of entities."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000602
 cco:ont00000602 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000258 ;
-                 rdfs:label "ITF Barcode"@en ;
-                 skos:definition "A One-Dimensional Barcode that consists of an even number of numerical characters and is used primarily in packaging and distribution."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000258 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002023
+                                ] ;
+                rdfs:label "Material Copy of a ITF Barcode"@en ;
+                skos:altLabel "ITF Barcode"@en ;
+                skos:definition "A One-Dimensional Barcode that consists of an even number of numerical characters and is used primarily in packaging and distribution."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000603
 cco:ont00000603 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Navigation Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized during events in which an Artifact is used to determine the precise location of itself or another object and plan a route to a specified destination."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Navigation Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized during events in which an Artifact is used to determine the precise location of itself or another object and plan a route to a specified destination."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000606
 cco:ont00000606 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000053 ;
-                 rdfs:comment "Trucks vary greatly in their size and power -- ranging from small ultra-light trucks to enormous heavy trucks. Trucks also vary greatly in their configurations -- ranging from very basic flatbeds or box trucks to highly specialized cargo carriers. Trucks may also be configured to mount specialized equipment, such as in the case of fire trucks, concrete mixers, and suction excavators."@en ;
-                 rdfs:label "Truck"@en ;
-                 skos:definition "A Ground Motor Vehicle that is designed to be used to transport cargo."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Truck&oldid=1060924486"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000053 ;
+                rdfs:comment "Trucks vary greatly in their size and power -- ranging from small ultra-light trucks to enormous heavy trucks. Trucks also vary greatly in their configurations -- ranging from very basic flatbeds or box trucks to highly specialized cargo carriers. Trucks may also be configured to mount specialized equipment, such as in the case of fire trucks, concrete mixers, and suction excavators."@en ;
+                rdfs:label "Truck"@en ;
+                skos:definition "A Ground Motor Vehicle that is designed to be used to transport cargo."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Truck&oldid=1060924486"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000617
 cco:ont00000617 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000199 ;
-                 rdfs:label "Infrared Camera"@en ;
-                 skos:altLabel "Thermal Imaging Camera"@en ,
-                               "Thermographic Camera"@en ;
-                 skos:definition "A Camera that is designed to form and record an image generated from infrared radiation."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Thermographic_camera&oldid=1063916009"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000199 ;
+                rdfs:label "Infrared Camera"@en ;
+                skos:altLabel "Thermal Imaging Camera"@en ,
+                              "Thermographic Camera"@en ;
+                skos:definition "A Camera that is designed to form and record an image generated from infrared radiation."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Thermographic_camera&oldid=1063916009"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000618
 cco:ont00000618 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000713 ;
-                 rdfs:label "Ground Vehicle"@en ;
-                 skos:definition "A Vehicle that is designed to convey passengers, cargo, or equipment from one location to another by some form of ground travel."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Category:Land_vehicles&oldid=546083623"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000713 ;
+                rdfs:label "Ground Vehicle"@en ;
+                skos:definition "A Vehicle that is designed to convey passengers, cargo, or equipment from one location to another by some form of ground travel."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Category:Land_vehicles&oldid=546083623"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000623
 cco:ont00000623 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Impact Shielding Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized during events in which an Artifact reduces the damage caused to the shielded object by an impact with another object."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Impact Shielding Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized during events in which an Artifact reduces the damage caused to the shielded object by an impact with another object."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000624
 cco:ont00000624 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001298 ;
-                 rdfs:label "Report"@en ;
-                 skos:definition "A Document that is designed to bear some specific Information Content Entity that conveys an account of some event, situation, or the result of some observation or inquiry."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Report&oldid=1063765657"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001298 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002043
+                                ] ;
+                rdfs:label "Material Copy of a Report"@en ;
+                skos:altLabel "Report"@en ;
+                skos:definition "A Document that is designed to bear some specific Information Content Entity that conveys an account of some event, situation, or the result of some observation or inquiry."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Report&oldid=1063765657"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000625
 cco:ont00000625 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000256 ;
-                 rdfs:label "Nozzle Throat"@en ;
-                 skos:definition "A Fluid Control Artifact that consists of the narrowest portion of a Nozzle that is designed to converge the flow of fluid in order to increase the Velocity of the flow."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000256 ;
+                rdfs:label "Nozzle Throat"@en ;
+                skos:definition "A Fluid Control Artifact that consists of the narrowest portion of a Nozzle that is designed to converge the flow of fluid in order to increase the Velocity of the flow."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000627
 cco:ont00000627 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000040
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty obo:BFO_0000196 ;
-                                                              owl:someValuesFrom cco:ont00001141
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf obo:BFO_0000040 ;
-                 rdfs:label "Infrastructure Element"@en ;
-                 skos:definition "A Material Entity that bears an Infrastructure Role."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000040
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:BFO_0000196 ;
+                                                             owl:someValuesFrom cco:ont00001141
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:BFO_0000040 ;
+                rdfs:label "Infrastructure Element"@en ;
+                skos:definition "A Material Entity that bears an Infrastructure Role."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000629
 cco:ont00000629 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Deception Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in processes which misinform or mislead some other entity."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Deception&oldid=1061346984"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Deception Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in processes which misinform or mislead some other entity."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Deception&oldid=1061346984"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000634
 cco:ont00000634 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000431 ;
-                 rdfs:label "Steam Engine"@en ;
-                 skos:definition "An External Combustion Engine that is designed to use steam as its working fluid."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Steam_engine&oldid=1064097686"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000431 ;
+                rdfs:label "Steam Engine"@en ;
+                skos:definition "An External Combustion Engine that is designed to use steam as its working fluid."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Steam_engine&oldid=1064097686"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000635
 cco:ont00000635 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Refraction Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized by an Artifact participating in a refraction event in which the Artifact causes a change in direction of wave propagation due to a change in its transmission medium."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Refraction Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized by an Artifact participating in a refraction event in which the Artifact causes a change in direction of wave propagation due to a change in its transmission medium."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000637
 cco:ont00000637 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000593 ;
-                 rdfs:label "Portion of Gaseous Propellant"@en ;
-                 skos:definition "A Portion of Propellant that is stored in a gaseous state."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000593 ;
+                rdfs:label "Portion of Gaseous Propellant"@en ;
+                skos:definition "A Portion of Propellant that is stored in a gaseous state."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000638
 cco:ont00000638 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000210 ;
-                 rdfs:label "Heat Engine"@en ;
-                 skos:definition "An Engine that is designed to convert thermal energy into mechanical energy."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000210 ;
+                rdfs:label "Heat Engine"@en ;
+                skos:definition "An Engine that is designed to convert thermal energy into mechanical energy."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000640
 cco:ont00000640 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001002 ;
-                 rdfs:label "Email Message"@en ;
-                 skos:definition "A Message that is transmitted to the recipient's Email Box."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Email&oldid=1063646749"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001002 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002012
+                                ] ;
+                rdfs:label "Material Copy of a Email Message"@en ;
+                skos:altLabel "Email Message"@en ;
+                skos:definition "A Message that is transmitted to the recipient's Email Box."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Email&oldid=1063646749"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000646
 cco:ont00000646 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000247 ;
-                 rdfs:label "Highway"@en ;
-                 skos:definition "A Road that is designed to enable Ground Vehicles to travel between relatively major destinations."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Highway&oldid=1063985949"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000247 ;
+                rdfs:label "Highway"@en ;
+                skos:definition "A Road that is designed to enable Ground Vehicles to travel between relatively major destinations."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Highway&oldid=1063985949"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000650
 cco:ont00000650 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000214 ;
-                 rdfs:label "Ground Moving Target Indication Artifact Function"@en ;
-                 skos:definition "A Moving Target Indication Artifact Function that inheres in Artifacts that are designed to identify and track entities moving on or near the ground."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000214 ;
+                rdfs:label "Ground Moving Target Indication Artifact Function"@en ;
+                skos:definition "A Moving Target Indication Artifact Function that inheres in Artifacts that are designed to identify and track entities moving on or near the ground."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000651
 cco:ont00000651 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Containing Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in a process in which one entity contains another."@en ;
-                 cco:ont00001754 "http://www.dictionary.com/browse/containing" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Containing Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in a process in which one entity contains another."@en ;
+                cco:ont00001754 "http://www.dictionary.com/browse/containing" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000652
 cco:ont00000652 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Decoy"@en ;
-                 skos:definition "A Material Artifact that is designed to distract or conceal what an individual or group might be looking for."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Decoy&oldid=1058455081"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Decoy"@en ;
+                skos:definition "A Material Artifact that is designed to distract or conceal what an individual or group might be looking for."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Decoy&oldid=1058455081"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000656
 cco:ont00000656 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000445 ;
-                 rdfs:label "Radiological Weapon"@en ;
-                 skos:definition "A Weapon that is designed to inflict harm, damage, or incapacity by means of releasing radioactive material."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Radiological_warfare&oldid=1060817328"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000445 ;
+                rdfs:label "Radiological Weapon"@en ;
+                skos:definition "A Weapon that is designed to inflict harm, damage, or incapacity by means of releasing radioactive material."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Radiological_warfare&oldid=1060817328"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000657
 cco:ont00000657 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001100 ;
-                 rdfs:label "Distance Measurement Artifact Function"@en ;
-                 skos:definition "A Measurement Artifact Function that is realized during events in which an Artifact is used to measure the spatial Distance to a specified object or class of objects."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001100 ;
+                rdfs:label "Distance Measurement Artifact Function"@en ;
+                skos:definition "A Measurement Artifact Function that is realized during events in which an Artifact is used to measure the spatial Distance to a specified object or class of objects."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000658
 cco:ont00000658 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001051 ;
-                 rdfs:label "Missile Launcher"@en ;
-                 skos:definition "A Projectile Launcher that is designed to launch one or more Precision-Guided Missiles."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001051 ;
+                rdfs:label "Missile Launcher"@en ;
+                skos:definition "A Projectile Launcher that is designed to launch one or more Precision-Guided Missiles."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000661
 cco:ont00000661 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001301 ;
-                 rdfs:label "Government Artifact Function"@en ;
-                 skos:definition "A Service Artifact Function that is realized in processes in which public policy is administered and the actions of its members are directed."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Government&oldid=1063736308"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001301 ;
+                rdfs:label "Government Artifact Function"@en ;
+                skos:definition "A Service Artifact Function that is realized in processes in which public policy is administered and the actions of its members are directed."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Government&oldid=1063736308"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000663
 cco:ont00000663 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Power Transmission Artifact"@en ;
-                 skos:definition "A Material Artifact that is designed to transfer and regulate Power flow from a Power Source to an application point."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Power Transmission Artifact"@en ;
+                skos:definition "A Material Artifact that is designed to transfer and regulate Power flow from a Power Source to an application point."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000665
 cco:ont00000665 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Cleaning Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in processes in which some Artifact is used to remove foreign objects from another object."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Cleaning Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in processes in which some Artifact is used to remove foreign objects from another object."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000668
 cco:ont00000668 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Battery Terminal"@en ;
-                 skos:definition "A Material Artifact that is designed to connect a load or charger to a single or multiple-cell Battery."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Battery_terminal&oldid=1059455659"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Battery Terminal"@en ;
+                skos:definition "A Material Artifact that is designed to connect a load or charger to a single or multiple-cell Battery."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Battery_terminal&oldid=1059455659"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000671
 cco:ont00000671 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000415 ;
-                 rdfs:label "Anti-Bacterial Artifact Function"@en ;
-                 skos:definition "An Anti-Microbial Artifact Function that is realized in a process which causes harm to, or the death of, some bacterium."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Antibiotic&oldid=1063633090"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000415 ;
+                rdfs:label "Anti-Bacterial Artifact Function"@en ;
+                skos:definition "An Anti-Microbial Artifact Function that is realized in a process which causes harm to, or the death of, some bacterium."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Antibiotic&oldid=1063633090"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000673
 cco:ont00000673 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000715 ;
-                 rdfs:label "Prosthetic Foot"@en ;
-                 skos:definition "A Prosthesis that is designed to replace a missing foot."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Prosthesis&oldid=1063749698"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000715 ;
+                rdfs:label "Prosthetic Foot"@en ;
+                skos:definition "A Prosthesis that is designed to replace a missing foot."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Prosthesis&oldid=1063749698"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000678
 cco:ont00000678 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000098 ;
-                 rdfs:label "Voltage Regulating Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized by processes in which some Artifact is used to cause a change in the voltage magnitude between the sending and receiving end of an electrical component."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Voltage_regulation&oldid=1045628774"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000098 ;
+                rdfs:label "Voltage Regulating Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized by processes in which some Artifact is used to cause a change in the voltage magnitude between the sending and receiving end of an electrical component."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Voltage_regulation&oldid=1045628774"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000679
 cco:ont00000679 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Attitude Control Artifact Function"@en ;
-                 skos:altLabel "Orientation Control Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized by an Artifact participating in an attitude control process."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Attitude Control Artifact Function"@en ;
+                skos:altLabel "Orientation Control Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized by an Artifact participating in an attitude control process."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000681
 cco:ont00000681 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000236 ;
-                 rdfs:label "External Navigation Lighting System"@en ;
-                 skos:definition "A Lighting System that is designed to be attached to some Vehicle and to emit colored light in order to signal that Vehicle's position, heading, and status."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Navigation_light&oldid=1034200601"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000236 ;
+                rdfs:label "External Navigation Lighting System"@en ;
+                skos:definition "A Lighting System that is designed to be attached to some Vehicle and to emit colored light in order to signal that Vehicle's position, heading, and status."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Navigation_light&oldid=1034200601"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000682
 cco:ont00000682 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000136 ;
-                 rdfs:label "Mirror"@en ;
-                 skos:definition "An Optical Instrument that is designed to reflect light that has a wavelength within a given range and is incident on its relflecting surface such that the reflected light maintains most of the characteristics of the original light."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Mirror&oldid=1063296474"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000136 ;
+                rdfs:label "Mirror"@en ;
+                skos:definition "An Optical Instrument that is designed to reflect light that has a wavelength within a given range and is incident on its relflecting surface such that the reflected light maintains most of the characteristics of the original light."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Mirror&oldid=1063296474"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000686
@@ -2472,1045 +2574,1083 @@ cco:ont00000686 rdf:type owl:Class .
 
 ###  https://www.commoncoreontologies.org/ont00000688
 cco:ont00000688 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000294 ;
-                 rdfs:label "Turbofan Air-Breathing Jet Engine"@en ;
-                 skos:definition "An Air-Breathing Jet Engine that uses a Turbofan, which consists of a Turbine and a Fan."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Turbofan&oldid=1063724215"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000294 ;
+                rdfs:label "Turbofan Air-Breathing Jet Engine"@en ;
+                skos:definition "An Air-Breathing Jet Engine that uses a Turbofan, which consists of a Turbine and a Fan."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Turbofan&oldid=1063724215"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000689
 cco:ont00000689 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Switch Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in a process of breaking an electric circuit by interrupting the current or diverting it from one conductor to another."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Switch&oldid=1059685800"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Switch Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in a process of breaking an electric circuit by interrupting the current or diverting it from one conductor to another."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Switch&oldid=1059685800"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000690
 cco:ont00000690 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000346 ;
-                 rdfs:label "Telecommunication Instrument"@en ;
-                 skos:definition "A Communication Instrument that is designed for use by some Agent in some Act of Communication where the recipient of that communication is potentially a significant distance away from the Agent."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000346 ;
+                rdfs:label "Telecommunication Instrument"@en ;
+                skos:definition "A Communication Instrument that is designed for use by some Agent in some Act of Communication where the recipient of that communication is potentially a significant distance away from the Agent."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000691
 cco:ont00000691 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000020 ;
-                 rdfs:label "Fuel Tank"@en ;
-                 skos:definition "A Container that is designed to store a Portion of Fuel."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000020 ;
+                rdfs:label "Fuel Tank"@en ;
+                skos:definition "A Container that is designed to store a Portion of Fuel."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000693
 cco:ont00000693 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000575 ;
-                 rdfs:label "Mass Specification"@en ;
-                 skos:definition "A Quality Specification that prescribes the Amount of Mass that a Material Entity should have."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000575 ;
+                rdfs:label "Mass Specification"@en ;
+                skos:definition "A Quality Specification that prescribes the Amount of Mass that a Material Entity should have."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000694
 cco:ont00000694 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000256 ;
-                 rdfs:label "Nozzle Mouth"@en ;
-                 skos:definition "A Fluid Control Artifact that consists of the portion of a Nozzle at the end that is designed to be where the flow of fluid exits the Nozzle."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000256 ;
+                rdfs:label "Nozzle Mouth"@en ;
+                skos:definition "A Fluid Control Artifact that consists of the portion of a Nozzle at the end that is designed to be where the flow of fluid exits the Nozzle."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000698
 cco:ont00000698 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000252 ;
-                 rdfs:comment "By increasing the Exhaust Velocity of the gas, the Nozzle increases the Thrust generated."@en ;
-                 rdfs:label "Convergent-Divergent Nozzle"@en ;
-                 skos:altLabel "CD Nozzle"@en ,
-                               "de Laval Nozzle"@en ;
-                 skos:definition "A Nozzle that consists of a tube with an asymmetric hourglass shape that is designed to accelerate hot pressurized gas by converting the heat energy of the gas flow into kinetic energy as it passes through the Nozzle Throat to generate increased Exhaust Velocity of the gas as it exits the Nozzle."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=De_Laval_nozzle&oldid=1062746288"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000252 ;
+                rdfs:comment "By increasing the Exhaust Velocity of the gas, the Nozzle increases the Thrust generated."@en ;
+                rdfs:label "Convergent-Divergent Nozzle"@en ;
+                skos:altLabel "CD Nozzle"@en ,
+                              "de Laval Nozzle"@en ;
+                skos:definition "A Nozzle that consists of a tube with an asymmetric hourglass shape that is designed to accelerate hot pressurized gas by converting the heat energy of the gas flow into kinetic energy as it passes through the Nozzle Throat to generate increased Exhaust Velocity of the gas as it exits the Nozzle."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=De_Laval_nozzle&oldid=1062746288"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000700
 cco:ont00000700 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000998 ;
-                 rdfs:label "Computer Network"@en ;
-                 skos:altLabel "Data Network"@en ;
-                 skos:definition "A Telecommunication Network that is designed to allow the exchange of data between two or more computers connected to the network."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Computer_network&oldid=1061571662"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000998 ;
+                rdfs:label "Computer Network"@en ;
+                skos:altLabel "Data Network"@en ;
+                skos:definition "A Telecommunication Network that is designed to allow the exchange of data between two or more computers connected to the network."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Computer_network&oldid=1061571662"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000701
 cco:ont00000701 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001145 ;
-                 rdfs:label "Wire Receiver"@en ;
-                 skos:definition "A Radio Receiver that uses a Wire Antenna to intercept radio signals."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001145 ;
+                rdfs:label "Wire Receiver"@en ;
+                skos:definition "A Radio Receiver that uses a Wire Antenna to intercept radio signals."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000702
 cco:ont00000702 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000798 ;
-                 rdfs:label "Image"@en ;
-                 skos:definition "An Information Bearing Artifact that is designed to carry an Information Content Entity that represents some entity owing to a visual isomorphism between the carrying artifact and the entity."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Image&oldid=1062709732"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000798 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002004
+                                ] ;
+                rdfs:label "Material Copy of a Image"@en ;
+                skos:altLabel "Image"@en ;
+                skos:definition "An Information Bearing Artifact that is designed to carry an Information Content Entity that represents some entity owing to a visual isomorphism between the carrying artifact and the entity."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Image&oldid=1062709732"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000703
 cco:ont00000703 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000159 ;
-                 rdfs:label "System Clock"@en ;
-                 skos:definition "A Timekeeping Instrument that is part of a computer an is designed to issue a steady high-frequency signal that is used to synchronize all of the computer's internal components."@en ;
-                 cco:ont00001754 "http://www.thefreedictionary.com/system+clock" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000159 ;
+                rdfs:label "Material Copy of a System Clock"@en ;
+                skos:altLabel "System Clock"@en ;
+                skos:definition "A Timekeeping Instrument that is part of a computer an is designed to issue a steady high-frequency signal that is used to synchronize all of the computer's internal components."@en ;
+                cco:ont00001754 "http://www.thefreedictionary.com/system+clock" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000704
 cco:ont00000704 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001326 ;
-                 rdfs:label "Tunnel"@en ;
-                 skos:definition "A Land Transportation Artifact that is designed to enable Ground Vehicles to travel underneath a surrounding soil, earth, or rock formation."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Tunnel&oldid=1062456881"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001326 ;
+                rdfs:label "Tunnel"@en ;
+                skos:definition "A Land Transportation Artifact that is designed to enable Ground Vehicles to travel underneath a surrounding soil, earth, or rock formation."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Tunnel&oldid=1062456881"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000706
 cco:ont00000706 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Terminal Board"@en ;
-                 skos:definition "A Material Artifact that is designed to join electrical terminations and create an electrical circuit by means of a block which connects individual wires without a splice or physically joining the ends."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electrical_connector&oldid=1061247409"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Terminal Board"@en ;
+                skos:definition "A Material Artifact that is designed to join electrical terminations and create an electrical circuit by means of a block which connects individual wires without a splice or physically joining the ends."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electrical_connector&oldid=1061247409"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000709
 cco:ont00000709 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001248 ;
-                 rdfs:label "Visual Prosthesis"@en ;
-                 skos:altLabel "Bionic Eye"@en ;
-                 skos:definition "An Artificial Eye that is designed to replace a missing eye, which performs the function of an eye."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Visual_prosthesis&oldid=1059269261"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001248 ;
+                rdfs:label "Visual Prosthesis"@en ;
+                skos:altLabel "Bionic Eye"@en ;
+                skos:definition "An Artificial Eye that is designed to replace a missing eye, which performs the function of an eye."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Visual_prosthesis&oldid=1059269261"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000711
 cco:ont00000711 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000156 ;
-                 rdfs:label "Semi-automatic Pistol"@en ;
-                 skos:definition "A Hand Gun that has a single fixed firing chamber machined into the rear of the barrel and an ammunition magazine capable of holding multiple Cartridges such that the Hand Gun is designed to automatically reload each time it is fired and to fire a Bullet with each successive pull of the trigger until the stored ammunition is depleted."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Semi-automatic_pistol&oldid=1058568715"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000156 ;
+                rdfs:label "Semi-automatic Pistol"@en ;
+                skos:definition "A Hand Gun that has a single fixed firing chamber machined into the rear of the barrel and an ammunition magazine capable of holding multiple Cartridges such that the Hand Gun is designed to automatically reload each time it is fired and to fire a Bullet with each successive pull of the trigger until the stored ammunition is depleted."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Semi-automatic_pistol&oldid=1058568715"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000713
 cco:ont00000713 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Vehicle"@en ;
-                 skos:definition "A Material Artifact that is designed to facilitate the movement of material entities from one location to another by conveying them there."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Vehicle&oldid=1063682179"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Vehicle"@en ;
+                skos:definition "A Material Artifact that is designed to facilitate the movement of material entities from one location to another by conveying them there."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Vehicle&oldid=1063682179"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000714
 cco:ont00000714 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001192 ;
-                 rdfs:label "Horn Antenna"@en ;
-                 skos:altLabel "Microwave Horn"@en ;
-                 skos:definition "A Radio Antenna that consists of a flaring metal waveguide shaped like a horn to direct radio waves in a beam and can be used on its own or as a feeder for larger antenna structures, such as Parabolic Antennas."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Horn_antenna&oldid=1050375403"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001192 ;
+                rdfs:label "Horn Antenna"@en ;
+                skos:altLabel "Microwave Horn"@en ;
+                skos:definition "A Radio Antenna that consists of a flaring metal waveguide shaped like a horn to direct radio waves in a beam and can be used on its own or as a feeder for larger antenna structures, such as Parabolic Antennas."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Horn_antenna&oldid=1050375403"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000715
 cco:ont00000715 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001381 ;
-                 rdfs:label "Prosthesis"@en ;
-                 skos:definition "A Medical Artifact that is designed to replace a missing body part."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Prosthesis&oldid=1063749698"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001381 ;
+                rdfs:label "Prosthesis"@en ;
+                skos:definition "A Medical Artifact that is designed to replace a missing body part."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Prosthesis&oldid=1063749698"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000716
 cco:ont00000716 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001049 ;
-                 rdfs:label "Electric Battery"@en ;
-                 skos:altLabel "Battery"@en ;
-                 skos:definition "An Electrical Power Source that is designed to produce electric power by converting chemical energy to electrical energy."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Battery_(electricity)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001049 ;
+                rdfs:label "Electric Battery"@en ;
+                skos:altLabel "Battery"@en ;
+                skos:definition "An Electrical Power Source that is designed to produce electric power by converting chemical energy to electrical energy."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Battery_(electricity)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000719
 cco:ont00000719 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Counterfeit Instrument"@en ;
-                 skos:definition "A Material Artifact that is designed to be a fake replica of some genuine Artifact."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Counterfeit&oldid=1063493600"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Counterfeit Instrument"@en ;
+                skos:definition "A Material Artifact that is designed to be a fake replica of some genuine Artifact."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Counterfeit&oldid=1063493600"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000720
 cco:ont00000720 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000020 ;
-                 rdfs:label "Cryogenic Storage Dewar"@en ;
-                 skos:definition "A Container that is designed to store a Portion of Cryogenic Material (such as liquid helium or liquid oxygen) and which consists of, minimally, walls that are constructed from two or more layers that are separated by a high vacuum to provide thermal insulation between the interior and exterior of the dewar."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Cryogenic_storage_dewar&oldid=1021282649"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000020 ;
+                rdfs:label "Cryogenic Storage Dewar"@en ;
+                skos:definition "A Container that is designed to store a Portion of Cryogenic Material (such as liquid helium or liquid oxygen) and which consists of, minimally, walls that are constructed from two or more layers that are separated by a high vacuum to provide thermal insulation between the interior and exterior of the dewar."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Cryogenic_storage_dewar&oldid=1021282649"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000721
 cco:ont00000721 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000804 ;
-                 rdfs:label "Polarizing Prism"@en ;
-                 skos:definition "A Prism designed to split a beam of light entering the Prism into components of varying polarization."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000804 ;
+                rdfs:label "Polarizing Prism"@en ;
+                skos:definition "A Prism designed to split a beam of light entering the Prism into components of varying polarization."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000723
 cco:ont00000723 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000781 ;
-                 rdfs:label "Vehicle Control System"@en ;
-                 skos:definition "A Control System that is designed to enable some Agent to control some Vehicle."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000781 ;
+                rdfs:label "Vehicle Control System"@en ;
+                skos:definition "A Control System that is designed to enable some Agent to control some Vehicle."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000724
 cco:ont00000724 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001192 ;
-                 rdfs:label "Parabolic Antenna"@en ;
-                 skos:altLabel "Dish Antenna"@en ,
-                               "Parabolic Dish"@en ;
-                 skos:definition "A Radio Antenna that uses a parabolic reflector to direct or receive radio waves and has a very high gain."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Parabolic_antenna&oldid=1057213241"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001192 ;
+                rdfs:label "Parabolic Antenna"@en ;
+                skos:altLabel "Dish Antenna"@en ,
+                              "Parabolic Dish"@en ;
+                skos:definition "A Radio Antenna that uses a parabolic reflector to direct or receive radio waves and has a very high gain."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Parabolic_antenna&oldid=1057213241"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000727
 cco:ont00000727 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Communication Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in a process in which meaningful signs are conveyed from one entity to another."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Communication Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in a process in which meaningful signs are conveyed from one entity to another."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000728
 cco:ont00000728 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000215 ;
-                 rdfs:comment "The submillimeter waveband is between the far-infrared and microwave wavebands and is typically taken to have a wavelength of between a few hundred micrometers and a millimeter."@en ;
-                 rdfs:label "Submillimeter Wavelength Radio Telescope"@en ;
-                 skos:altLabel "Microwave Telescope"@en ;
-                 skos:definition "A Radio Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing radio waves from the submillimeter waveband (i.e. microwaves) to form an enhanced image of the Object."@en ;
-                 cco:ont00001754 "http://kp12m.as.arizona.edu/docs/what_is_submillimeter.htm, https://en.wikipedia.org/wiki/Submillimetre_astronomy" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000215 ;
+                rdfs:comment "The submillimeter waveband is between the far-infrared and microwave wavebands and is typically taken to have a wavelength of between a few hundred micrometers and a millimeter."@en ;
+                rdfs:label "Submillimeter Wavelength Radio Telescope"@en ;
+                skos:altLabel "Microwave Telescope"@en ;
+                skos:definition "A Radio Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing radio waves from the submillimeter waveband (i.e. microwaves) to form an enhanced image of the Object."@en ;
+                cco:ont00001754 "http://kp12m.as.arizona.edu/docs/what_is_submillimeter.htm, https://en.wikipedia.org/wiki/Submillimetre_astronomy" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000730
 cco:ont00000730 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Hydraulic Power Transfer Unit"@en ;
-                 skos:definition "A Material Artifact that is designed to transfer hydraulic power from one of an Aircraft's hydraulic systems to another in the event that a system has failed or been turned off."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Power_transfer_unit&oldid=1002682083"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Hydraulic Power Transfer Unit"@en ;
+                skos:definition "A Material Artifact that is designed to transfer hydraulic power from one of an Aircraft's hydraulic systems to another in the event that a system has failed or been turned off."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Power_transfer_unit&oldid=1002682083"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000734
 cco:ont00000734 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000552 ;
-                 rdfs:label "Land Mine"@en ;
-                 skos:definition "An Explosive Weapon that is designed to be concealed under or on the ground and to detonate as its target passes over or near it."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Land_mine&oldid=1060289159"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000552 ;
+                rdfs:label "Land Mine"@en ;
+                skos:definition "An Explosive Weapon that is designed to be concealed under or on the ground and to detonate as its target passes over or near it."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Land_mine&oldid=1060289159"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000736
 cco:ont00000736 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Transducer"@en ;
-                 skos:definition "A Material Artifact that is designed to convert one form of energy to another."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Transducer&oldid=1053290948"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Transducer"@en ;
+                skos:definition "A Material Artifact that is designed to convert one form of energy to another."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Transducer&oldid=1053290948"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000740
 cco:ont00000740 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000002 ;
-                 rdfs:comment "This class is designed to group continuants according to a very broad criterion and is not intended to be used as a parent class for entities that can be more specifically represented under another class. Hence, Natural Resource may be an appropriate subtype but Money, Oil, and Gold Mine are not."@en ;
-                 rdfs:label "Resource"@en ;
-                 skos:definition "A Continuant that is owned by, in the possession of, or is otherwise controlled by an Agent such that it could be used by that Agent."@en ;
-                 skos:example "a group of interns" ,
-                              "a knowledge base" ,
-                              "a plot of land" ,
-                              "a software program" ,
-                              "a sum of money" ,
-                              "a vehicle" ;
-                 skos:scopeNote "Resources are Resources for some Agent. If no instance of Agent existed, no instance of Resource would exist either. It is not a requirement that something be valuable in order for it to be a Resource. Thus the value of something can drastically change without altering whether that thing is a Resource."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000002 ;
+                rdfs:comment "This class is designed to group continuants according to a very broad criterion and is not intended to be used as a parent class for entities that can be more specifically represented under another class. Hence, Natural Resource may be an appropriate subtype but Money, Oil, and Gold Mine are not."@en ;
+                rdfs:label "Resource"@en ;
+                skos:definition "A Continuant that is owned by, in the possession of, or is otherwise controlled by an Agent such that it could be used by that Agent."@en ;
+                skos:example "a group of interns" ,
+                             "a knowledge base" ,
+                             "a plot of land" ,
+                             "a software program" ,
+                             "a sum of money" ,
+                             "a vehicle" ;
+                skos:scopeNote "Resources are Resources for some Agent. If no instance of Agent existed, no instance of Resource would exist either. It is not a requirement that something be valuable in order for it to be a Resource. Thus the value of something can drastically change without altering whether that thing is a Resource."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000742
 cco:ont00000742 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Ignition System"@en ;
-                 skos:definition "A Material Artifact that is designed to produce an Ignition process."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Ignition System"@en ;
+                skos:definition "A Material Artifact that is designed to produce an Ignition process."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000743
 cco:ont00000743 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000702 ;
-                 rdfs:label "Chart"@en ;
-                 skos:definition "An Image that is designed to carry some Representational Information Content Entity that is prescribed by some canonical visual format."@en ;
-                 cco:ont00001754 "Adapted from “Chart.” Merriam-Webster.com Dictionary, Merriam-Webster, https://www.merriam-webster.com/dictionary/chart. Accessed 4 Aug. 2024." ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000702 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002005
+                                ] ;
+                rdfs:label "Material Copy of a Chart"@en ;
+                skos:altLabel "Chart"@en ;
+                skos:definition "An Image that is designed to carry some Representational Information Content Entity that is prescribed by some canonical visual format."@en ;
+                cco:ont00001754 "Adapted from “Chart.” Merriam-Webster.com Dictionary, Merriam-Webster, https://www.merriam-webster.com/dictionary/chart. Accessed 4 Aug. 2024." ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000746
 cco:ont00000746 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000638 ;
-                 rdfs:label "Combustion Engine"@en ;
-                 skos:definition "A Heat Engine that is designed to convert thermal energy that is generated through a local Combustion process into mechanical energy."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000638 ;
+                rdfs:label "Combustion Engine"@en ;
+                skos:definition "A Heat Engine that is designed to convert thermal energy that is generated through a local Combustion process into mechanical energy."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000747
 cco:ont00000747 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000549 ;
-                 rdfs:label "Canal"@en ;
-                 skos:definition "A Water Transportation Artifact that is an artificial Hydrographic Feature designed to convey water or enable Watercraft to travel inland."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Canal&oldid=1059514223" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000549 ;
+                rdfs:label "Canal"@en ;
+                skos:definition "A Water Transportation Artifact that is an artificial Hydrographic Feature designed to convey water or enable Watercraft to travel inland."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Canal&oldid=1059514223" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000748
 cco:ont00000748 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001150 ;
-                 rdfs:label "Bullet"@en ;
-                 skos:definition "A Portion of Ammunition that is designed to be projected by a Firearm, Sling, Slingshot, or Air Gun, but which does not (typically) contain explosives."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Bullet&oldid=1062391591"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001150 ;
+                rdfs:label "Bullet"@en ;
+                skos:definition "A Portion of Ammunition that is designed to be projected by a Firearm, Sling, Slingshot, or Air Gun, but which does not (typically) contain explosives."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Bullet&oldid=1062391591"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000756
 cco:ont00000756 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000798 ;
-                 rdfs:label "Database"@en ;
-                 skos:definition "An Information Bearing Artifact that is designed to bear some set of specific Information Content Entities and to be rapidly searchable and retrievable."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Database&oldid=1057024641"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000798 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002006
+                                ] ;
+                rdfs:label "Material Copy of a Database"@en ;
+                skos:altLabel "Database"@en ;
+                skos:definition "An Information Bearing Artifact that is designed to bear some set of specific Information Content Entities and to be rapidly searchable and retrievable."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Database&oldid=1057024641"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000758
 cco:ont00000758 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000023 ;
-                 rdfs:label "Component Role"@en ;
-                 skos:definition "A Role that inheres in an entity having a discrete structure in virtue of that entity being part of a system considered at a particular level of analysis."@en ;
-                 cco:ont00001754 "ISO/IEC. 1998. Information Technology ― System and Software Integrity Levels Geneva, Switzerland: International Organization for Standardization (ISO)/International Electrotechnical Commission (IEC). ISO/IEC. 15026:1998. : 3.1"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000023 ;
+                rdfs:label "Component Role"@en ;
+                skos:definition "A Role that inheres in an entity having a discrete structure in virtue of that entity being part of a system considered at a particular level of analysis."@en ;
+                cco:ont00001754 "ISO/IEC. 1998. Information Technology ― System and Software Integrity Levels Geneva, Switzerland: International Organization for Standardization (ISO)/International Electrotechnical Commission (IEC). ISO/IEC. 15026:1998. : 3.1"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000762
 cco:ont00000762 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000415 ;
-                 rdfs:label "Fungicide Artifact Function"@en ;
-                 skos:definition "An Anti-Microbial Artifact Function that is realized in a process which causes harm to, or the death of, some fungus or fungal spore."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Fungicide&oldid=1056769271"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000415 ;
+                rdfs:label "Fungicide Artifact Function"@en ;
+                skos:definition "An Anti-Microbial Artifact Function that is realized in a process which causes harm to, or the death of, some fungus or fungal spore."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Fungicide&oldid=1056769271"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000764
 cco:ont00000764 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000504 ;
-                 rdfs:label "Optical Focusing Artifact Function"@en ;
-                 skos:definition "An Optical Processing Artifact Function that is realized by an Artifact participating in a light focusing event in which the Artifact causes the light beam to converge on a target spatial point."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000504 ;
+                rdfs:label "Optical Focusing Artifact Function"@en ;
+                skos:definition "An Optical Processing Artifact Function that is realized by an Artifact participating in a light focusing event in which the Artifact causes the light beam to converge on a target spatial point."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000767
 cco:ont00000767 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:comment "A Lubrication System typical consists of a reservoir, pump, heat exchanger, filter, regulator, valves, sensors, pipes, and hoses. In some cases it also includes the passageways and openings within the artifact it is designed to lubricate. For example, the oil holes in a bearing and crankshaft."@en ;
-                 rdfs:label "Lubrication System"@en ;
-                 skos:definition "A Material Artifact that is designed to contain, transfer, and regulate the flow of lubricant to multiple locations in an Artifact."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:comment "A Lubrication System typical consists of a reservoir, pump, heat exchanger, filter, regulator, valves, sensors, pipes, and hoses. In some cases it also includes the passageways and openings within the artifact it is designed to lubricate. For example, the oil holes in a bearing and crankshaft."@en ;
+                rdfs:label "Lubrication System"@en ;
+                skos:definition "A Material Artifact that is designed to contain, transfer, and regulate the flow of lubricant to multiple locations in an Artifact."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000771
 cco:ont00000771 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Imaging Instrument"@en ;
-                 skos:definition "A Material Artifact that is designed to produce images (visual representations) of an entity."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Imaging Instrument"@en ;
+                skos:definition "A Material Artifact that is designed to produce images (visual representations) of an entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000774
 cco:ont00000774 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000199 ;
-                 rdfs:label "Video Camera"@en ;
-                 skos:definition "A Camera that is designed to form and digitally or physically record a continuous stream of subsequent images of an entity or scene such that the images can be played back in succession as a video."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000199 ;
+                rdfs:label "Video Camera"@en ;
+                skos:definition "A Camera that is designed to form and digitally or physically record a continuous stream of subsequent images of an entity or scene such that the images can be played back in succession as a video."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000775
 cco:ont00000775 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000796 ;
-                 rdfs:label "Locomotive"@en ;
-                 skos:definition "A Rail Transport Vehicle that is designed to provide the motive power for a Train."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Locomotive&oldid=1062802629"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000796 ;
+                rdfs:label "Locomotive"@en ;
+                skos:definition "A Rail Transport Vehicle that is designed to provide the motive power for a Train."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Locomotive&oldid=1062802629"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000776
 cco:ont00000776 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Signal Detection Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in the process of discerning between information-bearing patterns and random patterns, or noise, that distract from the information."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Detection_theory&oldid=1049765804"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Signal Detection Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in the process of discerning between information-bearing patterns and random patterns, or noise, that distract from the information."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Detection_theory&oldid=1049765804"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000777
 cco:ont00000777 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001221 ;
-                 rdfs:label "Hydraulic Motor"@en ;
-                 skos:definition "A Physically Powered Engine that converts hydraulic pressure and flow into torque and angular displacement."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Hydraulic_motor&oldid=1027427666"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001221 ;
+                rdfs:label "Hydraulic Motor"@en ;
+                skos:definition "A Physically Powered Engine that converts hydraulic pressure and flow into torque and angular displacement."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Hydraulic_motor&oldid=1027427666"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000781
 cco:ont00000781 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Control System"@en ;
-                 skos:definition "A Material Artifact that is designed to manage, command, direct, or regulate the behavior of at least one other Artifact."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Control_system&oldid=1061817176"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Control System"@en ;
+                skos:definition "A Material Artifact that is designed to manage, command, direct, or regulate the behavior of at least one other Artifact."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Control_system&oldid=1061817176"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000785
 cco:ont00000785 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001320 ;
-                 rdfs:label "Radio Repeater"@en ;
-                 skos:definition "A Radio Transceiver that is designed to receive a radio signal, amplify it, and retransmit it (often on another frequency)."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Repeater&oldid=1040047439"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001320 ;
+                rdfs:label "Radio Repeater"@en ;
+                skos:definition "A Radio Transceiver that is designed to receive a radio signal, amplify it, and retransmit it (often on another frequency)."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Repeater&oldid=1040047439"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000788
 cco:ont00000788 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000634 ;
-                 rdfs:label "Turbine Steam Engine"@en ;
-                 skos:altLabel "Steam Turbine"@en ;
-                 skos:definition "A Steam Engine that is designed to extract thermal energy from pressurized steam and use it to do mechanical work on a rotating output shaft."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Steam_turbine&oldid=1060224962"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000634 ;
+                rdfs:label "Turbine Steam Engine"@en ;
+                skos:altLabel "Steam Turbine"@en ;
+                skos:definition "A Steam Engine that is designed to extract thermal energy from pressurized steam and use it to do mechanical work on a rotating output shaft."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Steam_turbine&oldid=1060224962"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000790
 cco:ont00000790 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001049 ;
-                 rdfs:label "Direct Current Power Source"@en ;
-                 skos:definition "An Electrical Power Source that is designed to transfer electrical power in the form of direct current."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001049 ;
+                rdfs:label "Direct Current Power Source"@en ;
+                skos:definition "An Electrical Power Source that is designed to transfer electrical power in the form of direct current."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000791
 cco:ont00000791 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Chemical Reaction Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in a process that leads to the transformation of one set of chemical substances to another."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Chemical_reaction&oldid=1063262412"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Chemical Reaction Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in a process that leads to the transformation of one set of chemical substances to another."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Chemical_reaction&oldid=1063262412"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000792
 cco:ont00000792 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001009 ;
-                 rdfs:label "Catadioptric Optical Telescope"@en ;
-                 skos:altLabel "Catadioptric Telescope"@en ;
-                 skos:definition "An Optical Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing visible light through the use of a combination of Lenses and Mirrors to form an enhanced image of the Object."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Catadioptric_system&oldid=1017210114"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001009 ;
+                rdfs:label "Catadioptric Optical Telescope"@en ;
+                skos:altLabel "Catadioptric Telescope"@en ;
+                skos:definition "An Optical Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing visible light through the use of a combination of Lenses and Mirrors to form an enhanced image of the Object."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Catadioptric_system&oldid=1017210114"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000793
 cco:ont00000793 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000256 ;
-                 rdfs:label "Fuel Ventilation System"@en ;
-                 skos:definition "A Fluid Control Artifact that is designed to allow air into the Fuel Tank to take the place of burned fuel."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Aircraft_fuel_system&oldid=1003132173"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000256 ;
+                rdfs:label "Fuel Ventilation System"@en ;
+                skos:definition "A Fluid Control Artifact that is designed to allow air into the Fuel Tank to take the place of burned fuel."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Aircraft_fuel_system&oldid=1003132173"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000795
 cco:ont00000795 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000098 ;
-                 rdfs:label "Electrical Conduction Artifact Function"@en ;
-                 skos:definition "An Electrical Artifact Function that is realized by an Artifact being used to conduct an electric current."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000098 ;
+                rdfs:label "Electrical Conduction Artifact Function"@en ;
+                skos:definition "An Electrical Artifact Function that is realized by an Artifact being used to conduct an electric current."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000796
 cco:ont00000796 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000618 ;
-                 rdfs:label "Rail Transport Vehicle"@en ;
-                 skos:definition "A Ground Vehicle that is designed to convey cargo, passengers, or equipment by Railway."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rail_transport&oldid=1063793805"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000618 ;
+                rdfs:label "Rail Transport Vehicle"@en ;
+                skos:definition "A Ground Vehicle that is designed to convey cargo, passengers, or equipment by Railway."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rail_transport&oldid=1063793805"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000798
 cco:ont00000798 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:BFO_0000101 ;
-                                   owl:someValuesFrom cco:ont00000958
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:BFO_0000176 ;
-                                   owl:someValuesFrom cco:ont00000893
-                                 ] ;
-                 rdfs:label "Information Bearing Artifact"@en ;
-                 skos:definition "A Material Artifact that carries an Information Content Entity and is designed to do so using a particular format or structure."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00000958
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000176 ;
+                                  owl:someValuesFrom cco:ont00000893
+                                ] ;
+                rdfs:comment "This class continues to use the word ‘bearing’ in its rdfs:label for legacy reasons. It should be understood that all instances of this class are carriers of information content entities and only, strictly speaking, a bearer of their concretizations."@en ;
+                rdfs:label "Information Bearing Artifact"@en ;
+                skos:altLabel "Information Carrying Artifact"@en ;
+                skos:definition "A Material Artifact that carries an Information Content Entity and is designed to do so using a particular format or structure."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000799
 cco:ont00000799 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000798 ;
-                 rdfs:label "List"@en ;
-                 skos:definition "An Information Bearing Artifact that consists of one or more Information Bearing Artifacts that carry Information Content Entities and are the subjects of some Sequence Position Ordinality."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=List_(abstract_data_type)&oldid=1041588680"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000798 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002007
+                                ] ;
+                rdfs:label "Material Copy of a List"@en ;
+                skos:altLabel "List"@en ;
+                skos:definition "An Information Bearing Artifact that consists of one or more Information Bearing Artifacts that carry Information Content Entities and are the subjects of some Sequence Position Ordinality."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=List_(abstract_data_type)&oldid=1041588680"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000804
 cco:ont00000804 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000136 ;
-                 rdfs:label "Prism"@en ;
-                 skos:definition "An Optical Instrument that is designed to refract light and which consists of a transparent material with flat polished surfaces where at least two of these surfaces have an angle between them."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Prism&oldid=1060221124"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000136 ;
+                rdfs:label "Prism"@en ;
+                skos:definition "An Optical Instrument that is designed to refract light and which consists of a transparent material with flat polished surfaces where at least two of these surfaces have an angle between them."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Prism&oldid=1060221124"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000806
 cco:ont00000806 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000581 ;
-                 rdfs:label "Power Tool"@en ;
-                 skos:definition "A Tool that is designed to be actuated by a Power Source and mechanism other than or in addition to manual labor."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Power_tool&oldid=1057147715"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000581 ;
+                rdfs:label "Power Tool"@en ;
+                skos:definition "A Tool that is designed to be actuated by a Power Source and mechanism other than or in addition to manual labor."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Power_tool&oldid=1057147715"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000807
 cco:ont00000807 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000394 ;
-                 rdfs:label "Compression Ignition Engine"@en ;
-                 skos:definition "An Internal Combustion Engine that is designed to operate by igniting a portion of Fuel and Oxidizer mixture using heat generated via compression of the mixture."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000394 ;
+                rdfs:label "Compression Ignition Engine"@en ;
+                skos:definition "An Internal Combustion Engine that is designed to operate by igniting a portion of Fuel and Oxidizer mixture using heat generated via compression of the mixture."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000808
 cco:ont00000808 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000791 ;
-                 rdfs:label "Reactant Artifact Function"@en ;
-                 skos:definition "A Chemical Reaction Artifact Function that is realized in a process in which a substance or compound is added to a system in order to bring about a chemical reaction and is consumed in the course of the reaction."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Reagent&oldid=1017651471"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000791 ;
+                rdfs:label "Reactant Artifact Function"@en ;
+                skos:definition "A Chemical Reaction Artifact Function that is realized in a process in which a substance or compound is added to a system in order to bring about a chemical reaction and is consumed in the course of the reaction."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Reagent&oldid=1017651471"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000809
 cco:ont00000809 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Submersible Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in processes of operating while submerged in water."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Submersible&oldid=1062994844"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Submersible Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in processes of operating while submerged in water."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Submersible&oldid=1062994844"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000811
 cco:ont00000811 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Radio Wave Conversion Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized by an Artifact being used to convert electric power into radio waves or radio waves into electric power."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Radio Wave Conversion Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized by an Artifact being used to convert electric power into radio waves or radio waves into electric power."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000813
 cco:ont00000813 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000457 ;
-                 rdfs:label "Portion of Nuclear Fuel"@en ;
-                 skos:definition "A Portion of Material that is designed to be used in a nuclear fission process to produce energy."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000457 ;
+                rdfs:label "Portion of Nuclear Fuel"@en ;
+                skos:definition "A Portion of Material that is designed to be used in a nuclear fission process to produce energy."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000816
 cco:ont00000816 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000255 ;
-                 rdfs:label "Portion of Liquid Nitrogen"@en ;
-                 skos:definition "A Portion of Cryogenic Material that is composed (almost) entirely of liquid nitrogen."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000255 ;
+                rdfs:label "Portion of Liquid Nitrogen"@en ;
+                skos:definition "A Portion of Cryogenic Material that is composed (almost) entirely of liquid nitrogen."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000823
 cco:ont00000823 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001148 ;
-                 rdfs:label "Optical Communication Artifact Function"@en ;
-                 skos:definition "An Electromagnetic Communication Artifact Function that is realized in a process that conveys meaningful signs by means of visible light."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telecommunications&oldid=1061143810"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001148 ;
+                rdfs:label "Optical Communication Artifact Function"@en ;
+                skos:definition "An Electromagnetic Communication Artifact Function that is realized in a process that conveys meaningful signs by means of visible light."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telecommunications&oldid=1061143810"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000825
 cco:ont00000825 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000346 ;
-                 rdfs:label "Telecommunication Network Line"@en ;
-                 skos:definition "A Communication Artifact that is designed to be the physical transmission medium that connects two or more Telecommunication Network Nodes within a Telecommunication Network to facilitate communication between the Nodes."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telecommunications_link&oldid=1062252217"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000346 ;
+                rdfs:label "Telecommunication Network Line"@en ;
+                skos:definition "A Communication Artifact that is designed to be the physical transmission medium that connects two or more Telecommunication Network Nodes within a Telecommunication Network to facilitate communication between the Nodes."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telecommunications_link&oldid=1062252217"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000828
 cco:ont00000828 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001123 ;
-                 rdfs:label "Pesticide Artifact Function"@en ;
-                 skos:definition "A Poison Artifact Function that is realized in a process which causes illness in, or the death of, a living thing that is detrimental to humans or human concerns."@en ;
-                 cco:ont00001754 "http://www.dictionary.com/browse/pesticide" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001123 ;
+                rdfs:label "Pesticide Artifact Function"@en ;
+                skos:definition "A Poison Artifact Function that is realized in a process which causes illness in, or the death of, a living thing that is detrimental to humans or human concerns."@en ;
+                cco:ont00001754 "http://www.dictionary.com/browse/pesticide" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000831
 cco:ont00000831 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000828 ;
-                 rdfs:label "Herbicide Artifact Function"@en ;
-                 skos:definition "A Pesticide Artifact Function that is realized in a process which causes harm to, or the death to, unwanted plants."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Herbicide&oldid=1061228045"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000828 ;
+                rdfs:label "Herbicide Artifact Function"@en ;
+                skos:definition "A Pesticide Artifact Function that is realized in a process which causes harm to, or the death to, unwanted plants."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Herbicide&oldid=1061228045"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000838
 cco:ont00000838 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000457 ;
-                 rdfs:label "Portion of Fuel"@en ;
-                 skos:definition "A Portion of Material that is designed to release thermal energy when reacted with other substances."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000457 ;
+                rdfs:label "Portion of Fuel"@en ;
+                skos:definition "A Portion of Material that is designed to release thermal energy when reacted with other substances."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000840
 cco:ont00000840 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000618 ;
-                 rdfs:label "Bicycle"@en ;
-                 skos:definition "A Ground Vehicle that consists of two wheels, one in front of the other, attached to a frame along with handlebars and pedals such that it is designed to receive its motive power from pedaling."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Bicycle&oldid=1063761124"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000618 ;
+                rdfs:label "Bicycle"@en ;
+                skos:definition "A Ground Vehicle that consists of two wheels, one in front of the other, attached to a frame along with handlebars and pedals such that it is designed to receive its motive power from pedaling."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Bicycle&oldid=1063761124"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000841
 cco:ont00000841 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001153 ;
-                 rdfs:label "Explosive Artifact Function"@en ;
-                 skos:definition "A Damaging Artifact Function that is realized in a process in which the structural integrity of an entity is impaired beucase of the rapid increase in volume and release of energy in an extreme manner."@en ;
-                 cco:ont00001754 "http://www.dictionary.com/browse/explosive" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001153 ;
+                rdfs:label "Explosive Artifact Function"@en ;
+                skos:definition "A Damaging Artifact Function that is realized in a process in which the structural integrity of an entity is impaired beucase of the rapid increase in volume and release of energy in an extreme manner."@en ;
+                cco:ont00001754 "http://www.dictionary.com/browse/explosive" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000843
 cco:ont00000843 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001049 ;
-                 rdfs:label "Solar Panel"@en ;
-                 skos:definition "An Electrical Power Source that consists in part of one or more photovoltaic (i.e. solar) cells that convert light energy (photons) directly into electricity by means of the photovoltaic effect."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Solar_cell&oldid=1063439932"^^xsd:anyURI ,
-                                  "https://en.wikipedia.org/w/index.php?title=Solar_panel&oldid=1064397496"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001049 ;
+                rdfs:label "Solar Panel"@en ;
+                skos:definition "An Electrical Power Source that consists in part of one or more photovoltaic (i.e. solar) cells that convert light energy (photons) directly into electricity by means of the photovoltaic effect."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Solar_cell&oldid=1063439932"^^xsd:anyURI ,
+                                "https://en.wikipedia.org/w/index.php?title=Solar_panel&oldid=1064397496"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000848
 cco:ont00000848 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000088 ;
-                 rdfs:label "Mounted Gun"@en ;
-                 skos:definition "A Firearm that is designed to be fired while mounted."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000088 ;
+                rdfs:label "Mounted Gun"@en ;
+                skos:definition "A Firearm that is designed to be fired while mounted."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000849
 cco:ont00000849 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000453 ;
-                 rdfs:label "Heating System"@en ;
-                 skos:definition "An Environment Control System that is designed to heat the air or objects in a Site."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000453 ;
+                rdfs:label "Heating System"@en ;
+                skos:definition "An Environment Control System that is designed to heat the air or objects in a Site."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000851
 cco:ont00000851 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001104 ;
-                 rdfs:label "Light Machine Gun"@en ;
-                 skos:definition "A Long Gun that is designed to fire bullets in quick succession from an ammunition belt or magazine and to be employed by an individual soldier, with or without assistance, and typically weighing 9-22 lbs."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Light_machine_gun&oldid=1063598801"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001104 ;
+                rdfs:label "Light Machine Gun"@en ;
+                skos:definition "A Long Gun that is designed to fire bullets in quick succession from an ammunition belt or magazine and to be employed by an individual soldier, with or without assistance, and typically weighing 9-22 lbs."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Light_machine_gun&oldid=1063598801"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000856
 cco:ont00000856 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000182 ;
-                 rdfs:label "Artifact History"@en ;
-                 skos:definition "A History of an Artifact."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000182 ;
+                rdfs:label "Artifact History"@en ;
+                skos:definition "A History of an Artifact."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000857
 cco:ont00000857 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000903 ;
-                 rdfs:label "Ultra High Frequency Communication Instrument"@en ;
-                 skos:definition "A Radio Communication Instrument that is designed to participate in some process that has process part some Ultra High Frequency."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000903 ;
+                rdfs:label "Ultra High Frequency Communication Instrument"@en ;
+                skos:definition "A Radio Communication Instrument that is designed to participate in some process that has process part some Ultra High Frequency."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000858
 cco:ont00000858 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000552 ;
-                 rdfs:label "Improvised Explosive Device"@en ;
-                 skos:definition "An Explosive Weapon that is designed to be used in non-conventional military action."@en ;
-                 cco:ont00001753 "IED" ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Improvised_explosive_device&oldid=1063432318"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000552 ;
+                rdfs:label "Improvised Explosive Device"@en ;
+                skos:definition "An Explosive Weapon that is designed to be used in non-conventional military action."@en ;
+                cco:ont00001753 "IED" ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Improvised_explosive_device&oldid=1063432318"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000864
 cco:ont00000864 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001301 ;
-                 rdfs:label "Public Safety Artifact Function"@en ;
-                 skos:definition "A Service Artifact Function that is realized in processes of preventing and responding to events that could endanger the safety of the general public from significant danger, injury/harm, or damage, such as crimes or disasters (natural or man-made)."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Public_security&oldid=1058257389"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001301 ;
+                rdfs:label "Public Safety Artifact Function"@en ;
+                skos:definition "A Service Artifact Function that is realized in processes of preventing and responding to events that could endanger the safety of the general public from significant danger, injury/harm, or damage, such as crimes or disasters (natural or man-made)."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Public_security&oldid=1058257389"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000868
 cco:ont00000868 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001173 ;
-                 rdfs:label "Rocket Pod"@en ;
-                 skos:definition "A Rocket Launcher that is designed to contain several Unguided Rockets held in individual tubes and to be used by Aircraft or Helicopters for close air support."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001173 ;
+                rdfs:label "Rocket Pod"@en ;
+                skos:definition "A Rocket Launcher that is designed to contain several Unguided Rockets held in individual tubes and to be used by Aircraft or Helicopters for close air support."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000869
 cco:ont00000869 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000199 ;
-                 rdfs:label "Optical Camera"@en ;
-                 skos:definition "A Camera that is designed to form and record an image generated from visible light."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Camera&oldid=1063931551"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000199 ;
+                rdfs:label "Optical Camera"@en ;
+                skos:definition "A Camera that is designed to form and record an image generated from visible light."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Camera&oldid=1063931551"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000870
 cco:ont00000870 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000040 ;
-                 rdfs:label "Infrastructure System"@en ;
-                 skos:altLabel "Infrastructure"@en ;
-                 skos:definition "A Material Entity that is composed of elements bearing Infrastructure Roles and is by itself sufficient to provide a planned service or benefit to some organization that maintains its elements."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000040 ;
+                rdfs:label "Infrastructure System"@en ;
+                skos:altLabel "Infrastructure"@en ;
+                skos:definition "A Material Entity that is composed of elements bearing Infrastructure Roles and is by itself sufficient to provide a planned service or benefit to some organization that maintains its elements."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000874
 cco:ont00000874 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000798 ;
-                 rdfs:label "Video"@en ;
-                 skos:definition "An Information Bearing Artifact that is designed to bear some specific Information Content Entity in the form of a sequence of representations that are presented sufficiently rapidly to create the appearance of motion and continuity."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Video&oldid=1049376249"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000798 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002009
+                                ] ;
+                rdfs:label "Material Copy of a Video"@en ;
+                skos:altLabel "Video"@en ;
+                skos:definition "An Information Bearing Artifact that is designed to bear some specific Information Content Entity in the form of a sequence of representations that are presented sufficiently rapidly to create the appearance of motion and continuity."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Video&oldid=1049376249"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000877
 cco:ont00000877 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000723 ;
-                 rdfs:label "Brake Control System"@en ;
-                 skos:definition "A Vehicle Control System that is designed to control the process of braking with the aim of preventing rolling, skidding, and hydroplaning."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000723 ;
+                rdfs:label "Brake Control System"@en ;
+                skos:definition "A Vehicle Control System that is designed to control the process of braking with the aim of preventing rolling, skidding, and hydroplaning."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000878
 cco:ont00000878 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000325 ;
-                 rdfs:label "Identification Friend or Foe Transponder"@en ;
-                 skos:altLabel "IFF"@en ;
-                 skos:definition "A Radio Transponder that is designed to automatically transmit a predefined signal in response to receiving an appropriate interrogation signal such that the entity it is located on can be positively identified as friendly."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Identification_friend_or_foe&oldid=1055168718"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000325 ;
+                rdfs:label "Identification Friend or Foe Transponder"@en ;
+                skos:altLabel "IFF"@en ;
+                skos:definition "A Radio Transponder that is designed to automatically transmit a predefined signal in response to receiving an appropriate interrogation signal such that the entity it is located on can be positively identified as friendly."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Identification_friend_or_foe&oldid=1055168718"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000880
 cco:ont00000880 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001301 ;
-                 rdfs:label "Religious Artifact Function"@en ;
-                 skos:definition "A Service Artifact Function that is realized in processes related to worship and prayer."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Religion&oldid=1063431202"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001301 ;
+                rdfs:label "Religious Artifact Function"@en ;
+                skos:definition "A Service Artifact Function that is realized in processes related to worship and prayer."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Religion&oldid=1063431202"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000886
 cco:ont00000886 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000422 ;
-                 rdfs:label "Wired Communication Reception Artifact Function"@en ;
-                 skos:definition "A Communication Reception Artifact Function that is realized during events in which an Artifact receives information transmitted from another Artifact, where the transmission of information occurs via a direct connection using an electrical conductor."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000422 ;
+                rdfs:label "Wired Communication Reception Artifact Function"@en ;
+                skos:definition "A Communication Reception Artifact Function that is realized during events in which an Artifact receives information transmitted from another Artifact, where the transmission of information occurs via a direct connection using an electrical conductor."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000888
 cco:ont00000888 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000903 ;
-                 rdfs:label "High Frequency Communication Instrument"@en ;
-                 skos:definition "A Radio Communication Instrument that is designed to participate in some process that has process part some High Frequency."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000903 ;
+                rdfs:label "High Frequency Communication Instrument"@en ;
+                skos:definition "A Radio Communication Instrument that is designed to participate in some process that has process part some High Frequency."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000893
 cco:ont00000893 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:comment "An empty notebook, when manufactured, is a medium but not yet a carrier of information content. However, a book, in the sense of a novel or collection of philosophical essays or poems, depends necessarily on it carrying some information content. Thus, there are no empty books. Likewise, there are no empty databases, only portions of digital storage that have not yet been configured to carry some information content according to a database software application."@en ;
-                 rdfs:label "Information Medium Artifact"@en ;
-                 skos:definition "A Material Artifact that is designed to have some Information Bearing Artifact as part."@en ;
-                 skos:example "A magnetic hard drive" ,
-                              "A notebook" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:comment "An empty notebook, when manufactured, is a medium but not yet a carrier of information content. However, a book, in the sense of a novel or collection of philosophical essays or poems, depends necessarily on it carrying some information content. Thus, there are no empty books. Likewise, there are no empty databases, only portions of digital storage that have not yet been configured to carry some information content according to a database software application."@en ;
+                rdfs:label "Information Medium Artifact"@en ;
+                skos:definition "A Material Artifact that is designed to have some Information Bearing Artifact as part."@en ;
+                skos:example "A magnetic hard drive" ,
+                             "A notebook" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000897
 cco:ont00000897 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000457 ;
-                 rdfs:comment "Oxidizers are essential participants in many processes including combustion and rusting. Hence, a portion of oxidizer must always be present along with a portion of fuel in order for combustion to occur."@en ;
-                 rdfs:label "Portion of Oxidizer"@en ;
-                 skos:altLabel "Portion of Oxidant"@en ,
-                               "Portion of Oxidizing Agent"@en ;
-                 skos:definition "A Portion of Material that is disposed to steal electrons from other substances (i.e. to oxidize other substances) as a participant in a reduction-oxidation process."@en ;
-                 skos:example "oxygen, hydrogen peroxide, chlorine, sulfiric acid, potassium nitrate" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000457 ;
+                rdfs:comment "Oxidizers are essential participants in many processes including combustion and rusting. Hence, a portion of oxidizer must always be present along with a portion of fuel in order for combustion to occur."@en ;
+                rdfs:label "Portion of Oxidizer"@en ;
+                skos:altLabel "Portion of Oxidant"@en ,
+                              "Portion of Oxidizing Agent"@en ;
+                skos:definition "A Portion of Material that is disposed to steal electrons from other substances (i.e. to oxidize other substances) as a participant in a reduction-oxidation process."@en ;
+                skos:example "oxygen, hydrogen peroxide, chlorine, sulfiric acid, potassium nitrate" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000899
 cco:ont00000899 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000258 ;
-                 rdfs:label "MSI Plessey Barcode"@en ;
-                 skos:definition "A One-Dimensional Barcode that consists of an indefinite number of numerical characters and is used for inventory control and marking storage containers and shelves in warehouse environments."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000258 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002024
+                                ] ;
+                rdfs:label "Material Copy of a MSI Plessey Barcode"@en ;
+                skos:altLabel "MSI Plessey Barcode"@en ;
+                skos:definition "A One-Dimensional Barcode that consists of an indefinite number of numerical characters and is used for inventory control and marking storage containers and shelves in warehouse environments."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000900
 cco:ont00000900 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001169 ;
-                 rdfs:label "Radio Communication Relay Artifact Function"@en ;
-                 skos:definition "A Communication Relay Artifact Function that is realized during events in which an Artifact is used to first receive and then transmit information without the use of wires from one Artifact to another for the purpose of communiction."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001169 ;
+                rdfs:label "Radio Communication Relay Artifact Function"@en ;
+                skos:definition "A Communication Relay Artifact Function that is realized during events in which an Artifact is used to first receive and then transmit information without the use of wires from one Artifact to another for the purpose of communiction."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000903
 cco:ont00000903 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000346 ;
-                 rdfs:label "Radio Communication Instrument"@en ;
-                 skos:definition "A Communication Instrument that is designed to enable communication between two or more entities via the use of radio waves."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000346 ;
+                rdfs:label "Radio Communication Instrument"@en ;
+                skos:definition "A Communication Instrument that is designed to enable communication between two or more entities via the use of radio waves."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000904
 cco:ont00000904 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000205 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty cco:ont00001855 ;
-                                   owl:someValuesFrom cco:ont00000122
-                                 ] ;
-                 rdfs:label "Vehicle Track"@en ;
-                 skos:definition "An Object Track for a Vehicle during some motion."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000205 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty cco:ont00001855 ;
+                                  owl:someValuesFrom cco:ont00000122
+                                ] ;
+                rdfs:label "Vehicle Track"@en ;
+                skos:definition "An Object Track for a Vehicle during some motion."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000906
 cco:ont00000906 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000690 ;
-                 rdfs:label "Email Box"@en ;
-                 skos:definition "A Telecommunication Instrument that is designed to be the delivery destination of Email Messages that are addressed to the corresponding Email Address."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Email_box&oldid=1061295368"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000690 ;
+                rdfs:label "Email Box"@en ;
+                skos:definition "A Telecommunication Instrument that is designed to be the delivery destination of Email Messages that are addressed to the corresponding Email Address."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Email_box&oldid=1061295368"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000907
 cco:ont00000907 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000690 ;
-                 rdfs:label "Telephone"@en ;
-                 skos:altLabel "Phone"@en ;
-                 skos:definition "A Telecommunication Instrument that is designed to provide point-to-point communication between agents by means of audio messages."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telephone&oldid=1060006278"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000690 ;
+                rdfs:label "Telephone"@en ;
+                skos:altLabel "Phone"@en ;
+                skos:definition "A Telecommunication Instrument that is designed to provide point-to-point communication between agents by means of audio messages."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telephone&oldid=1060006278"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000909
 cco:ont00000909 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001049 ;
-                 rdfs:label "Emergency AC/DC Power Source"@en ;
-                 skos:definition "An Electrical Power Source that is designed to provide electrical power in an emergency situation by means of both alternating current and direct current."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001049 ;
+                rdfs:label "Emergency AC/DC Power Source"@en ;
+                skos:definition "An Electrical Power Source that is designed to provide electrical power in an emergency situation by means of both alternating current and direct current."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000918
 cco:ont00000918 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000346 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:BFO_0000176 ;
-                                   owl:someValuesFrom cco:ont00000998
-                                 ] ;
-                 rdfs:label "Telecommunication Network Node"@en ;
-                 skos:definition "A Communication Artifact that consists of a connection point, redistribution point, or endpoint that is designed to be part of a Telecommunication Network and can be either active or passive."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Node_(networking)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000346 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000176 ;
+                                  owl:someValuesFrom cco:ont00000998
+                                ] ;
+                rdfs:label "Telecommunication Network Node"@en ;
+                skos:definition "A Communication Artifact that consists of a connection point, redistribution point, or endpoint that is designed to be part of a Telecommunication Network and can be either active or passive."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Node_(networking)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000919
 cco:ont00000919 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000575 ;
-                 rdfs:label "Parts List"@en ;
-                 skos:definition "A Quality Specification that prescribes the Amount of some type of Artifact that are part of or located on another Artifact."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000575 ;
+                rdfs:label "Parts List"@en ;
+                skos:definition "A Quality Specification that prescribes the Amount of some type of Artifact that are part of or located on another Artifact."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000928
 cco:ont00000928 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000796 ;
-                 rdfs:label "Train Car"@en ;
-                 skos:altLabel "Railroad Car"@en ;
-                 skos:definition "A Rail Transport Vehicle that consists of a single Vehicle that is not a Train but is designed to be connected to other Train Cars along with at least one Locomotive to form a Train."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Railroad_car&oldid=1063802472"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000796 ;
+                rdfs:label "Train Car"@en ;
+                skos:altLabel "Railroad Car"@en ;
+                skos:definition "A Rail Transport Vehicle that consists of a single Vehicle that is not a Train but is designed to be connected to other Train Cars along with at least one Locomotive to form a Train."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Railroad_car&oldid=1063802472"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000929
 cco:ont00000929 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000023 ;
-                 rdfs:label "Part Role"@en ;
-                 skos:definition "A Role that inheres in an entity in virtue of it being part of some other entity without being subject to further subdivision or disassembly without destruction of its designated use."@en ;
-                 cco:ont00001754 "http://origins.sese.asu.edu/ses405/Class%20Notes/Sys-Hier-WBS_Module_V1.0_PAS.pdf"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000023 ;
+                rdfs:label "Part Role"@en ;
+                skos:definition "A Role that inheres in an entity in virtue of it being part of some other entity without being subject to further subdivision or disassembly without destruction of its designated use."@en ;
+                cco:ont00001754 "http://origins.sese.asu.edu/ses405/Class%20Notes/Sys-Hier-WBS_Module_V1.0_PAS.pdf"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000930
 cco:ont00000930 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001105 ;
-                 rdfs:label "Nickel-metal Hydride Electric Battery"@en ;
-                 skos:altLabel "NiMH Battery"@en ;
-                 skos:definition "A Secondary Cell Electric Battery that has a metal-hydride anode and nickel oxide hydroxide cathode."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Nickel%E2%80%93metal_hydride_battery&oldid=1061626676"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001105 ;
+                rdfs:label "Nickel-metal Hydride Electric Battery"@en ;
+                skos:altLabel "NiMH Battery"@en ;
+                skos:definition "A Secondary Cell Electric Battery that has a metal-hydride anode and nickel oxide hydroxide cathode."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Nickel%E2%80%93metal_hydride_battery&oldid=1061626676"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000931
 cco:ont00000931 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000326 ;
-                 rdfs:label "UPC-A Barcode"@en ;
-                 skos:definition "A UPC Barcode that consists of 12 numerical digits."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000326 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002035
+                                ] ;
+                rdfs:label "Material Copy of a UPC-A Barcode"@en ;
+                skos:altLabel "UPC-A Barcode"@en ;
+                skos:definition "A UPC Barcode that consists of 12 numerical digits."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000932
 cco:ont00000932 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Computing Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized by an Artifact participating in a computation process."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Computing Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized by an Artifact participating in a computation process."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000933
 cco:ont00000933 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000907 ;
-                 rdfs:label "Landline Telephone"@en ;
-                 skos:definition "A Telephone that is connected to a Telephone Network through a pair of wires."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telephone&oldid=1060006278"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000907 ;
+                rdfs:label "Landline Telephone"@en ;
+                skos:definition "A Telephone that is connected to a Telephone Network through a pair of wires."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telephone&oldid=1060006278"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000937
 cco:ont00000937 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Inhibiting Motion Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized by processes in which some Artifact is used to inhibit the motion of some object."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Inhibiting Motion Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized by processes in which some Artifact is used to inhibit the motion of some object."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000938
 cco:ont00000938 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001301 ;
-                 rdfs:label "Financial Artifact Function"@en ;
-                 skos:definition "A Service Artifact Function that is realized in processes of managing money."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Finance&oldid=1062402926"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001301 ;
+                rdfs:label "Financial Artifact Function"@en ;
+                skos:definition "A Service Artifact Function that is realized in processes of managing money."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Finance&oldid=1062402926"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000942
 cco:ont00000942 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000204 ;
-                 rdfs:label "Sniper Rifle"@en ;
-                 skos:definition "A Rifle that is designed to be highly accurate for long-range precision tactical shooting."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Sniper_rifle&oldid=1061592308"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000204 ;
+                rdfs:label "Sniper Rifle"@en ;
+                skos:definition "A Rifle that is designed to be highly accurate for long-range precision tactical shooting."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Sniper_rifle&oldid=1061592308"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000943
 cco:ont00000943 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001248 ;
-                 rdfs:label "Ocular Prosthesis"@en ;
-                 skos:definition "An Artificial Eye that is designed to replace a missing eye, but which does not function as an eye."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ocular_prosthesis&oldid=1061336760"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001248 ;
+                rdfs:label "Ocular Prosthesis"@en ;
+                skos:definition "An Artificial Eye that is designed to replace a missing eye, but which does not function as an eye."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ocular_prosthesis&oldid=1061336760"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000944
 cco:ont00000944 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000601 ;
-                 rdfs:label "Thermal Imaging Artifact Function"@en ;
-                 skos:definition "An Imaging Artifact Function that is realized during events in which an Artifact is used to create a visual representation of an entity using radiation from the far infrared region of the electromagnetic spectrum that the entity emits"@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000601 ;
+                rdfs:label "Thermal Imaging Artifact Function"@en ;
+                skos:definition "An Imaging Artifact Function that is realized during events in which an Artifact is used to create a visual representation of an entity using radiation from the far infrared region of the electromagnetic spectrum that the entity emits"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000945
 cco:ont00000945 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000547 ;
-                 rdfs:label "X-ray Telescope"@en ;
-                 skos:definition "A Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing X-rays to form an enhanced image of the Object."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=X-ray_telescope&oldid=1035025593"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000547 ;
+                rdfs:label "X-ray Telescope"@en ;
+                skos:definition "A Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing X-rays to form an enhanced image of the Object."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=X-ray_telescope&oldid=1035025593"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000947
 cco:ont00000947 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001100 ;
-                 rdfs:label "Temperature Measurement Artifact Function"@en ;
-                 skos:definition "A Measurement Artifact Function that is realized during events in which an Artifact is used to measure the Temperature of a specified object or class of objects."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001100 ;
+                rdfs:label "Temperature Measurement Artifact Function"@en ;
+                skos:definition "A Measurement Artifact Function that is realized during events in which an Artifact is used to measure the Temperature of a specified object or class of objects."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000952
 cco:ont00000952 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000210 ;
-                 rdfs:label "Electric Motor"@en ;
-                 skos:altLabel "Electric Engine"@en ;
-                 skos:definition "An Engine that is designed to convert electrical energy into mechanical energy."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electric_motor&oldid=1063829856"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000210 ;
+                rdfs:label "Electric Motor"@en ;
+                skos:altLabel "Electric Engine"@en ;
+                skos:definition "An Engine that is designed to convert electrical energy into mechanical energy."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electric_motor&oldid=1063829856"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000954
 cco:ont00000954 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000870 ;
-                 rdfs:label "Telecommunication Infrastructure"@en ;
-                 skos:definition "An Infrastructure System that is designed to support the use of Telecommunication Instruments to communicate."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Category:Telecommunications_infrastructure&oldid=989151314"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000870 ;
+                rdfs:label "Telecommunication Infrastructure"@en ;
+                skos:definition "An Infrastructure System that is designed to support the use of Telecommunication Instruments to communicate."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Category:Telecommunications_infrastructure&oldid=989151314"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000956
 cco:ont00000956 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001086 ;
-                 rdfs:label "Highway Interchange"@en ;
-                 skos:definition "A Road Junction that is designed to enable Ground Vehicles to exit one or more Highways and enter another Highway without directly crossing any other traffic stream."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Interchange_(road)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001086 ;
+                rdfs:label "Highway Interchange"@en ;
+                skos:definition "A Road Junction that is designed to enable Ground Vehicles to exit one or more Highways and enter another Highway without directly crossing any other traffic stream."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Interchange_(road)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000958
@@ -3519,26 +3659,26 @@ cco:ont00000958 rdf:type owl:Class .
 
 ###  https://www.commoncoreontologies.org/ont00000961
 cco:ont00000961 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000098 ;
-                 rdfs:label "Current Conversion Artifact Function"@en ;
-                 skos:definition "An Electrical Artifact Function that is realized by processes in which some Artifact is used to convert some electrical current."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000098 ;
+                rdfs:label "Current Conversion Artifact Function"@en ;
+                skos:definition "An Electrical Artifact Function that is realized by processes in which some Artifact is used to convert some electrical current."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000962
 cco:ont00000962 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000593 ;
-                 rdfs:label "Portion of Liquid Propellant"@en ;
-                 skos:definition "A Portion of Propellant that is stored in a liquid state."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000593 ;
+                rdfs:label "Portion of Liquid Propellant"@en ;
+                skos:definition "A Portion of Propellant that is stored in a liquid state."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000963
 cco:ont00000963 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000256 ;
-                 rdfs:label "Fuel Transfer System"@en ;
-                 skos:definition "A Fluid Control Artifact that is designed to facilitate the transfer of some Portion of Fuel from the Fuel Tank for use in some Engine."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000256 ;
+                rdfs:label "Fuel Transfer System"@en ;
+                skos:definition "A Fluid Control Artifact that is designed to facilitate the transfer of some Portion of Fuel from the Fuel Tank for use in some Engine."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000965
@@ -3547,1449 +3687,1520 @@ cco:ont00000965 rdf:type owl:Class .
 
 ###  https://www.commoncoreontologies.org/ont00000966
 cco:ont00000966 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000258 ;
-                 rdfs:label "EAN Barcode"@en ;
-                 skos:definition "A One-Dimensional Barcode that consists of 8 or 13 numerical digits and is used to scan consumer goods."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000258 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002025
+                                ] ;
+                rdfs:label "Material Copy of a EAN Barcode"@en ;
+                skos:altLabel "EAN Barcode"@en ;
+                skos:definition "A One-Dimensional Barcode that consists of 8 or 13 numerical digits and is used to scan consumer goods."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000968
 cco:ont00000968 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000204 ;
-                 rdfs:label "Assault Rifle"@en ;
-                 skos:definition "A Rifle that is designed to have selective-fire functionality and use an intermediate Cartridge and a detachable magazine."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Assault_rifle&oldid=1063774380"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000204 ;
+                rdfs:label "Assault Rifle"@en ;
+                skos:definition "A Rifle that is designed to have selective-fire functionality and use an intermediate Cartridge and a detachable magazine."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Assault_rifle&oldid=1063774380"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000972
 cco:ont00000972 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000966 ;
-                 rdfs:label "EAN-13 Barcode"@en ;
-                 skos:definition "An EAN Barcode that consists of 13 numerical digits and is used to designate products at the point of sale."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000966 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002028
+                                ] ;
+                rdfs:label "Material Copy of a EAN-13 Barcode"@en ;
+                skos:altLabel "EAN-13 Barcode"@en ;
+                skos:definition "An EAN Barcode that consists of 13 numerical digits and is used to designate products at the point of sale."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000980
 cco:ont00000980 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001084 ;
-                 rdfs:label "Portion of Waste Material"@en ;
-                 skos:definition "A Portion of Processed Material that serves no further use in terms of the initial user's own purposes of production, transformation, or consumption such that the Agent wants to dispose of it."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001084 ;
+                rdfs:label "Portion of Waste Material"@en ;
+                skos:definition "A Portion of Processed Material that serves no further use in terms of the initial user's own purposes of production, transformation, or consumption such that the Agent wants to dispose of it."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000985
 cco:ont00000985 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001350 ;
-                 rdfs:label "Thermal Insulation Artifact Function"@en ;
-                 skos:definition "A Thermal Control Artifact Function that is realized during events in which an Artifact prevents or reduces the transfer of heat between objects that are in thermal contact or in range of radiative influence."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Thermal_insulation&oldid=1059273300"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001350 ;
+                rdfs:label "Thermal Insulation Artifact Function"@en ;
+                skos:definition "A Thermal Control Artifact Function that is realized during events in which an Artifact prevents or reduces the transfer of heat between objects that are in thermal contact or in range of radiative influence."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Thermal_insulation&oldid=1059273300"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000988
 cco:ont00000988 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000804 ;
-                 rdfs:label "Reflective Prism"@en ;
-                 skos:definition "A Prism designed to reflect light in order to flip, invert, rotate, deviate, or displace a beam of light entering the Prism."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000804 ;
+                rdfs:label "Reflective Prism"@en ;
+                skos:definition "A Prism designed to reflect light in order to flip, invert, rotate, deviate, or displace a beam of light entering the Prism."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000993
 cco:ont00000993 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000961 ;
-                 rdfs:label "Power Rectifying Artifact Function"@en ;
-                 skos:definition "A Current Conversion Artifact Function that is realized by processes in which some Artifact is used to convert alternating current (AC) to direct current (DC)."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000961 ;
+                rdfs:label "Power Rectifying Artifact Function"@en ;
+                skos:definition "A Current Conversion Artifact Function that is realized by processes in which some Artifact is used to convert alternating current (AC) to direct current (DC)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000994
 cco:ont00000994 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000098 ;
-                 rdfs:label "Electrical Power Production Artifact Function"@en ;
-                 skos:definition "An Electrical Artifact Function that is realized during events in which an Artifact is used to generate electrical power."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000098 ;
+                rdfs:label "Electrical Power Production Artifact Function"@en ;
+                skos:definition "An Electrical Artifact Function that is realized during events in which an Artifact is used to generate electrical power."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000995
 cco:ont00000995 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000040 ;
-                 rdfs:label "Material Artifact"@en ;
-                 skos:definition "A Material Entity that was designed by some Agent to realize a certain Function."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000040 ;
+                rdfs:label "Material Artifact"@en ;
+                skos:definition "A Material Entity that was designed by some Agent to realize a certain Function."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000996
 cco:ont00000996 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000294 ;
-                 rdfs:label "Ramjet Engine"@en ;
-                 skos:altLabel "Ramjet"@en ;
-                 skos:definition "An Air-Breathing Jet Engine that uses the forward motion of the Engine to compress incoming air (without the use of an axial compressor) and decelerate it to subsonic speeds before adding the fuel and constantly combusting the mixture then expelling the exhaust out through the rear Propelling Nozzle to generate Thrust."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ramjet&oldid=1062836331"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000294 ;
+                rdfs:label "Ramjet Engine"@en ;
+                skos:altLabel "Ramjet"@en ;
+                skos:definition "An Air-Breathing Jet Engine that uses the forward motion of the Engine to compress incoming air (without the use of an axial compressor) and decelerate it to subsonic speeds before adding the fuel and constantly combusting the mixture then expelling the exhaust out through the rear Propelling Nozzle to generate Thrust."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ramjet&oldid=1062836331"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000998
 cco:ont00000998 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001036 ;
-                 rdfs:label "Telecommunication Network"@en ;
-                 skos:definition "A Communication System that is designed to enable the transmission of information over significant distances between Telecommunication Endpoints via Telecommunication Network Nodes and Lines."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telecommunications_network&oldid=1063347482"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001036 ;
+                rdfs:label "Telecommunication Network"@en ;
+                skos:definition "A Communication System that is designed to enable the transmission of information over significant distances between Telecommunication Endpoints via Telecommunication Network Nodes and Lines."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telecommunications_network&oldid=1063347482"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001000
 cco:ont00001000 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000252 ;
-                 rdfs:label "Spray Nozzle"@en ;
-                 skos:definition "A Nozzle that is designed to facilitate a conversion of the flow of a portion of liquid into a dynamic collection of drops dispersed in a portion of gas."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000252 ;
+                rdfs:label "Spray Nozzle"@en ;
+                skos:definition "A Nozzle that is designed to facilitate a conversion of the flow of a portion of liquid into a dynamic collection of drops dispersed in a portion of gas."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001002
 cco:ont00001002 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000798 ;
-                 rdfs:label "Message"@en ;
-                 skos:definition "An Information Bearing Artifact that is designed to bear some specific Information Content Entity that is relatively brief and to be transmitted from a sender to a recipient."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Message&oldid=1060098631"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000798 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002010
+                                ] ;
+                rdfs:label "Material Copy of a Message"@en ;
+                skos:altLabel "Message"@en ;
+                skos:definition "An Information Bearing Artifact that is designed to bear some specific Information Content Entity that is relatively brief and to be transmitted from a sender to a recipient."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Message&oldid=1060098631"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001003
 cco:ont00001003 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001150 ;
-                 rdfs:label "Cartridge"@en ;
-                 skos:definition "A Portion of Ammunition that is designed to package a Bullet, a propellant substance, and a primer within a case that is designed to fit within the firing chamber of a Firearm."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Cartridge_(firearms)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001150 ;
+                rdfs:label "Cartridge"@en ;
+                skos:definition "A Portion of Ammunition that is designed to package a Bullet, a propellant substance, and a primer within a case that is designed to fit within the firing chamber of a Firearm."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Cartridge_(firearms)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001005
 cco:ont00001005 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000294 ;
-                 rdfs:label "Turbojet Air-Breathing Jet Engine"@en ;
-                 skos:definition "An Air-Breathing Jet Engine that uses a Turbojet, which consists of a Turbine with a Propelling Nozzle."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Turbojet&oldid=1060948529"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000294 ;
+                rdfs:label "Turbojet Air-Breathing Jet Engine"@en ;
+                skos:definition "An Air-Breathing Jet Engine that uses a Turbojet, which consists of a Turbine with a Propelling Nozzle."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Turbojet&oldid=1060948529"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001007
 cco:ont00001007 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000928 ;
-                 rdfs:label "Passenger Train Car"@en ;
-                 skos:definition "A Train Car that is designed to transport passengers."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Passenger_car_(rail)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000928 ;
+                rdfs:label "Passenger Train Car"@en ;
+                skos:definition "A Train Car that is designed to transport passengers."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Passenger_car_(rail)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001008
 cco:ont00001008 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000445 ;
-                 rdfs:label "Biological Weapon"@en ;
-                 skos:definition "A Weapon that is designed to inflict harm, incapacity, or death by means of releasing disease-producing agents—such as bacteria, viruses, or fungi."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Biological_warfare&oldid=1062972883"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000445 ;
+                rdfs:label "Biological Weapon"@en ;
+                skos:definition "A Weapon that is designed to inflict harm, incapacity, or death by means of releasing disease-producing agents—such as bacteria, viruses, or fungi."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Biological_warfare&oldid=1062972883"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001009
 cco:ont00001009 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000547 ;
-                 rdfs:label "Optical Telescope"@en ;
-                 skos:definition "A Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing visible light to form an enhanced image of the Object."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Optical_telescope&oldid=1062201329"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000547 ;
+                rdfs:label "Optical Telescope"@en ;
+                skos:definition "A Telescope that is designed to aid in the observation of spatially distant Objects by means of collecting and focusing visible light to form an enhanced image of the Object."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Optical_telescope&oldid=1062201329"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001011
 cco:ont00001011 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000053 ;
-                 rdfs:label "Automobile"@en ;
-                 skos:definition "A Ground Motor Vehicle that is designed to transport a small number of passengers while traveling on four tired wheels."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Car&oldid=1064116950"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000053 ;
+                rdfs:label "Automobile"@en ;
+                skos:definition "A Ground Motor Vehicle that is designed to transport a small number of passengers while traveling on four tired wheels."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Car&oldid=1064116950"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001012
 cco:ont00001012 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000258 ;
-                 rdfs:comment "Further variants of GS1 DataBar have not been defined here."@en ;
-                 rdfs:label "GS1 DataBar Barcode"@en ;
-                 skos:definition "A One-Dimensional Barcode that consists of 12-14 numerical digits and is used in retail and healthcare."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000258 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002031
+                                ] ;
+                rdfs:comment "Further variants of GS1 DataBar have not been defined here."@en ;
+                rdfs:label "Material Copy of a GS1 DataBar Barcode"@en ;
+                skos:altLabel "GS1 DataBar Barcode"@en ;
+                skos:definition "A One-Dimensional Barcode that consists of 12-14 numerical digits and is used in retail and healthcare."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001013
 cco:ont00001013 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Heating Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in a process in which the thermal energy of a system increases."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Heating Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in a process in which the thermal energy of a system increases."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001015
 cco:ont00001015 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000646 ;
-                 rdfs:label "Controlled-Access Highway"@en ;
-                 skos:altLabel "Expressway"@en ,
-                               "Freeway"@en ,
-                               "Motorway"@en ;
-                 skos:definition "A Highway that is designed for high-speed vehicular traffic, with all traffic flow and ingress/egress regulated."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Controlled-access_highway&oldid=1063655601"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000646 ;
+                rdfs:label "Controlled-Access Highway"@en ;
+                skos:altLabel "Expressway"@en ,
+                              "Freeway"@en ,
+                              "Motorway"@en ;
+                skos:definition "A Highway that is designed for high-speed vehicular traffic, with all traffic flow and ingress/egress regulated."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Controlled-access_highway&oldid=1063655601"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001018
 cco:ont00001018 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000350 ;
-                 rdfs:label "Equipment Cooling System"@en ;
-                 skos:definition "A Cooling System that is designed to cool some piece of equipment."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000350 ;
+                rdfs:label "Equipment Cooling System"@en ;
+                skos:definition "A Cooling System that is designed to cool some piece of equipment."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001019
 cco:ont00001019 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000723 ;
-                 rdfs:label "Steering Control System"@en ;
-                 skos:definition "A Vehicle Control System that is designed to control the direction some Vehicle is traveling."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000723 ;
+                rdfs:label "Steering Control System"@en ;
+                skos:definition "A Vehicle Control System that is designed to control the direction some Vehicle is traveling."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001020
 cco:ont00001020 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000838 ;
-                 rdfs:label "Portion of Gaseous Fuel"@en ;
-                 skos:definition "A Portion of Fuel that is stored in a gaseous state."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000838 ;
+                rdfs:label "Portion of Gaseous Fuel"@en ;
+                skos:definition "A Portion of Fuel that is stored in a gaseous state."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001024
 cco:ont00001024 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000394 ;
-                 rdfs:label "Spark Ignition Engine"@en ;
-                 skos:definition "An Internal Combustion Engine that is designed to operate by generating a spark to ignite a portion of Fuel and Oxidizer mixture."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000394 ;
+                rdfs:label "Spark Ignition Engine"@en ;
+                skos:definition "An Internal Combustion Engine that is designed to operate by generating a spark to ignite a portion of Fuel and Oxidizer mixture."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001025
 cco:ont00001025 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001049 ;
-                 rdfs:label "Electric Generator"@en ;
-                 skos:definition "An Electrical Power Source that is designed to convert mechanical energy to electrical energy for use in an external circuit."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electric_generator&oldid=1057805035"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001049 ;
+                rdfs:label "Electric Generator"@en ;
+                skos:definition "An Electrical Power Source that is designed to convert mechanical energy to electrical energy for use in an external circuit."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electric_generator&oldid=1057805035"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001027
 cco:ont00001027 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000095 ;
-                 rdfs:label "Trim Tab"@en ;
-                 skos:definition "A Control Surface that is designed to counteract hydro-, aerodynamic, or other forces in order to stabilize the Vehicle it is part of in the desired Attitude."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Trim_tab&oldid=1054550485"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000095 ;
+                rdfs:label "Trim Tab"@en ;
+                skos:definition "A Control Surface that is designed to counteract hydro-, aerodynamic, or other forces in order to stabilize the Vehicle it is part of in the desired Attitude."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Trim_tab&oldid=1054550485"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001029
 cco:ont00001029 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001150 ;
-                 rdfs:label "Unguided Rocket"@en ;
-                 skos:altLabel "Rocket"@en ;
-                 skos:definition "A Portion of Ammunition that is designed to be a self-propelled, but unguided, projectile that delivers some payload (explosive or other) over relatively long distances through the use of a Rocket Engine."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Rocket_(weapon)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001150 ;
+                rdfs:label "Unguided Rocket"@en ;
+                skos:altLabel "Rocket"@en ;
+                skos:definition "A Portion of Ammunition that is designed to be a self-propelled, but unguided, projectile that delivers some payload (explosive or other) over relatively long distances through the use of a Rocket Engine."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Rocket_(weapon)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001030
 cco:ont00001030 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000796 ;
-                 rdfs:label "Train"@en ;
-                 skos:altLabel "Railroad Train"@en ,
-                               "Railway Train"@en ;
-                 skos:definition "A Rail Transport Vehicle that consists of a series of connected Train Cars or Railcars."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Train&oldid=1064071492"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000796 ;
+                rdfs:label "Train"@en ;
+                skos:altLabel "Railroad Train"@en ,
+                              "Railway Train"@en ;
+                skos:definition "A Rail Transport Vehicle that consists of a series of connected Train Cars or Railcars."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Train&oldid=1064071492"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001034
 cco:ont00001034 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000774 ;
-                 rdfs:label "Full Motion Video Camera"@en ;
-                 skos:definition "A Video Camera that is designed to capture and record images of sufficiently high quality and in rapid enough succession that the resulting video supports smooth playback."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000774 ;
+                rdfs:label "Full Motion Video Camera"@en ;
+                skos:definition "A Video Camera that is designed to capture and record images of sufficiently high quality and in rapid enough succession that the resulting video supports smooth playback."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001036
 cco:ont00001036 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Communication System"@en ;
-                 skos:definition "A Material Artifact that is designed to enable some Act of Communication by means of transmission systems, relay stations, tributary stations, and data terminal equipment, usually capable of interconnection and interoperation to form an integrated whole."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Communications_system&oldid=1058600948"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Communication System"@en ;
+                skos:definition "A Material Artifact that is designed to enable some Act of Communication by means of transmission systems, relay stations, tributary stations, and data terminal equipment, usually capable of interconnection and interoperation to form an integrated whole."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Communications_system&oldid=1058600948"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001038
 cco:ont00001038 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001105 ;
-                 rdfs:label "Nickel Cadmium Electric Battery"@en ;
-                 skos:altLabel "NiCad Battery"@en ;
-                 skos:definition "A Secondary Cell Electric Battery that has a cadmium anode and nickel oxide hydroxide cathode."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Nickel%E2%80%93cadmium_battery&oldid=1061809659"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001105 ;
+                rdfs:label "Nickel Cadmium Electric Battery"@en ;
+                skos:altLabel "NiCad Battery"@en ;
+                skos:definition "A Secondary Cell Electric Battery that has a cadmium anode and nickel oxide hydroxide cathode."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Nickel%E2%80%93cadmium_battery&oldid=1061809659"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001042
 cco:ont00001042 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Equipment Mount"@en ;
-                 skos:definition "A Material Artifact that is designed to support an Artifact."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Equipment Mount"@en ;
+                skos:definition "A Material Artifact that is designed to support an Artifact."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001043
 cco:ont00001043 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000713 ;
-                 rdfs:label "Aircraft"@en ;
-                 skos:definition "A Vehicle that is designed to convey passengers, cargo, or equipment from one location to another by air travel."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Aircraft&oldid=1063924562"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000713 ;
+                rdfs:label "Aircraft"@en ;
+                skos:definition "A Vehicle that is designed to convey passengers, cargo, or equipment from one location to another by air travel."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Aircraft&oldid=1063924562"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001044
 cco:ont00001044 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Nuclear Radiation Detection Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized during events in which an Artifact is used to detect the presence of nuclear radiation particles."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Nuclear Radiation Detection Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized during events in which an Artifact is used to detect the presence of nuclear radiation particles."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001045
 cco:ont00001045 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000319 ;
-                 rdfs:label "Artifact Model"@en ;
-                 skos:definition "A Directive Information Content Entity that prescribes a common set of Functions and Qualities to inhere in a set of artifact instances."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000319 ;
+                rdfs:label "Artifact Model"@en ;
+                skos:definition "A Directive Information Content Entity that prescribes a common set of Functions and Qualities to inhere in a set of artifact instances."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001046
 cco:ont00001046 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001002 ;
-                 rdfs:label "Notification Message"@en ;
-                 skos:definition "A Message that is designed to bear an Information Content Entity that describes a scenario that has been determined to merit attention by the recipient."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001002 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002013
+                                ] ;
+                rdfs:label "Material Copy of a Notification Message"@en ;
+                skos:altLabel "Notification Message"@en ;
+                skos:definition "A Message that is designed to bear an Information Content Entity that describes a scenario that has been determined to merit attention by the recipient."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001049
 cco:ont00001049 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000288 ;
-                 rdfs:label "Electrical Power Source"@en ;
-                 skos:definition "A Power Source that is designed to generate, control, and transfer power in the form of electrical energy."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000288 ;
+                rdfs:label "Electrical Power Source"@en ;
+                skos:definition "A Power Source that is designed to generate, control, and transfer power in the form of electrical energy."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001050
 cco:ont00001050 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000716 ;
-                 rdfs:label "Primary Cell Electric Battery"@en ;
-                 skos:altLabel "Primary Cell Battery"@en ;
-                 skos:definition "A Electric Battery that is designed for one-time use and not to be recharged."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Primary_cell&oldid=1047226932"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000716 ;
+                rdfs:label "Primary Cell Electric Battery"@en ;
+                skos:altLabel "Primary Cell Battery"@en ;
+                skos:definition "A Electric Battery that is designed for one-time use and not to be recharged."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Primary_cell&oldid=1047226932"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001051
 cco:ont00001051 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000445 ;
-                 rdfs:label "Projectile Launcher"@en ;
-                 skos:definition "A Weapon that is designed to inflict damage or harm by means of launching a high-velocity projectile at a target."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Projectile&oldid=1062048285"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000445 ;
+                rdfs:label "Projectile Launcher"@en ;
+                skos:definition "A Weapon that is designed to inflict damage or harm by means of launching a high-velocity projectile at a target."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Projectile&oldid=1062048285"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001054
 cco:ont00001054 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000499 ;
-                 rdfs:label "Helical Antenna"@en ;
-                 skos:definition "A Wire Antenna that consists of a conducting wire wound in the form of a helix that is typically mounted over a ground plane with a feed line connected between the bottom of the helix and the ground plane."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Helical_antenna&oldid=1062343033"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000499 ;
+                rdfs:label "Helical Antenna"@en ;
+                skos:definition "A Wire Antenna that consists of a conducting wire wound in the form of a helix that is typically mounted over a ground plane with a feed line connected between the bottom of the helix and the ground plane."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Helical_antenna&oldid=1062343033"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001060
 cco:ont00001060 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Fuel System"@en ;
-                 skos:definition "A Material Artifact that is designed to pump, manage, and deliver some Portion of Fuel to the Propulsion System and Auxiliary Power Unit of some Vehicle."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Aircraft_fuel_system&oldid=1003132173"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Fuel System"@en ;
+                skos:definition "A Material Artifact that is designed to pump, manage, and deliver some Portion of Fuel to the Propulsion System and Auxiliary Power Unit of some Vehicle."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Aircraft_fuel_system&oldid=1003132173"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001061
 cco:ont00001061 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000053 ;
-                 rdfs:label "Motorcycle"@en ;
-                 skos:altLabel "Motorbike"@en ;
-                 skos:definition "A Ground Motor Vehicle that is designed to transport a very small number of passengers (usually 1 or 2) while traveling on two or three tired wheels."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Motorcycle&oldid=1063743553"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000053 ;
+                rdfs:label "Motorcycle"@en ;
+                skos:altLabel "Motorbike"@en ;
+                skos:definition "A Ground Motor Vehicle that is designed to transport a very small number of passengers (usually 1 or 2) while traveling on two or three tired wheels."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Motorcycle&oldid=1063743553"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001064
 cco:ont00001064 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000798 ;
-                 rdfs:comment "For information on types of barcodes, see: https://www.scandit.com/types-barcodes-choosing-right-barcode/"@en ;
-                 rdfs:label "Barcode"@en ;
-                 skos:definition "An Information Bearing Artifact that is designed to bear one or more geometric shapes that concretize some Directive Information Content Entity."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Barcode&oldid=1059844765"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000798 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002014
+                                ] ;
+                rdfs:comment "For information on types of barcodes, see: https://www.scandit.com/types-barcodes-choosing-right-barcode/"@en ;
+                rdfs:label "Material Copy of a Barcode"@en ;
+                skos:altLabel "Barcode"@en ;
+                skos:definition "An Information Bearing Artifact that is designed to bear one or more geometric shapes that concretize some Directive Information Content Entity."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Barcode&oldid=1059844765"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001067
 cco:ont00001067 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Laser"@en ;
-                 skos:definition "A Material Artifact that is designed to emit light coherently through a process of optical amplification based on the stimulated emission of electromagnetic radiation."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Laser&oldid=1059215159"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Laser"@en ;
+                skos:definition "A Material Artifact that is designed to emit light coherently through a process of optical amplification based on the stimulated emission of electromagnetic radiation."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Laser&oldid=1059215159"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001070
 cco:ont00001070 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Fluid Control Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in processes in which some Artifact is used to control the direction or flow of some fluid."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Fluid Control Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in processes in which some Artifact is used to control the direction or flow of some fluid."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001071
 cco:ont00001071 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:BFO_0000197 ;
-                                   owl:someValuesFrom cco:ont00000713
-                                 ] ;
-                 rdfs:label "Payload Capacity"@en ;
-                 skos:definition "An Artifact Function that inheres in a Vehicle that is designed to transport Payload, and which is typically characterized by the maximum Weight, Mass, or Volume of Payload that the Vehicle can transport."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Payload&oldid=1035953573"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000197 ;
+                                  owl:someValuesFrom cco:ont00000713
+                                ] ;
+                rdfs:label "Payload Capacity"@en ;
+                skos:definition "An Artifact Function that inheres in a Vehicle that is designed to transport Payload, and which is typically characterized by the maximum Weight, Mass, or Volume of Payload that the Vehicle can transport."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Payload&oldid=1035953573"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001077
 cco:ont00001077 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000848 ;
-                 rdfs:label "Heavy Machine Gun"@en ;
-                 skos:definition "A Mounted Gun that is designed to fire ammunition greater than .50 caliber or 12.7mm ammunition in quick succession from an ammunition belt, and which typically weighs more than 30lbs."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Heavy_machine_gun&oldid=1047303735"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000848 ;
+                rdfs:label "Heavy Machine Gun"@en ;
+                skos:definition "A Mounted Gun that is designed to fire ammunition greater than .50 caliber or 12.7mm ammunition in quick succession from an ammunition belt, and which typically weighs more than 30lbs."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Heavy_machine_gun&oldid=1047303735"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001082
 cco:ont00001082 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001145 ;
-                 rdfs:label "Patch Receiver"@en ;
-                 skos:definition "A Radio Receiver that uses a Patch Antenna to intercept radio signals."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001145 ;
+                rdfs:label "Patch Receiver"@en ;
+                skos:definition "A Radio Receiver that uses a Patch Antenna to intercept radio signals."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001083
 cco:ont00001083 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000056 ;
-                 rdfs:label "Air-Breathing Combustion Engine"@en ;
-                 skos:definition "A Reaction Engine that functions by drawing a continuous stream of air into and through the Engine where it is compressed, mixed with a Portion of Fuel, ignited, and then expelled as exhaust gas."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Engine&oldid=1063879193"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000056 ;
+                rdfs:label "Air-Breathing Combustion Engine"@en ;
+                skos:definition "A Reaction Engine that functions by drawing a continuous stream of air into and through the Engine where it is compressed, mixed with a Portion of Fuel, ignited, and then expelled as exhaust gas."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Engine&oldid=1063879193"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001084
 cco:ont00001084 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Portion of Processed Material"@en ;
-                 skos:definition "A Material Artifact that is the output of an Act of Artifact Processing."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Portion of Processed Material"@en ;
+                skos:definition "A Material Artifact that is the output of an Act of Artifact Processing."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001085
 cco:ont00001085 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Reflection Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized by an Artifact participating in a reflection event in which the Artifact causes a change in a wavefront at an interface between the reflecting medium and the transmission medium such that the wavefront returns into the transmission medium."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Reflection Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized by an Artifact participating in a reflection event in which the Artifact causes a change in a wavefront at an interface between the reflecting medium and the transmission medium such that the wavefront returns into the transmission medium."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001086
 cco:ont00001086 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001326 ;
-                 rdfs:label "Road Junction"@en ;
-                 skos:definition "A Land Transportation Artifact that is designed to enable Ground Vehicles to exit one Road and enter another."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Junction_(road)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001326 ;
+                rdfs:label "Road Junction"@en ;
+                skos:definition "A Land Transportation Artifact that is designed to enable Ground Vehicles to exit one Road and enter another."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Junction_(road)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001087
 cco:ont00001087 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001306 ;
-                 rdfs:label "Orientation Observation Artifact Function"@en ;
-                 skos:altLabel "Attitude Observation Artifact Function"@en ;
-                 skos:definition "An Observation Artifact Function that is realized during events in which an Artifact is used to collect information about the Orientation of a specified object or class of objects."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001306 ;
+                rdfs:label "Orientation Observation Artifact Function"@en ;
+                skos:altLabel "Attitude Observation Artifact Function"@en ;
+                skos:definition "An Observation Artifact Function that is realized during events in which an Artifact is used to collect information about the Orientation of a specified object or class of objects."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001092
 cco:ont00001092 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000098 ;
-                 rdfs:label "Electrical Power Storage Artifact Function"@en ;
-                 skos:altLabel "Capacitance"@en ;
-                 skos:definition "An Electrical Artifact Function that is realized during events in which an Artifact is used to store electrical power to be released at a later time."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000098 ;
+                rdfs:label "Electrical Power Storage Artifact Function"@en ;
+                skos:altLabel "Capacitance"@en ;
+                skos:definition "An Electrical Artifact Function that is realized during events in which an Artifact is used to store electrical power to be released at a later time."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001093
 cco:ont00001093 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000475 ;
-                 rdfs:label "Coin"@en ;
-                 skos:definition "A Portion of Cash that consists of a flat, portable, round pieces of metal designed to bear some specified Financial Value."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000475 ;
+                rdfs:label "Coin"@en ;
+                skos:definition "A Portion of Cash that consists of a flat, portable, round pieces of metal designed to bear some specified Financial Value."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001095
 cco:ont00001095 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000363 ;
-                 rdfs:label "Cellular Telecommunication Network"@en ;
-                 skos:altLabel "Cellular Network"@en ,
-                               "Mobile Telecommunication Network"@en ;
-                 skos:definition "A Wireless Telecommunication Network where the last link between the network and the end user is wireless and is distributed over service areas called cells."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Cellular_network&oldid=1061429562"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000363 ;
+                rdfs:label "Cellular Telecommunication Network"@en ;
+                skos:altLabel "Cellular Network"@en ,
+                              "Mobile Telecommunication Network"@en ;
+                skos:definition "A Wireless Telecommunication Network where the last link between the network and the end user is wireless and is distributed over service areas called cells."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Cellular_network&oldid=1061429562"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001096
 cco:ont00001096 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001104 ;
-                 rdfs:label "Submachine Gun"@en ;
-                 skos:definition "An Long Gun that is designed to be have automatic-fire functionality, fire pistol-caliber ammunition that is magazine-fed, and which is usually smaller than other automatic firearms."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Submachine_gun&oldid=1063939013"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001104 ;
+                rdfs:label "Submachine Gun"@en ;
+                skos:definition "An Long Gun that is designed to be have automatic-fire functionality, fire pistol-caliber ammunition that is magazine-fed, and which is usually smaller than other automatic firearms."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Submachine_gun&oldid=1063939013"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001097
 cco:ont00001097 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001278 ;
-                 rdfs:label "Common Stock"@en ;
-                 skos:definition "Stock that entitles its holder to voting on corporate decisions."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001278 ;
+                rdfs:label "Common Stock"@en ;
+                skos:definition "Stock that entitles its holder to voting on corporate decisions."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001099
 cco:ont00001099 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001326 ;
-                 rdfs:label "Bridge"@en ;
-                 skos:definition "A Land Transportation Artifact that is designed to span physical obstacles without closing the way underneath to enable Persons or Ground Vehicles to pass over the obstacles."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Bridge&oldid=1061858310" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001326 ;
+                rdfs:label "Bridge"@en ;
+                skos:definition "A Land Transportation Artifact that is designed to span physical obstacles without closing the way underneath to enable Persons or Ground Vehicles to pass over the obstacles."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Bridge&oldid=1061858310" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001100
 cco:ont00001100 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Measurement Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized during events in which an Artifact is used to measure one or more features of a specified object or class of objects."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Measurement Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized during events in which an Artifact is used to measure one or more features of a specified object or class of objects."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001103
 cco:ont00001103 rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( cco:ont00000686
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty cco:ont00001916 ;
-                                                              owl:someValuesFrom cco:ont00001045
-                                                            ]
-                                                          ) ;
-                                       rdf:type owl:Class
-                                     ] ;
-                 rdfs:subClassOf cco:ont00000686 ;
-                 rdfs:label "Artifact Model Name"@en ;
-                 skos:definition "A Designative Information Content Entity that designates some Artifact Model."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000686
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001916 ;
+                                                             owl:someValuesFrom cco:ont00001045
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000686 ;
+                rdfs:label "Artifact Model Name"@en ;
+                skos:definition "A Designative Information Content Entity that designates some Artifact Model."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001104
 cco:ont00001104 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000088 ;
-                 rdfs:label "Long Gun"@en ;
-                 skos:definition "A Firearm that is designed to have a longer barrel than a Hand Gun and to be fired while braced against the shoulder."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Long_gun&oldid=1063715506"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000088 ;
+                rdfs:label "Long Gun"@en ;
+                skos:definition "A Firearm that is designed to have a longer barrel than a Hand Gun and to be fired while braced against the shoulder."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Long_gun&oldid=1063715506"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001105
 cco:ont00001105 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000716 ;
-                 rdfs:label "Secondary Cell Electric Battery"@en ;
-                 skos:altLabel "Rechargeable Battery"@en ,
-                               "Secondary Cell Battery"@en ;
-                 skos:definition "An Electric Battery that is designed to be recharged."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rechargeable_battery&oldid=1064096406"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000716 ;
+                rdfs:label "Secondary Cell Electric Battery"@en ;
+                skos:altLabel "Rechargeable Battery"@en ,
+                              "Secondary Cell Battery"@en ;
+                skos:definition "An Electric Battery that is designed to be recharged."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rechargeable_battery&oldid=1064096406"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001117
 cco:ont00001117 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000252 ;
-                 rdfs:label "Propelling Nozzle"@en ;
-                 skos:altLabel "Jet Nozzle"@en ;
-                 skos:definition "A Nozzle that is used to convert a propulsion Engine into a Jet Engine and functions by using its narrowest part, the throat, to increase Pressure within the Engine by constricting flow, usually until the flow chokes, then expanding the exhaust stream to, or near to, atmospheric pressure, while forming it into a high speed jet to propel the Vehicle."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Propelling_nozzle&oldid=1061239812"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000252 ;
+                rdfs:label "Propelling Nozzle"@en ;
+                skos:altLabel "Jet Nozzle"@en ;
+                skos:definition "A Nozzle that is used to convert a propulsion Engine into a Jet Engine and functions by using its narrowest part, the throat, to increase Pressure within the Engine by constricting flow, usually until the flow chokes, then expanding the exhaust stream to, or near to, atmospheric pressure, while forming it into a high speed jet to propel the Vehicle."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Propelling_nozzle&oldid=1061239812"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001119
 cco:ont00001119 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001298 ;
-                 rdfs:label "Document Form"@en ;
-                 skos:definition "A Document having Document Fields as parts in which to write or select prescribed content."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Form_(document)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001298 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002044
+                                ] ;
+                rdfs:label "Material Copy of a Form Document"@en ;
+                skos:altLabel "Document Form"@en ;
+                skos:definition "A Document having Document Fields as parts in which to write or select prescribed content."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Form_(document)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001121
 cco:ont00001121 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000294 ;
-                 rdfs:label "Scramjet Engine"@en ;
-                 skos:altLabel "Scramjet"@en ,
-                               "Supersonic Combusting Ramjet"@en ;
-                 skos:definition "An Air-Breathing Jet Engine that uses the forward motion of the Engine to compress incoming air at supersonic speeds before adding the fuel and constantly combusting the mixture then expelling the exhaust out through the rear Propelling Nozzle to generate Thrust."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Scramjet&oldid=1062429697"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000294 ;
+                rdfs:label "Scramjet Engine"@en ;
+                skos:altLabel "Scramjet"@en ,
+                              "Supersonic Combusting Ramjet"@en ;
+                skos:definition "An Air-Breathing Jet Engine that uses the forward motion of the Engine to compress incoming air at supersonic speeds before adding the fuel and constantly combusting the mixture then expelling the exhaust out through the rear Propelling Nozzle to generate Thrust."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Scramjet&oldid=1062429697"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001123
 cco:ont00001123 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001153 ;
-                 rdfs:label "Poison Artifact Function"@en ;
-                 skos:definition "A Damaging Artifact Function that is realized in a process which causes illness in, or the death of, a living thing."@en ;
-                 cco:ont00001754 "http://www.dictionary.com/browse/poison" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001153 ;
+                rdfs:label "Poison Artifact Function"@en ;
+                skos:definition "A Damaging Artifact Function that is realized in a process which causes illness in, or the death of, a living thing."@en ;
+                cco:ont00001754 "http://www.dictionary.com/browse/poison" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001124
 cco:ont00001124 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001150 ;
-                 rdfs:label "Precision-Guided Missile"@en ;
-                 skos:altLabel "Missile"@en ;
-                 skos:definition "A Portion of Ammunition that is designed to be a self-propelled and precision-guided projectile that delivers some payload (explosive or other) over relatively long distances."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Missile&oldid=1062028589"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001150 ;
+                rdfs:label "Precision-Guided Missile"@en ;
+                skos:altLabel "Missile"@en ;
+                skos:definition "A Portion of Ammunition that is designed to be a self-propelled and precision-guided projectile that delivers some payload (explosive or other) over relatively long distances."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Missile&oldid=1062028589"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001129
 cco:ont00001129 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000113 ;
-                 rdfs:label "Pressurization Control Artifact Function"@en ;
-                 skos:definition "A Ventilation Control Artifact Function that is realized by processes in which some Artifact is used to control the partial pressure of air in some space."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000113 ;
+                rdfs:label "Pressurization Control Artifact Function"@en ;
+                skos:definition "A Ventilation Control Artifact Function that is realized by processes in which some Artifact is used to control the partial pressure of air in some space."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001131
 cco:ont00001131 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000966 ;
-                 rdfs:label "EAN-8 Barcode"@en ;
-                 skos:definition "An EAN Barcode that consists of 8 numerical digits and is used to designate products at the point of sale."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000966 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002029
+                                ] ;
+                rdfs:label "Material Copy of a EAN-8 Barcode"@en ;
+                skos:altLabel "EAN-8 Barcode"@en ;
+                skos:definition "An EAN Barcode that consists of 8 numerical digits and is used to designate products at the point of sale."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001134
 cco:ont00001134 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Vehicle Frame"@en ;
-                 skos:definition "A Material Artifact that is designed to be the main supporting structure of some Vehicle."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Vehicle_frame&oldid=1054003530"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Vehicle Frame"@en ;
+                skos:definition "A Material Artifact that is designed to be the main supporting structure of some Vehicle."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Vehicle_frame&oldid=1054003530"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001135
 cco:ont00001135 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000838 ;
-                 rdfs:label "Portion of Liquid Fuel"@en ;
-                 skos:definition "A Portion of Fuel that is stored in a liquid state."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000838 ;
+                rdfs:label "Portion of Liquid Fuel"@en ;
+                skos:definition "A Portion of Fuel that is stored in a liquid state."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001138
 cco:ont00001138 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000499 ;
-                 rdfs:label "Beverage Antenna"@en ;
-                 skos:definition "A Wire Antenna that consists of a horizontal wire one-half to two wavelengths long that is suspended above the ground with one end attached to the receiver feedline and the other grounded and which is typically used in the low and medium frequency radio bands."@en ;
-                 cco:ont00001754 "Adapted from: https://en.wikipedia.org/wiki/Beverage_antenna" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000499 ;
+                rdfs:label "Beverage Antenna"@en ;
+                skos:definition "A Wire Antenna that consists of a horizontal wire one-half to two wavelengths long that is suspended above the ground with one end attached to the receiver feedline and the other grounded and which is typically used in the low and medium frequency radio bands."@en ;
+                cco:ont00001754 "Adapted from: https://en.wikipedia.org/wiki/Beverage_antenna" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001139
 cco:ont00001139 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000713 ;
-                 rdfs:label "Spacecraft"@en ;
-                 skos:definition "A Vehicle that is designed to convey passengers, cargo, or equipment from one location to another by Spaceflight."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Spacecraft&oldid=1062102614"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000713 ;
+                rdfs:label "Spacecraft"@en ;
+                skos:definition "A Vehicle that is designed to convey passengers, cargo, or equipment from one location to another by Spaceflight."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Spacecraft&oldid=1062102614"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001140
 cco:ont00001140 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Flywheel"@en ;
-                 skos:definition "A Material Artifact that is designed to store rotational energy such that it has a significant moment of inertia which enables it to resist changes in rotational speed."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Flywheel&oldid=1061360783"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Flywheel"@en ;
+                skos:definition "A Material Artifact that is designed to store rotational energy such that it has a significant moment of inertia which enables it to resist changes in rotational speed."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Flywheel&oldid=1061360783"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001141
 cco:ont00001141 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000023 ;
-                 rdfs:comment "The disposition will typically be a function of an artifact, which is often designed to be part of some Infrastructure system. But not always. In some cases an entity may be repurposed to be an element of some Infrastructure. In those cases it is a capability of that entity that supports the functioning of the system."@en ;
-                 rdfs:label "Infrastructure Role"@en ;
-                 skos:definition "A Role that inheres in the bearer of a Disposition and has been assigned to an Infrastructure System such that the realization of that Disposition is sometimes part of the functioning of the Infrastructure System."@en ;
-                 cco:ont00001754 "https://archive.org/details/economicsprincip00osul/page/n489/mode/2up"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000023 ;
+                rdfs:comment "The disposition will typically be a function of an artifact, which is often designed to be part of some Infrastructure system. But not always. In some cases an entity may be repurposed to be an element of some Infrastructure. In those cases it is a capability of that entity that supports the functioning of the system."@en ;
+                rdfs:label "Infrastructure Role"@en ;
+                skos:definition "A Role that inheres in the bearer of a Disposition and has been assigned to an Infrastructure System such that the realization of that Disposition is sometimes part of the functioning of the Infrastructure System."@en ;
+                cco:ont00001754 "https://archive.org/details/economicsprincip00osul/page/n489/mode/2up"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001145
 cco:ont00001145 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000903 ;
-                 rdfs:label "Radio Receiver"@en ;
-                 skos:definition "A Radio Communication Instrument that is an electronic device that is designed to extract information from radio waves intercepted by a Radio Antenna by using electronic filters to separate the desired radio frequency signal from other signals, an electronic amplifier to increase the power of the signal, and demodulation to recover the desired information."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Radio_receiver&oldid=1060111342"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000903 ;
+                rdfs:label "Radio Receiver"@en ;
+                skos:definition "A Radio Communication Instrument that is an electronic device that is designed to extract information from radio waves intercepted by a Radio Antenna by using electronic filters to separate the desired radio frequency signal from other signals, an electronic amplifier to increase the power of the signal, and demodulation to recover the desired information."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Radio_receiver&oldid=1060111342"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001148
 cco:ont00001148 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000727 ;
-                 rdfs:label "Electromagnetic Communication Artifact Function"@en ;
-                 skos:definition "A Communication Artifact Function that is realized in a process that conveys meaningful signs by means of electromagnetic radiation."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telecommunications&oldid=1061143810"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000727 ;
+                rdfs:label "Electromagnetic Communication Artifact Function"@en ;
+                skos:definition "A Communication Artifact Function that is realized in a process that conveys meaningful signs by means of electromagnetic radiation."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telecommunications&oldid=1061143810"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001150
 cco:ont00001150 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000445 ;
-                 rdfs:label "Portion of Ammunition"@en ;
-                 skos:definition "A Weapon that is designed to inflict harm, damage, or incapacity by being projected toward its target at a significant Velocity."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ammunition&oldid=1062875850"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000445 ;
+                rdfs:label "Portion of Ammunition"@en ;
+                skos:definition "A Weapon that is designed to inflict harm, damage, or incapacity by being projected toward its target at a significant Velocity."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ammunition&oldid=1062875850"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001151
 cco:ont00001151 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000893 ;
-                 rdfs:label "Portion of Paper"@en ;
-                 skos:definition "An Information Medium Artifact that is designed to bear some Information Content Entity by means of pressing together moist fibres of cellulose pulp derived from wood, rags, or grasses, and drying them into flexible sheets."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Paper&oldid=1057624743"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000893 ;
+                rdfs:label "Portion of Paper"@en ;
+                skos:definition "An Information Medium Artifact that is designed to bear some Information Content Entity by means of pressing together moist fibres of cellulose pulp derived from wood, rags, or grasses, and drying them into flexible sheets."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Paper&oldid=1057624743"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001153
 cco:ont00001153 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Damaging Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in a process in which the structural integrity of an entity is impaired."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Damaging Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in a process in which the structural integrity of an entity is impaired."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001155
 cco:ont00001155 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000601 ;
-                 rdfs:label "Full Motion Video Imaging Artifact Function"@en ;
-                 skos:definition "An Imaging Artifact Function that inheres in Artifacts that are designed to produce video of entities that is of high enough quality to make the represented motion appear continuous to human viewers."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000601 ;
+                rdfs:label "Full Motion Video Imaging Artifact Function"@en ;
+                skos:definition "An Imaging Artifact Function that inheres in Artifacts that are designed to produce video of entities that is of high enough quality to make the represented motion appear continuous to human viewers."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001156
 cco:ont00001156 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000798 ;
-                 rdfs:label "Information Line"@en ;
-                 skos:definition "An Information Bearing Artifact that consists of a single line or row of some larger Information Bearing Artifact of which it is a part."@en ;
-                 skos:example "a line in a computer file that bears a portion of code for some computer program" ,
-                              "a line of data in a database" ,
-                              "a line of text in a book" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000798 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002037
+                                ] ;
+                rdfs:label "Material Copy of a Information Line"@en ;
+                skos:altLabel "Information Line"@en ;
+                skos:definition "An Information Bearing Artifact that consists of a single line or row of some larger Information Bearing Artifact of which it is a part."@en ;
+                skos:example "a line in a computer file that bears a portion of code for some computer program" ,
+                             "a line of data in a database" ,
+                             "a line of text in a book" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001157
 cco:ont00001157 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000288 ;
-                 rdfs:label "Hydraulic Power Source"@en ;
-                 skos:definition "A Power Source that is designed to generate, control, or transmit power by means of pressurized liquid."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000288 ;
+                rdfs:label "Hydraulic Power Source"@en ;
+                skos:definition "A Power Source that is designed to generate, control, or transmit power by means of pressurized liquid."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001159
 cco:ont00001159 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000537 ;
-                 rdfs:label "Bond"@en ;
-                 skos:definition "A Financial Instrument that is designed to secure an Agent's debt for the holders of that debt."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Bond_(finance)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000537 ;
+                rdfs:label "Bond"@en ;
+                skos:definition "A Financial Instrument that is designed to secure an Agent's debt for the holders of that debt."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Bond_(finance)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001160
 cco:ont00001160 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000791 ;
-                 rdfs:label "Solvent Artifact Function"@en ;
-                 skos:definition "A Chemical Reaction Artifact Function that is realized in the dissolving of other substances (namely, solutes) without change in the former's chemical structure."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Solvent&oldid=1062572314"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000791 ;
+                rdfs:label "Solvent Artifact Function"@en ;
+                skos:definition "A Chemical Reaction Artifact Function that is realized in the dissolving of other substances (namely, solutes) without change in the former's chemical structure."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Solvent&oldid=1062572314"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001161
 cco:ont00001161 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000719 ;
-                 rdfs:label "Counterfeit Legal Instrument"@en ;
-                 skos:definition "A Counterfeit Instrument that is designed to be a fake replica of some genuine Legal Instrument."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Counterfeit&oldid=1063493600"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000719 ;
+                rdfs:label "Counterfeit Legal Instrument"@en ;
+                skos:definition "A Counterfeit Instrument that is designed to be a fake replica of some genuine Legal Instrument."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Counterfeit&oldid=1063493600"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001168
 cco:ont00001168 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000040 ;
-                 rdfs:label "Reaction Mass"@en ;
-                 skos:altLabel "Working Mass"@en ;
-                 skos:definition "A Material Entity against which a Propulsion System operates in order to produce Acceleration."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Working_mass&oldid=1057126114"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000040 ;
+                rdfs:label "Reaction Mass"@en ;
+                skos:altLabel "Working Mass"@en ;
+                skos:definition "A Material Entity against which a Propulsion System operates in order to produce Acceleration."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Working_mass&oldid=1057126114"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001169
 cco:ont00001169 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Communication Relay Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized during events in which an Artifact is used to first receive and then transmit information from one Artifact to another for the purpose of communiction."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Communication Relay Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized during events in which an Artifact is used to first receive and then transmit information from one Artifact to another for the purpose of communiction."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001172
 cco:ont00001172 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000593 ;
-                 rdfs:label "Portion of Gelatinous Propellant"@en ;
-                 skos:definition "A Portion of Propellant that is stored in a gelatinous state."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000593 ;
+                rdfs:label "Portion of Gelatinous Propellant"@en ;
+                skos:definition "A Portion of Propellant that is stored in a gelatinous state."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001173
 cco:ont00001173 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001051 ;
-                 rdfs:label "Rocket Launcher"@en ;
-                 skos:definition "A Projectile Launcher that is designed to launch one or more Unguided Rockets."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rocket_launcher&oldid=1049900727"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001051 ;
+                rdfs:label "Rocket Launcher"@en ;
+                skos:definition "A Projectile Launcher that is designed to launch one or more Unguided Rockets."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rocket_launcher&oldid=1049900727"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001174
 cco:ont00001174 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Electromagnetic Shielding Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in a process in which an electromagnetic field is blocked by barriers made of conductive or magnetic materials."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electromagnetic_shielding&oldid=1063432544"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Electromagnetic Shielding Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in a process in which an electromagnetic field is blocked by barriers made of conductive or magnetic materials."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electromagnetic_shielding&oldid=1063432544"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001178
 cco:ont00001178 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001326 ;
-                 rdfs:label "Railway Crossing"@en ;
-                 skos:altLabel "Level Crossing"@en ;
-                 skos:definition "A Land Transportation Artifact that is designed to enable Persons or Ground Vehicles to cross a Railway when traveling along a road or path that is perpendicular to and at the same elevation as the Railway at the point where they overlap."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001326 ;
+                rdfs:label "Railway Crossing"@en ;
+                skos:altLabel "Level Crossing"@en ;
+                skos:definition "A Land Transportation Artifact that is designed to enable Persons or Ground Vehicles to cross a Railway when traveling along a road or path that is perpendicular to and at the same elevation as the Railway at the point where they overlap."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001179
 cco:ont00001179 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000893 ;
-                 rdfs:label "Digital Storage Device"@en ;
-                 skos:definition "An Information Medium Artifact that is designed to bear some Information Content Entity by means of recording that information in digital (binary) format."@en ;
-                 skos:example "A computer's Hard Disk Drive" ,
-                              "A portable USB Drive" ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Data_storage&oldid=1060116427"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000893 ;
+                rdfs:label "Digital Storage Device"@en ;
+                skos:definition "An Information Medium Artifact that is designed to bear some Information Content Entity by means of recording that information in digital (binary) format."@en ;
+                skos:example "A computer's Hard Disk Drive" ,
+                             "A portable USB Drive" ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Data_storage&oldid=1060116427"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001181
 cco:ont00001181 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000287 ;
-                 rdfs:label "Triple Inertial Navigation System"@en ;
-                 skos:altLabel "Triple INS"@en ;
-                 skos:definition "An Inertial Navigation System that is designed to use three redundant computers to continuously calculate via dead reckoning the position, orientation, and velocity of a moving object without the need for external references, in such a way that eliminates the need for a navigator."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000287 ;
+                rdfs:label "Triple Inertial Navigation System"@en ;
+                skos:altLabel "Triple INS"@en ;
+                skos:definition "An Inertial Navigation System that is designed to use three redundant computers to continuously calculate via dead reckoning the position, orientation, and velocity of a moving object without the need for external references, in such a way that eliminates the need for a navigator."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001185
 cco:ont00001185 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000713 ;
-                 rdfs:label "Rocket"@en ;
-                 skos:definition "A Vehicle that is designed to travel through air or space and which obtains Thrust from a Rocket Engine."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rocket&oldid=1063307477"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000713 ;
+                rdfs:label "Rocket"@en ;
+                skos:definition "A Vehicle that is designed to travel through air or space and which obtains Thrust from a Rocket Engine."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rocket&oldid=1063307477"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001187
 cco:ont00001187 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Navigation System"@en ;
-                 skos:definition "A Material Artifact that is designed to enable an Agent or Artifact to determine the position or direction of some object, usually for the purpose of monitoring or controlling the movement of some Vehicle from one place to another."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Navigation&oldid=1064122463"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Navigation System"@en ;
+                skos:definition "A Material Artifact that is designed to enable an Agent or Artifact to determine the position or direction of some object, usually for the purpose of monitoring or controlling the movement of some Vehicle from one place to another."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Navigation&oldid=1064122463"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001188
 cco:ont00001188 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000715 ;
-                 rdfs:label "Denture"@en ;
-                 skos:definition "A Prosthesis that is designed to replace missing teeth."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Dentures&oldid=1056527226"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000715 ;
+                rdfs:label "Denture"@en ;
+                skos:definition "A Prosthesis that is designed to replace missing teeth."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Dentures&oldid=1056527226"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001192
 cco:ont00001192 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000092 ;
-                 rdfs:label "Radio Antenna"@en ;
-                 skos:definition "A Bidirectional Transducer that is designed to convert electric power into radio waves, and radio waves into electric power."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Antenna_(radio)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000092 ;
+                rdfs:label "Radio Antenna"@en ;
+                skos:definition "A Bidirectional Transducer that is designed to convert electric power into radio waves, and radio waves into electric power."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Antenna_(radio)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001198
 cco:ont00001198 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000796 ;
-                 rdfs:comment "In American-English, the term 'Railcar' is often used in a broader sense that is interchangeable with 'Railroad Car'."@en ;
-                 rdfs:label "Railcar"@en ;
-                 skos:definition "A Rail Transport Vehicle that consists of a single self-propelled Vehicle that is not a Train, is designed to transport passengers, and which may also be designed to connect to other Railcars to form a Train."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Railcar&oldid=1063519348"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000796 ;
+                rdfs:comment "In American-English, the term 'Railcar' is often used in a broader sense that is interchangeable with 'Railroad Car'."@en ;
+                rdfs:label "Railcar"@en ;
+                skos:definition "A Rail Transport Vehicle that consists of a single self-propelled Vehicle that is not a Train, is designed to transport passengers, and which may also be designed to connect to other Railcars to form a Train."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Railcar&oldid=1063519348"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001200
 cco:ont00001200 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Structural Support Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized by an Artifact providing physical support to another object."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Structural Support Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized by an Artifact providing physical support to another object."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001201
 cco:ont00001201 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001326 ;
-                 rdfs:label "Trail"@en ;
-                 skos:definition "A Land Transportation Artifact that is designed to enable transport through rough country, such as a forest or moor."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Trail&oldid=1056047142"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001326 ;
+                rdfs:label "Trail"@en ;
+                skos:definition "A Land Transportation Artifact that is designed to enable transport through rough country, such as a forest or moor."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Trail&oldid=1056047142"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001207
 cco:ont00001207 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000136 ;
-                 rdfs:label "Optical Lens"@en ;
-                 skos:altLabel "Lens"@en ;
-                 skos:definition "An Optical Instrument that is designed to focus or disperse a beam of light entering the lens by means of refraction."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Lens_(optics)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001209
-cco:ont00001209 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000326 ;
-                 rdfs:label "UPC-E Barcode"@en ;
-                 skos:definition "A UPC Barcode that consists of 6 numerical digits."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000136 ;
+                rdfs:label "Optical Lens"@en ;
+                skos:altLabel "Lens"@en ;
+                skos:definition "An Optical Instrument that is designed to focus or disperse a beam of light entering the lens by means of refraction."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Lens_(optics)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001210
 cco:ont00001210 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001301 ;
-                 rdfs:label "Retail Artifact Function"@en ;
-                 skos:definition "A Service Artifact Function that is realized in processes of selling goods or merchandise in small or individual lots for direct consumption by persons or organizations."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Retail&oldid=1061431295"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001301 ;
+                rdfs:label "Retail Artifact Function"@en ;
+                skos:definition "A Service Artifact Function that is realized in processes of selling goods or merchandise in small or individual lots for direct consumption by persons or organizations."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Retail&oldid=1061431295"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001211
 cco:ont00001211 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Lifting Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized by processes in which some Artifact is used to lift some object."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Lifting Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized by processes in which some Artifact is used to lift some object."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001216
 cco:ont00001216 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000136 ;
-                 rdfs:label "Periscope"@en ;
-                 skos:definition "An Optical Instrument that is designed to enable observation of an object that is located over, around, or through another object, obstacle, or condition that prevents direct line-of-sight observation from the observer's current position."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Periscope&oldid=1030400442"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000136 ;
+                rdfs:label "Periscope"@en ;
+                skos:definition "An Optical Instrument that is designed to enable observation of an object that is located over, around, or through another object, obstacle, or condition that prevents direct line-of-sight observation from the observer's current position."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Periscope&oldid=1030400442"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001217
 cco:ont00001217 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000848 ;
-                 rdfs:label "Medium Machine Gun"@en ;
-                 skos:definition "A Mounted Gun that is designed to fire full-power rifle Cartridges (less than .50 caliber or 12.7mm) in quick succession from an ammunition belt, and which typically weighs 22-30 lbs."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Medium_machine_gun&oldid=1063571269"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000848 ;
+                rdfs:label "Medium Machine Gun"@en ;
+                skos:definition "A Mounted Gun that is designed to fire full-power rifle Cartridges (less than .50 caliber or 12.7mm) in quick succession from an ammunition belt, and which typically weighs 22-30 lbs."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Medium_machine_gun&oldid=1063571269"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001218
 cco:ont00001218 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Signal Processing Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in the process of transferring or processing information contained in signals."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Signal_processing&oldid=1062720685"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Signal Processing Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in the process of transferring or processing information contained in signals."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Signal_processing&oldid=1062720685"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001221
 cco:ont00001221 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000210 ;
-                 rdfs:label "Physically Powered Engine"@en ;
-                 skos:altLabel "Physical Engine"@en ;
-                 skos:definition "An Engine that is designed to convert potential or kinetic energy into mechanical energy."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000210 ;
+                rdfs:label "Physically Powered Engine"@en ;
+                skos:altLabel "Physical Engine"@en ;
+                skos:definition "An Engine that is designed to convert potential or kinetic energy into mechanical energy."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001222
 cco:ont00001222 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001049 ;
-                 rdfs:label "Solar Panel System"@en ;
-                 skos:altLabel "Photovoltaic System"@en ,
-                               "Solar Array"@en ;
-                 skos:definition "An Electrical Power Source that consists in part of one or more Solar Panels, a power inverter, electrical wiring between the components, a mounting and support structure, and may also include a battery and/or a solar tracking system and is the bearer of functions realized in processes of deriving, transferring, and storing electrical energy derived from light energy."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Photovoltaic_system&oldid=1063366598"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001049 ;
+                rdfs:label "Solar Panel System"@en ;
+                skos:altLabel "Photovoltaic System"@en ,
+                              "Solar Array"@en ;
+                skos:definition "An Electrical Power Source that consists in part of one or more Solar Panels, a power inverter, electrical wiring between the components, a mounting and support structure, and may also include a battery and/or a solar tracking system and is the bearer of functions realized in processes of deriving, transferring, and storing electrical energy derived from light energy."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Photovoltaic_system&oldid=1063366598"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001223
 cco:ont00001223 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001145 ;
-                 rdfs:label "Dish Receiver"@en ;
-                 skos:definition "A Radio Receiver that uses a Parabolic (or Dish) Antenna to intercept radio signals."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001145 ;
+                rdfs:label "Dish Receiver"@en ;
+                skos:definition "A Radio Receiver that uses a Parabolic (or Dish) Antenna to intercept radio signals."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001228
 cco:ont00001228 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000798 ;
-                 rdfs:label "Journal Article"@en ;
-                 skos:definition "An Information Bearing Artifact that is designed to bear a specific brief composition on a specific topic as part of a Journal Issue."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Academic_journal&oldid=1059723283"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001298 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002045
+                                ] ;
+                rdfs:label "Material Copy of a Journal Article"@en ;
+                skos:altLabel "Journal Article"@en ;
+                skos:definition "An Information Bearing Artifact that is designed to bear a specific brief composition on a specific topic as part of a Journal Issue."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Academic_journal&oldid=1059723283"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001229
 cco:ont00001229 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001050 ;
-                 rdfs:label "Alkaline Electric Battery"@en ;
-                 skos:definition "A Primary Cell Electric Battery that has a Zinc anode and Manganese (IV) oxide cathode."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Alkaline_battery&oldid=1055652562"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001050 ;
+                rdfs:label "Alkaline Electric Battery"@en ;
+                skos:definition "A Primary Cell Electric Battery that has a Zinc anode and Manganese (IV) oxide cathode."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Alkaline_battery&oldid=1055652562"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001230
 cco:ont00001230 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000499 ;
-                 rdfs:label "Rhombic Antenna"@en ;
-                 skos:definition "A Wire Antenna that consists of one to three parallel wires suspended above the ground by poles or towers at each vertex in a rhombic shape with each of the four sides being the same length (typically at least one wavelength or longer)."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rhombic_antenna&oldid=1057114456"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000499 ;
+                rdfs:label "Rhombic Antenna"@en ;
+                skos:definition "A Wire Antenna that consists of one to three parallel wires suspended above the ground by poles or towers at each vertex in a rhombic shape with each of the four sides being the same length (typically at least one wavelength or longer)."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Rhombic_antenna&oldid=1057114456"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001233
 cco:ont00001233 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001153 ;
-                 rdfs:label "Crushing Artifact Function"@en ;
-                 skos:definition "A Damaging Artifact Function that is realized in a process in which the structural integrity of an entity is impaired because of significant pressure."@en ;
-                 cco:ont00001754 "http://www.dictionary.com/browse/crushing" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001153 ;
+                rdfs:label "Crushing Artifact Function"@en ;
+                skos:definition "A Damaging Artifact Function that is realized in a process in which the structural integrity of an entity is impaired because of significant pressure."@en ;
+                cco:ont00001754 "http://www.dictionary.com/browse/crushing" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001234
 cco:ont00001234 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000791 ;
-                 rdfs:label "Neutralization Artifact Function"@en ;
-                 skos:definition "A Chemical Reaction Artifact Function that is realized in a process in which an acid and a base react quantitatively with each other."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Neutralization_(chemistry)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000791 ;
+                rdfs:label "Neutralization Artifact Function"@en ;
+                skos:definition "A Chemical Reaction Artifact Function that is realized in a process in which an acid and a base react quantitatively with each other."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Neutralization_(chemistry)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001240
 cco:ont00001240 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001148 ;
-                 rdfs:label "Radio Communication Artifact Function"@en ;
-                 skos:definition "An Electromagnetic Communication Artifact Function that is realized in a process that conveys meaningful signs by means of radio waves."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telecommunications&oldid=1061143810"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001148 ;
+                rdfs:label "Radio Communication Artifact Function"@en ;
+                skos:definition "An Electromagnetic Communication Artifact Function that is realized in a process that conveys meaningful signs by means of radio waves."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Telecommunications&oldid=1061143810"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001241
 cco:ont00001241 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Sensor Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in processes wherein its bearer is used to produce an output signal which reliably corresponds to changes in the artifact's environment."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Sensor&oldid=1059883466"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Sensor Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in processes wherein its bearer is used to produce an output signal which reliably corresponds to changes in the artifact's environment."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Sensor&oldid=1059883466"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001242
 cco:ont00001242 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000736 ;
-                 rdfs:label "Actuator"@en ;
-                 skos:definition "A Transducer that is designed to convert some control signal into mechanical motion."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Actuator&oldid=1064000375"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000736 ;
+                rdfs:label "Actuator"@en ;
+                skos:definition "A Transducer that is designed to convert some control signal into mechanical motion."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Actuator&oldid=1064000375"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001243
 cco:ont00001243 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000253 ;
-                 rdfs:label "Document Field"@en ;
-                 skos:definition "An Information Bearing Entity that is a part of some document into which bearers of prescribed information can be written or selected."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000798 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002038
+                                ] ;
+                rdfs:label "Material Copy of a Document Field"@en ;
+                skos:definition "An Information Bearing Entity that is a part of some document into which bearers of prescribed information can be written or selected."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001245
 cco:ont00001245 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000241 ;
-                 rdfs:label "PDF417 Code"@en ;
-                 skos:definition "A Two-Dimensional Barcode that is used in applications that require the storage of huge amounts of data."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000241 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002019
+                                ] ;
+                rdfs:label "Material Copy of a PDF417 Code"@en ;
+                skos:altLabel "PDF417 Code"@en ;
+                skos:definition "A Two-Dimensional Barcode that is used in applications that require the storage of huge amounts of data."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001247
 cco:ont00001247 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000918 ;
-                 rdfs:label "Telecommunication Endpoint"@en ;
-                 skos:definition "A Telecommunication Network Node that connects a Telecommunication Terminal to a Telecommunication Network."@en ;
-                 skos:scopeNote "A Telecommunication Terminal is an end user device such as a Telephone, fax machine, or Computer."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Communication_endpoint&oldid=1020569501"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000918 ;
+                rdfs:label "Telecommunication Endpoint"@en ;
+                skos:definition "A Telecommunication Network Node that connects a Telecommunication Terminal to a Telecommunication Network."@en ;
+                skos:scopeNote "A Telecommunication Terminal is an end user device such as a Telephone, fax machine, or Computer."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Communication_endpoint&oldid=1020569501"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001248
 cco:ont00001248 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000715 ;
-                 rdfs:label "Artificial Eye"@en ;
-                 skos:definition "A Prosthesis that is designed to replace a missing eye."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Artificial_eye&oldid=1046672400"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000715 ;
+                rdfs:label "Artificial Eye"@en ;
+                skos:definition "A Prosthesis that is designed to replace a missing eye."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Artificial_eye&oldid=1046672400"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001249
 cco:ont00001249 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000453 ;
-                 rdfs:label "Cabin Pressurization Control System"@en ;
-                 skos:definition "An Environment Control System that is designed to control the process in which conditioned air is pumped into the Cabin of some Aircraft or Spacecraft in order to create a safe and comfortable environment for passengers and crew flying at high altitudes."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Cabin_pressurization&oldid=1062243955"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000453 ;
+                rdfs:label "Cabin Pressurization Control System"@en ;
+                skos:definition "An Environment Control System that is designed to control the process in which conditioned air is pumped into the Cabin of some Aircraft or Spacecraft in order to create a safe and comfortable environment for passengers and crew flying at high altitudes."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Cabin_pressurization&oldid=1062243955"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001250
 cco:ont00001250 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000236 ;
-                 rdfs:label "Interior Lighting System"@en ;
-                 skos:definition "A Lighting System that is designed to emit light within the interior of some area."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000236 ;
+                rdfs:label "Interior Lighting System"@en ;
+                skos:definition "A Lighting System that is designed to emit light within the interior of some area."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001252
 cco:ont00001252 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000448 ;
-                 rdfs:label "Propulsion Artifact Function"@en ;
-                 skos:definition "A Motion Artifact Function that is realized in a process in which the bearer of the function creates force leading to an entity's movement."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Propulsion&oldid=1022034059"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000448 ;
+                rdfs:label "Propulsion Artifact Function"@en ;
+                skos:definition "A Motion Artifact Function that is realized in a process in which the bearer of the function creates force leading to an entity's movement."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Propulsion&oldid=1022034059"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001253
 cco:ont00001253 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Fuel Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in processes in which a Portion of Fuel is reacted with other substances in order to release chemical or nuclear energy to be used for heat or for work."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Fuel&oldid=1063590518"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Fuel Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in processes in which a Portion of Fuel is reacted with other substances in order to release chemical or nuclear energy to be used for heat or for work."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Fuel&oldid=1063590518"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001254
 cco:ont00001254 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000156 ;
-                 rdfs:label "Revolver"@en ;
-                 skos:definition "A Hand Gun having a number of firing chambers in a revolving cylinder, where each chamber in the cylinder can be loaded with a single Cartridge."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Revolver&oldid=1060461644"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000156 ;
+                rdfs:label "Revolver"@en ;
+                skos:definition "A Hand Gun having a number of firing chambers in a revolving cylinder, where each chamber in the cylinder can be loaded with a single Cartridge."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Revolver&oldid=1060461644"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001255
 cco:ont00001255 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000828 ;
-                 rdfs:label "Insecticide Artifact Function"@en ;
-                 skos:definition "A Pesticide Artifact Function that is realized in a process that causes harm to, or the death of, an insect."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Insecticide&oldid=1063322558"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000828 ;
+                rdfs:label "Insecticide Artifact Function"@en ;
+                skos:definition "A Pesticide Artifact Function that is realized in a process that causes harm to, or the death of, an insect."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Insecticide&oldid=1063322558"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001260
 cco:ont00001260 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000258 ;
-                 rdfs:label "Code 39 Barcode"@en ;
-                 skos:definition "A One-Dimensional Barcode that consists of 39 characters that are numbers 0-9, capital letters A-Z, or the symbols -.$/+% and space and is used primarily in automotive and defense industries."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000258 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002032
+                                ] ;
+                rdfs:label "Material Copy of a Code 39 Barcode"@en ;
+                skos:altLabel "Code 39 Barcode"@en ;
+                skos:definition "A One-Dimensional Barcode that consists of 39 characters that are numbers 0-9, capital letters A-Z, or the symbols -.$/+% and space and is used primarily in automotive and defense industries."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001264
 cco:ont00001264 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000258 ;
-                 rdfs:label "Code 128 Barcode"@en ;
-                 skos:definition "A One-Dimensional Barcode that consists of up to 128 ASCII characters and is used primarily in supply chains."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000258 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002033
+                                ] ;
+                rdfs:label "Material Copy of a Code 128 Barcode"@en ;
+                skos:altLabel "Code 128 Barcode"@en ;
+                skos:definition "A One-Dimensional Barcode that consists of up to 128 ASCII characters and is used primarily in supply chains."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001265
 cco:ont00001265 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001036 ;
-                 rdfs:label "Public Address System"@en ;
-                 skos:altLabel "PA System"@en ;
-                 skos:definition "A Communication System that is designed to allow a Person to speak to a large audience."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Public_address_system&oldid=1059177344"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001036 ;
+                rdfs:label "Public Address System"@en ;
+                skos:altLabel "PA System"@en ;
+                skos:definition "A Communication System that is designed to allow a Person to speak to a large audience."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Public_address_system&oldid=1059177344"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001268
 cco:ont00001268 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000966 ;
-                 rdfs:label "ISBN Barcode"@en ;
-                 skos:definition "An EAN Barcode that is used to designate books."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000966 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002030
+                                ] ;
+                rdfs:label "Material Copy of a ISBN Barcode"@en ;
+                skos:altLabel "ISBN Barcode"@en ;
+                skos:definition "An EAN Barcode that is used to designate books."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001270
 cco:ont00001270 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000268 ;
-                 rdfs:label "Howitzer"@en ;
-                 skos:definition "A Cannon that is designed to have a relatively short barrel and to use relatively small propellant charges to propel projectiles in relatively high trajectories with a steep angle of descent."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Howitzer&oldid=1059576383"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000268 ;
+                rdfs:label "Howitzer"@en ;
+                skos:definition "A Cannon that is designed to have a relatively short barrel and to use relatively small propellant charges to propel projectiles in relatively high trajectories with a steep angle of descent."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Howitzer&oldid=1059576383"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001271
 cco:ont00001271 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001169 ;
-                 rdfs:label "Wired Communication Relay Artifact Function"@en ;
-                 skos:definition "A Communication Relay Artifact Function that is realized during events in which an Artifact is used to first receive and then transmit information by means of wires from one Artifact to another for the purpose of communiction."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001169 ;
+                rdfs:label "Wired Communication Relay Artifact Function"@en ;
+                skos:definition "A Communication Relay Artifact Function that is realized during events in which an Artifact is used to first receive and then transmit information by means of wires from one Artifact to another for the purpose of communiction."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001273
 cco:ont00001273 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001241 ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:BFO_0000197 ;
-                                   owl:someValuesFrom cco:ont00000569
-                                 ] ;
-                 rdfs:label "Sensor Modality Function"@en ;
-                 skos:definition "A Sensor Artifact Function that inheres in some Sensor in virtue of the type of energy the Sensor is capable of converting into an output signal."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001241 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000197 ;
+                                  owl:someValuesFrom cco:ont00000569
+                                ] ;
+                rdfs:label "Sensor Modality Function"@en ;
+                skos:definition "A Sensor Artifact Function that inheres in some Sensor in virtue of the type of energy the Sensor is capable of converting into an output signal."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001275
 cco:ont00001275 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001353 ;
-                 rdfs:label "Nominal Speed Artifact Function"@en ;
-                 skos:definition "A Speed Artifact Function that is realized in some process in which the Artifact bearing the Artifact Function attains a speed that does not exceed some specified tolerance of that Artifact."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001353 ;
+                rdfs:label "Nominal Speed Artifact Function"@en ;
+                skos:definition "A Speed Artifact Function that is realized in some process in which the Artifact bearing the Artifact Function attains a speed that does not exceed some specified tolerance of that Artifact."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001278
 cco:ont00001278 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000537 ;
-                 rdfs:label "Stock"@en ;
-                 skos:definition "A Financial Instrument that entitles holders to an ownership interest (equity) in the specified Incorporated Organization."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Stock&oldid=1064040249"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000537 ;
+                rdfs:label "Stock"@en ;
+                skos:definition "A Financial Instrument that entitles holders to an ownership interest (equity) in the specified Incorporated Organization."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Stock&oldid=1064040249"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001281
 cco:ont00001281 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000791 ;
-                 rdfs:label "Emulsifier Artifact Function"@en ;
-                 skos:definition "A Chemical Reaction Artifact Function that is realized in a process in which two or more liquids that are normally immiscible are mixed."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Emulsion&oldid=1056901580"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000791 ;
+                rdfs:label "Emulsifier Artifact Function"@en ;
+                skos:definition "A Chemical Reaction Artifact Function that is realized in a process in which two or more liquids that are normally immiscible are mixed."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Emulsion&oldid=1056901580"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001282
 cco:ont00001282 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000598 ;
-                 rdfs:label "Hydraulic Valve"@en ;
-                 skos:definition "A Valve that is designed to regulate, direct, or control the flow of a liquid by opening, closing, or partially obstructing various passageways."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Power_transfer_unit&oldid=1002682083"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000598 ;
+                rdfs:label "Hydraulic Valve"@en ;
+                skos:definition "A Valve that is designed to regulate, direct, or control the flow of a liquid by opening, closing, or partially obstructing various passageways."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Power_transfer_unit&oldid=1002682083"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001288
 cco:ont00001288 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001150 ;
-                 rdfs:label "Round Shot"@en ;
-                 skos:definition "A Portion of Ammunition that is designed to be a solid projectile without explosive charge and to be fired from a cannon."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Round_shot&oldid=1062790260"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001150 ;
+                rdfs:label "Round Shot"@en ;
+                skos:definition "A Portion of Ammunition that is designed to be a solid projectile without explosive charge and to be fired from a cannon."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Round_shot&oldid=1062790260"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001292
 cco:ont00001292 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000053 ;
-                 rdfs:label "Bus"@en ;
-                 skos:definition "A Ground Motor Vehicle that is designed to transport a large number of people and to travel on six or more tired wheels."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Bus&oldid=1055341487"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000053 ;
+                rdfs:label "Bus"@en ;
+                skos:definition "A Ground Motor Vehicle that is designed to transport a large number of people and to travel on six or more tired wheels."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Bus&oldid=1055341487"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001298
 cco:ont00001298 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000798 ;
-                 rdfs:label "Document"@en ;
-                 skos:definition "An Information Bearing Artifact that is designed to bear some specific Information Content Entity in a series of paragraphs of text or diagrams in the form of physical pieces of paper or an electronic word processor file."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Document&oldid=1057829688"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000798 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002039
+                                ] ;
+                rdfs:label "Material Copy of a Document"@en ;
+                skos:altLabel "Document"@en ;
+                skos:definition "An Information Bearing Artifact that is designed to bear some specific Information Content Entity in a series of paragraphs of text or diagrams in the form of physical pieces of paper or an electronic word processor file."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Document&oldid=1057829688"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001299
 cco:ont00001299 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000344 ;
-                 rdfs:label "Wetting Agent Artifact Function"@en ;
-                 skos:definition "A Surfactant Artifact Function that is realized in a process that reduces the water repellent tendency of a substance thereby allowing it to become wet."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Wetting&oldid=1062806793"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000344 ;
+                rdfs:label "Wetting Agent Artifact Function"@en ;
+                skos:definition "A Surfactant Artifact Function that is realized in a process that reduces the water repellent tendency of a substance thereby allowing it to become wet."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Wetting&oldid=1062806793"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001300
 cco:ont00001300 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001192 ;
-                 rdfs:label "Patch Antenna"@en ;
-                 skos:altLabel "Microstrip Patch Antenna"@en ,
-                               "Rectangular Microstrip Antenna"@en ;
-                 skos:definition "A Radio Antenna that consists of a flat rectangular sheet (or patch) of metal mounted over a larger sheet of metal called a ground plane which is typically contained inside a plastic radome for protection and is small enough that it can be mounted on a flat surface."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Patch_antenna&oldid=1016658507"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001192 ;
+                rdfs:label "Patch Antenna"@en ;
+                skos:altLabel "Microstrip Patch Antenna"@en ,
+                              "Rectangular Microstrip Antenna"@en ;
+                skos:definition "A Radio Antenna that consists of a flat rectangular sheet (or patch) of metal mounted over a larger sheet of metal called a ground plane which is typically contained inside a plastic radome for protection and is small enough that it can be mounted on a flat surface."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Patch_antenna&oldid=1016658507"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001301
 cco:ont00001301 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Service Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in a process of providing intangible goods to consumers."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Goods_and_services&oldid=1063137197"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Service Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in a process of providing intangible goods to consumers."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Goods_and_services&oldid=1063137197"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001303
 cco:ont00001303 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001306 ;
-                 rdfs:label "Position Observation Artifact Function"@en ;
-                 skos:definition "An Observation Artifact Function that is realized during events in which an Artifact is used to collect information about the position of a specified object or class of objects."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001306 ;
+                rdfs:label "Position Observation Artifact Function"@en ;
+                skos:definition "An Observation Artifact Function that is realized during events in which an Artifact is used to collect information about the position of a specified object or class of objects."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001304
 cco:ont00001304 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000575 ;
-                 rdfs:label "Dimension Specification"@en ;
-                 skos:definition "An Quality Specification that prescribes some Size Quality."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000575 ;
+                rdfs:label "Dimension Specification"@en ;
+                skos:definition "An Quality Specification that prescribes some Size Quality."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001306
 cco:ont00001306 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Observation Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized during events in which an Artifact is used to collect information about a specified object or class of objects."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Observation Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized during events in which an Artifact is used to collect information about a specified object or class of objects."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001310
 cco:ont00001310 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Covering Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in a process in which an entity is covered."@en ;
-                 cco:ont00001754 "http://www.dictionary.com/browse/covering" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Covering Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in a process in which an entity is covered."@en ;
+                cco:ont00001754 "http://www.dictionary.com/browse/covering" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001313
 cco:ont00001313 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Article of Clothing"@en ;
-                 skos:definition "A Material Artifact that is designed to cover some portion of a body."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Clothing&oldid=1063505718"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Article of Clothing"@en ;
+                skos:definition "A Material Artifact that is designed to cover some portion of a body."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Clothing&oldid=1063505718"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001316
 cco:ont00001316 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001042 ;
-                 rdfs:label "Gimbal"@en ;
-                 skos:definition "An Equipment Mount that consists of a pivoted support that allows an Artifact to Rotate about one or more Axes."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Gimbal&oldid=1053306885"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001042 ;
+                rdfs:label "Gimbal"@en ;
+                skos:definition "An Equipment Mount that consists of a pivoted support that allows an Artifact to Rotate about one or more Axes."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Gimbal&oldid=1053306885"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001319
 cco:ont00001319 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000427 ;
-                 rdfs:comment "Tank firepower is normally provided by a large-caliber main gun mounted in a rotating turret, which is supported by secondary machine guns. A tank's heavy armour and all-terrain mobility provide protection for both the tank and its crew, allowing it to perform all primary tasks of the armoured troops on the battlefield."@en ;
-                 rdfs:label "Tank"@en ;
-                 skos:definition "An Armored Fighting Vehicle that is designed to carry heavy firepower, have a powerful Engine, and travel on one or more continuous tracks such that it is suitable for front-line combat and can provide operational maneuverability as well as tactical offensive and defensive capabilities."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Tank&oldid=1060527612"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000427 ;
+                rdfs:comment "Tank firepower is normally provided by a large-caliber main gun mounted in a rotating turret, which is supported by secondary machine guns. A tank's heavy armour and all-terrain mobility provide protection for both the tank and its crew, allowing it to perform all primary tasks of the armoured troops on the battlefield."@en ;
+                rdfs:label "Tank"@en ;
+                skos:definition "An Armored Fighting Vehicle that is designed to carry heavy firepower, have a powerful Engine, and travel on one or more continuous tracks such that it is suitable for front-line combat and can provide operational maneuverability as well as tactical offensive and defensive capabilities."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Tank&oldid=1060527612"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001320
 cco:ont00001320 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000903 ;
-                 rdfs:label "Radio Transceiver"@en ;
-                 skos:definition "A Radio Communication Instrument that is an electronic device composed of both a Radio Transmitter and a Radio Receiver that share common circuitry or a single housing."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Transceiver&oldid=1058453736"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000903 ;
+                rdfs:label "Radio Transceiver"@en ;
+                skos:definition "A Radio Communication Instrument that is an electronic device composed of both a Radio Transmitter and a Radio Receiver that share common circuitry or a single housing."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Transceiver&oldid=1058453736"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001321
 cco:ont00001321 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001105 ;
-                 rdfs:label "Lead Acid Electric Battery"@en ;
-                 skos:definition "A Secondary Cell Electric Battery that has a lead anode and lead oxide cathode."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Lead%E2%80%93acid_battery&oldid=1061641405"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001105 ;
+                rdfs:label "Lead Acid Electric Battery"@en ;
+                skos:definition "A Secondary Cell Electric Battery that has a lead anode and lead oxide cathode."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Lead%E2%80%93acid_battery&oldid=1061641405"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001323
 cco:ont00001323 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Bearing Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in processes in which the Artifact constrains relative motion to only the desired motion, and reduces friction between moving parts."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Bearing_(mechanical)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Bearing Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in processes in which the Artifact constrains relative motion to only the desired motion, and reduces friction between moving parts."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Bearing_(mechanical)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001326
 cco:ont00001326 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000254 ;
-                 rdfs:label "Land Transportation Artifact"@en ;
-                 skos:definition "A Transportation Artifact that is fixed in place and designed to bear a Function, the realization of which is sometimes part of a process moving Vehicles and Agents from one location to another via land."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000254 ;
+                rdfs:label "Land Transportation Artifact"@en ;
+                skos:definition "A Transportation Artifact that is fixed in place and designed to bear a Function, the realization of which is sometimes part of a process moving Vehicles and Agents from one location to another via land."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001329
 cco:ont00001329 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001301 ;
-                 rdfs:label "Education Artifact Function"@en ;
-                 skos:definition "A Service Artifact Function that is realized in processes of transmiting accumulated knowledge skills and values from one generation to another."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Education&oldid=1064011752"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001301 ;
+                rdfs:label "Education Artifact Function"@en ;
+                skos:definition "A Service Artifact Function that is realized in processes of transmiting accumulated knowledge skills and values from one generation to another."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Education&oldid=1064011752"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001341
@@ -4998,162 +5209,182 @@ cco:ont00001341 rdf:type owl:Class .
 
 ###  https://www.commoncoreontologies.org/ont00001342
 cco:ont00001342 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000427 ;
-                 rdfs:label "Infantry Fighting Vehicle"@en ;
-                 skos:definition "An Armored Fighting Vehicle that is designed to carry infantry into battle and to provide fire support for them."@en ;
-                 skos:scopeNote "Infantry Fighting Vehicles (IFVs) are differentiated from Armored Personnel Carriers (APCs) because they are designed to give direct fire support to the dismounted infantry and so usually have significantly enhanced armament. IFVs also often have improved armour and firing ports (allowing the infantry to fire personal weapons while mounted)."@en ;
-                 cco:ont00001753 "IFV" ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Infantry_fighting_vehicle&oldid=1062470745"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000427 ;
+                rdfs:label "Infantry Fighting Vehicle"@en ;
+                skos:definition "An Armored Fighting Vehicle that is designed to carry infantry into battle and to provide fire support for them."@en ;
+                skos:scopeNote "Infantry Fighting Vehicles (IFVs) are differentiated from Armored Personnel Carriers (APCs) because they are designed to give direct fire support to the dismounted infantry and so usually have significantly enhanced armament. IFVs also often have improved armour and firing ports (allowing the infantry to fire personal weapons while mounted)."@en ;
+                cco:ont00001753 "IFV" ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Infantry_fighting_vehicle&oldid=1062470745"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001343
 cco:ont00001343 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Circuit Breaker"@en ;
-                 skos:definition "A Material Artifact that is designed to protect an electrical circuit from damage caused by excess current from an overload or short circuit."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Circuit_breaker&oldid=1060854893"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Circuit Breaker"@en ;
+                skos:definition "A Material Artifact that is designed to protect an electrical circuit from damage caused by excess current from an overload or short circuit."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Circuit_breaker&oldid=1060854893"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001346
 cco:ont00001346 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Legal Instrument"@en ;
-                 skos:definition "A Material Artifact that is designed as a formally executed written document that can be formally attributed to its author, records and formally expresses a legally enforceable act, process, or contractual duty, obligation, or right, and therefore evidences that act, process, or agreement."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Legal_instrument&oldid=1054387344"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Legal Instrument"@en ;
+                skos:definition "A Material Artifact that is designed as a formally executed written document that can be formally attributed to its author, records and formally expresses a legally enforceable act, process, or contractual duty, obligation, or right, and therefore evidences that act, process, or agreement."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Legal_instrument&oldid=1054387344"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001350
 cco:ont00001350 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Thermal Control Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized by an Artifact increasing, decreasing, or maintaining the temperature of itself, a part of itself, or another object."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Thermal Control Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized by an Artifact increasing, decreasing, or maintaining the temperature of itself, a part of itself, or another object."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001353
 cco:ont00001353 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000448 ;
-                 rdfs:label "Speed Artifact Function"@en ;
-                 skos:definition "A Motion Artifact Function that is realized in some process in which its bearer has some speed."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000448 ;
+                rdfs:label "Speed Artifact Function"@en ;
+                skos:definition "A Motion Artifact Function that is realized in some process in which its bearer has some speed."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001355
 cco:ont00001355 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000928 ;
-                 rdfs:label "Freight Train Car"@en ;
-                 skos:altLabel "Freight Car"@en ;
-                 skos:definition "A Train Car that is designed to transport cargo."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Goods_wagon&oldid=1062686785"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000928 ;
+                rdfs:label "Freight Train Car"@en ;
+                skos:altLabel "Freight Car"@en ;
+                skos:definition "A Train Car that is designed to transport cargo."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Goods_wagon&oldid=1062686785"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001361
 cco:ont00001361 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Healing Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized in a process in which health is restored to an unbalanced, diseased, or damaged organism."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Healing&oldid=1053920678"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Healing Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized in a process in which health is restored to an unbalanced, diseased, or damaged organism."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Healing&oldid=1053920678"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001365
 cco:ont00001365 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001353 ;
-                 rdfs:label "Maximum Speed Artifact Function"@en ;
-                 skos:definition "A Speed Artifact Function that is realized in some process in which the Artifact bearing the Artifact Function attains the highest speed at which that Artifact is designed to operate."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001353 ;
+                rdfs:label "Maximum Speed Artifact Function"@en ;
+                skos:definition "A Speed Artifact Function that is realized in some process in which the Artifact bearing the Artifact Function attains the highest speed at which that Artifact is designed to operate."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001366
 cco:ont00001366 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Powering Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized by processes in which some Artifact is used to supply power to some Artifact."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Powering Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized by processes in which some Artifact is used to supply power to some Artifact."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001368
 cco:ont00001368 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001306 ;
-                 rdfs:label "Motion Observation Artifact Function"@en ;
-                 skos:definition "An Observation Artifact Function that is realized during events in which an Artifact is used to collect information about the Motion of a specified object or class of objects."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001306 ;
+                rdfs:label "Motion Observation Artifact Function"@en ;
+                skos:definition "An Observation Artifact Function that is realized during events in which an Artifact is used to collect information about the Motion of a specified object or class of objects."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001370
 cco:ont00001370 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Machine Bearing"@en ;
-                 skos:definition "A Material Artifact that is designed to constrain relative motion to only desired motion and reduces friction between moving parts."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/wiki/Bearing_(mechanical)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Machine Bearing"@en ;
+                skos:definition "A Material Artifact that is designed to constrain relative motion to only desired motion and reduces friction between moving parts."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Bearing_(mechanical)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001371
 cco:ont00001371 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:label "Electromagnetic Induction Artifact Function"@en ;
-                 skos:definition "An Artifact Function that is realized by processes in which some Artifact that is used to produce electromotive force across an electrical conductor due to its dynamic interaction with a magnetic field."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electromagnetic_induction&oldid=1061836930"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:label "Electromagnetic Induction Artifact Function"@en ;
+                skos:definition "An Artifact Function that is realized by processes in which some Artifact that is used to produce electromotive force across an electrical conductor due to its dynamic interaction with a magnetic field."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Electromagnetic_induction&oldid=1061836930"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001372
 cco:ont00001372 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000437 ;
-                 rdfs:label "Fertilizer Artifact Function"@en ;
-                 skos:definition "An Enhancing Artifact Function that is realized in processes of supplying soilds or plant tissues with one or more plant nutrients essential to growth."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Fertilizer&oldid=1062923261"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000437 ;
+                rdfs:label "Fertilizer Artifact Function"@en ;
+                skos:definition "An Enhancing Artifact Function that is realized in processes of supplying soilds or plant tissues with one or more plant nutrients essential to growth."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Fertilizer&oldid=1062923261"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001373
 cco:ont00001373 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001051 ;
-                 rdfs:label "Bow"@en ;
-                 skos:definition "A Projectile Launcher that is designed to launch Arrows."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Bow_and_arrow&oldid=1062193194"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001051 ;
+                rdfs:label "Bow"@en ;
+                skos:definition "A Projectile Launcher that is designed to launch Arrows."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Bow_and_arrow&oldid=1062193194"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001378
 cco:ont00001378 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00001301 ;
-                 rdfs:label "Hospitality Artifact Function"@en ;
-                 skos:definition "A Service Artifact Function that is realized in processes of accommodation food and beverage meeting and events gaming entertainment and recreation tourism services and visitor information."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Hospitality&oldid=1049599161"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00001301 ;
+                rdfs:label "Hospitality Artifact Function"@en ;
+                skos:definition "A Service Artifact Function that is realized in processes of accommodation food and beverage meeting and events gaming entertainment and recreation tourism services and visitor information."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Hospitality&oldid=1049599161"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001381
 cco:ont00001381 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000995 ;
-                 rdfs:label "Medical Artifact"@en ;
-                 skos:definition "A Material Artifact that is designed for diagnosing, treating, or preventing disease, disability, or death."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000995 ;
+                rdfs:label "Medical Artifact"@en ;
+                skos:definition "A Material Artifact that is designed for diagnosing, treating, or preventing disease, disability, or death."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001382
 cco:ont00001382 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000475 ;
-                 rdfs:label "Electronic Cash"@en ;
-                 skos:definition "A Portion of Cash that consists of Bytes."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:subClassOf cco:ont00000475 ;
+                rdfs:label "Electronic Cash"@en ;
+                skos:definition "A Portion of Cash that consists of Bytes."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00001999
 cco:ont00001999 rdf:type owl:Class ;
-                 rdfs:subClassOf cco:ont00000323 ;
-                 rdfs:comment """Although its basic function remains the same, a Filter can be used in 2 different ways:
+                rdfs:subClassOf cco:ont00000323 ;
+                rdfs:comment """Although its basic function remains the same, a Filter can be used in 2 different ways:
 (1) to allow only the desired entities to pass through (e.g. removing dirt from engine oil); or
 (2) to allow everything except the desired entities to pass through (e.g. panning for gold)."""@en ;
-                 rdfs:label "Filter Function"@en ;
-                 skos:definition "An Artifact Function that is realized in a process where entities of a specific type or which have specified properties enter it or pass through it."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+                rdfs:label "Filter Function"@en ;
+                skos:definition "An Artifact Function that is realized in a process where entities of a specific type or which have specified properties enter it or pass through it."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
 
 
-###  Generated by the OWL API (version 4.5.29) https://github.com/owlcs/owlapi
+###  https://www.commoncoreontologies.org/ont00002038
+cco:ont00002038 rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000176 ;
+                                  owl:someValuesFrom cco:ont00002039
+                                ] .
+
+
+###  https://www.commoncoreontologies.org/ont00002049
+cco:ont00002049 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000326 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000101 ;
+                                  owl:someValuesFrom cco:ont00002036
+                                ] ;
+                rdfs:label "Material Copy of a UPC-E Barcode"@en ;
+                skos:altLabel "UPC-E Barcode"@en ;
+                skos:definition "A UPC Barcode that consists of 6 numerical digits."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/ArtifactOntology"^^xsd:anyURI .
+
+
+###  Generated by the OWL API (version 4.5.26.2023-07-17T20:34:13Z) https://github.com/owlcs/owlapi

--- a/src/cco-modules/InformationEntityOntology.ttl
+++ b/src/cco-modules/InformationEntityOntology.ttl
@@ -1,4 +1,3 @@
-@base <https://www.commoncoreontologies.org/InformationEntityOntology/> .
 @prefix : <https://www.commoncoreontologies.org/InformationEntityOntology/> .
 @prefix cco: <https://www.commoncoreontologies.org/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
@@ -9,2699 +8,2690 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-# 
-# 
-# #################################################################
-# #
-# #    Annotation properties
-# #
-# #################################################################
-# 
-# 
-# http://purl.org/dc/terms/rights
-# 
-# https://www.commoncoreontologies.org/ont00001753
-# 
-# https://www.commoncoreontologies.org/ont00001754
-# 
-# https://www.commoncoreontologies.org/ont00001760
-# 
-# 
-# 
-# #################################################################
-# #
-# #    Object Properties
-# #
-# #################################################################
-# 
-# 
-# https://www.commoncoreontologies.org/ont00001801
-# 
-# https://www.commoncoreontologies.org/ont00001808
-# 
-# https://www.commoncoreontologies.org/ont00001811
-# 
-# https://www.commoncoreontologies.org/ont00001824
-# 
-# https://www.commoncoreontologies.org/ont00001837
-# 
-# https://www.commoncoreontologies.org/ont00001863
-# 
-# https://www.commoncoreontologies.org/ont00001868
-# 
-# https://www.commoncoreontologies.org/ont00001873
-# 
-# https://www.commoncoreontologies.org/ont00001877
-# 
-# https://www.commoncoreontologies.org/ont00001878
-# 
-# https://www.commoncoreontologies.org/ont00001879
-# 
-# https://www.commoncoreontologies.org/ont00001884
-# 
-# https://www.commoncoreontologies.org/ont00001899
-# 
-# https://www.commoncoreontologies.org/ont00001900
-# 
-# https://www.commoncoreontologies.org/ont00001904
-# 
-# https://www.commoncoreontologies.org/ont00001908
-# 
-# https://www.commoncoreontologies.org/ont00001912
-# 
-# https://www.commoncoreontologies.org/ont00001913
-# 
-# https://www.commoncoreontologies.org/ont00001914
-# 
-# https://www.commoncoreontologies.org/ont00001916
-# 
-# https://www.commoncoreontologies.org/ont00001917
-# 
-# https://www.commoncoreontologies.org/ont00001919
-# 
-# https://www.commoncoreontologies.org/ont00001920
-# 
-# https://www.commoncoreontologies.org/ont00001938
-# 
-# https://www.commoncoreontologies.org/ont00001942
-# 
-# https://www.commoncoreontologies.org/ont00001961
-# 
-# https://www.commoncoreontologies.org/ont00001963
-# 
-# https://www.commoncoreontologies.org/ont00001964
-# 
-# https://www.commoncoreontologies.org/ont00001965
-# 
-# https://www.commoncoreontologies.org/ont00001966
-# 
-# https://www.commoncoreontologies.org/ont00001976
-# 
-# https://www.commoncoreontologies.org/ont00001980
-# 
-# https://www.commoncoreontologies.org/ont00001982
-# 
-# https://www.commoncoreontologies.org/ont00001983
-# 
-# https://www.commoncoreontologies.org/ont00001997
-# 
-# 
-# 
-# #################################################################
-# #
-# #    Data properties
-# #
-# #################################################################
-# 
-# 
-# https://www.commoncoreontologies.org/ont00001765
-# 
-# https://www.commoncoreontologies.org/ont00001767
-# 
-# https://www.commoncoreontologies.org/ont00001768
-# 
-# https://www.commoncoreontologies.org/ont00001769
-# 
-# https://www.commoncoreontologies.org/ont00001770
-# 
-# https://www.commoncoreontologies.org/ont00001771
-# 
-# https://www.commoncoreontologies.org/ont00001772
-# 
-# https://www.commoncoreontologies.org/ont00001773
-# 
-# 
-# 
-# #################################################################
-# #
-# #    Classes
-# #
-# #################################################################
-# 
-# 
-# https://www.commoncoreontologies.org/ont00000003
-# 
-# https://www.commoncoreontologies.org/ont00000029
-# 
-# https://www.commoncoreontologies.org/ont00000067
-# 
-# https://www.commoncoreontologies.org/ont00000073
-# 
-# https://www.commoncoreontologies.org/ont00000077
-# 
-# https://www.commoncoreontologies.org/ont00000080
-# 
-# https://www.commoncoreontologies.org/ont00000087
-# 
-# https://www.commoncoreontologies.org/ont00000120
-# 
-# https://www.commoncoreontologies.org/ont00000124
-# 
-# https://www.commoncoreontologies.org/ont00000127
-# 
-# https://www.commoncoreontologies.org/ont00000146
-# 
-# https://www.commoncoreontologies.org/ont00000154
-# 
-# https://www.commoncoreontologies.org/ont00000164
-# 
-# https://www.commoncoreontologies.org/ont00000186
-# 
-# https://www.commoncoreontologies.org/ont00000203
-# 
-# https://www.commoncoreontologies.org/ont00000223
-# 
-# https://www.commoncoreontologies.org/ont00000253
-# 
-# https://www.commoncoreontologies.org/ont00000263
-# 
-# https://www.commoncoreontologies.org/ont00000275
-# 
-# https://www.commoncoreontologies.org/ont00000276
-# 
-# https://www.commoncoreontologies.org/ont00000293
-# 
-# https://www.commoncoreontologies.org/ont00000314
-# 
-# https://www.commoncoreontologies.org/ont00000326
-# 
-# https://www.commoncoreontologies.org/ont00000359
-# 
-# https://www.commoncoreontologies.org/ont00000369
-# 
-# https://www.commoncoreontologies.org/ont00000390
-# 
-# https://www.commoncoreontologies.org/ont00000398
-# 
-# https://www.commoncoreontologies.org/ont00000399
-# 
-# https://www.commoncoreontologies.org/ont00000406
-# 
-# https://www.commoncoreontologies.org/ont00000419
-# 
-# https://www.commoncoreontologies.org/ont00000469
-# 
-# https://www.commoncoreontologies.org/ont00000496
-# 
-# https://www.commoncoreontologies.org/ont00000498
-# 
-# https://www.commoncoreontologies.org/ont00000529
-# 
-# https://www.commoncoreontologies.org/ont00000539
-# 
-# https://www.commoncoreontologies.org/ont00000540
-# 
-# https://www.commoncoreontologies.org/ont00000589
-# 
-# https://www.commoncoreontologies.org/ont00000592
-# 
-# https://www.commoncoreontologies.org/ont00000604
-# 
-# https://www.commoncoreontologies.org/ont00000605
-# 
-# https://www.commoncoreontologies.org/ont00000626
-# 
-# https://www.commoncoreontologies.org/ont00000630
-# 
-# https://www.commoncoreontologies.org/ont00000649
-# 
-# https://www.commoncoreontologies.org/ont00000653
-# 
-# https://www.commoncoreontologies.org/ont00000669
-# 
-# https://www.commoncoreontologies.org/ont00000683
-# 
-# https://www.commoncoreontologies.org/ont00000686
-# 
-# https://www.commoncoreontologies.org/ont00000692
-# 
-# https://www.commoncoreontologies.org/ont00000702
-# 
-# https://www.commoncoreontologies.org/ont00000729
-# 
-# https://www.commoncoreontologies.org/ont00000731
-# 
-# https://www.commoncoreontologies.org/ont00000735
-# 
-# https://www.commoncoreontologies.org/ont00000745
-# 
-# https://www.commoncoreontologies.org/ont00000749
-# 
-# https://www.commoncoreontologies.org/ont00000798
-# 
-# https://www.commoncoreontologies.org/ont00000800
-# 
-# https://www.commoncoreontologies.org/ont00000827
-# 
-# https://www.commoncoreontologies.org/ont00000829
-# 
-# https://www.commoncoreontologies.org/ont00000833
-# 
-# https://www.commoncoreontologies.org/ont00000845
-# 
-# https://www.commoncoreontologies.org/ont00000853
-# 
-# https://www.commoncoreontologies.org/ont00000891
-# 
-# https://www.commoncoreontologies.org/ont00000894
-# 
-# https://www.commoncoreontologies.org/ont00000896
-# 
-# https://www.commoncoreontologies.org/ont00000915
-# 
-# https://www.commoncoreontologies.org/ont00000916
-# 
-# https://www.commoncoreontologies.org/ont00000923
-# 
-# https://www.commoncoreontologies.org/ont00000958
-# 
-# https://www.commoncoreontologies.org/ont00000965
-# 
-# https://www.commoncoreontologies.org/ont00000973
-# 
-# https://www.commoncoreontologies.org/ont00000990
-# 
-# https://www.commoncoreontologies.org/ont00001010
-# 
-# https://www.commoncoreontologies.org/ont00001014
-# 
-# https://www.commoncoreontologies.org/ont00001022
-
-cco:InformationEntityOntology a owl:Ontology;
-  owl:versionIRI </2024-11-06/InformationEntityOntology>;
-  owl:imports cco:GeospatialOntology, cco:TimeOntology;
-  dcterms:license "BSD 3-Clause: https://github.com/CommonCoreOntology/CommonCoreOntologies/blob/master/LICENSE"@en;
-  dcterms:rights "CUBRC Inc., see full license."@en;
-  rdfs:comment "This ontology is designed to represent generic types of information as well as the relationships between information and other entities."@en;
-  rdfs:label "Information Entity Ontology"@en;
-  owl:versionInfo "Version 2.0"@en .
-
-dcterms:rights a owl:AnnotationProperty .
-
-cco:ont00001753 a owl:AnnotationProperty .
-
-cco:ont00001754 a owl:AnnotationProperty .
-
-cco:ont00001760 a owl:AnnotationProperty .
-
-cco:ont00001801 a owl:ObjectProperty;
-  owl:inverseOf cco:ont00001808;
-  rdfs:domain obo:BFO_0000001;
-  rdfs:range cco:ont00000958;
-  rdfs:label "is subject of"@en;
-  skos:definition "x is_subject_of y iff x is an instance of Entity and y is an instance of Information Content Entity and y is_about x."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001808 a owl:ObjectProperty;
-  rdfs:domain cco:ont00000958;
-  rdfs:range obo:BFO_0000001;
-  rdfs:label "is about"@en;
-  skos:definition "x is_about y is a primitive relationship between an instance of Information Content Entity x and an instance of Entity y."@en;
-  cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000136";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001811 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001966;
-  owl:inverseOf cco:ont00001963;
-  rdfs:domain cco:ont00001010;
-  rdfs:range obo:BFO_0000001;
-  rdfs:label "is an ordinal measurement of"@en;
-  skos:definition "x is_an_ordinal_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity and y is_measured_by_ordinal x."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001824 a owl:ObjectProperty;
-  rdfs:domain cco:ont00000253;
-  rdfs:range cco:ont00000253;
-  rdfs:label "is excerpted from"@en;
-  skos:definition "An Information Bearing Entity b1 is excerpted from another Information Bearing Entity B2 iff b1 is part of some Information Bearing Entity B1 that is carrier of some Information Content Entity C1, B2 is carrier of some Information Content Entity C2, C1 is not identical with C2, b1 is carrier of some Information Content Entity c1, b2 is an Information Bearing Entity that is part of B2 and b2 is carrier of c1 (i.e. the same Information Content Entity as borne by b1)."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001837 a owl:ObjectProperty;
-  rdfs:subPropertyOf obo:BFO_0000084;
-  owl:inverseOf cco:ont00001908;
-  rdfs:domain cco:ont00000829;
-  rdfs:range cco:ont00000253;
-  rdfs:label "time zone identifier used by"@en;
-  skos:definition "x time_zone_identifier_used_by y iff y is an instance of Information Bearing Entity and x is an instance of Time Zone Identifier, such that x designates the spatial region associated with the time zone mentioned in y."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001863 a owl:ObjectProperty;
-  rdfs:subPropertyOf obo:BFO_0000101;
-  owl:inverseOf cco:ont00001961;
-  rdfs:domain cco:ont00000253;
-  rdfs:range cco:ont00000120;
-  rdfs:label "uses measurement unit"@en;
-  skos:definition "y uses_measurement_unit x iff y is an instance of Information Bearing Entity and x is an instance of Measurement Unit, such that x describes the magnitude of measured physical quantity mentioned in y."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001868 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001966;
-  owl:inverseOf cco:ont00001914;
-  rdfs:domain cco:ont00000293;
-  rdfs:range obo:BFO_0000001;
-  rdfs:label "is a nominal measurement of"@en;
-  skos:definition "x is_a_nominal_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x classifies y relative to some set of shared, possibly arbitrary, characteristics."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001873 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001801;
-  owl:inverseOf cco:ont00001938;
-  rdfs:range cco:ont00001069;
-  rdfs:comment "See notes for inverse property.";
-  rdfs:label "represented by"@en;
-  skos:definition "y represented_by x iff x is an instance of Representational Information Content Entity, and y is an instance of Entity, and z is carrier of x, such that x is about y in virtue of there existing an isomorphism between characteristics of z and y."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001877 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001966;
-  owl:inverseOf cco:ont00001964;
-  rdfs:domain cco:ont00001364;
-  rdfs:range obo:BFO_0000001;
-  rdfs:label "is an interval measurement of"@en;
-  skos:definition "x is_an_interval_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity and y is_measured_by_interval x."@en;
-  skos:example "a measurement of air temperature on the Celsius scale.";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001878 a owl:ObjectProperty;
-  owl:inverseOf cco:ont00001919;
-  rdfs:domain cco:ont00000253;
-  rdfs:range obo:BFO_0000001;
-  rdfs:label "is mention of"@en;
-  skos:definition "x is_mention_of y iff x is an instance Information Bearing Entity and y is an instance of Entity, such that x is used as a reference to y."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001879 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001801;
-  owl:inverseOf cco:ont00001916;
-  rdfs:domain obo:BFO_0000001;
-  rdfs:range cco:ont00000686;
-  rdfs:label "designated by"@en;
-  skos:definition "x designated_by y iff y is an instance of Designative Information Content Entity and x is an instance of Entity and y designates x."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001884 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001801;
-  owl:inverseOf cco:ont00001980;
-  rdfs:domain obo:BFO_0000001;
-  rdfs:range cco:ont00000127;
-  owl:propertyChainAxiom _:genid2;
-  rdfs:label "condition described by"@en;
-  skos:definition "x condition_described_by y iff y is an instance of Performance Specification and x is an instance of Entity and y describes_condition x."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid2 a rdf:List;
-  rdf:first cco:ont00001917;
-  rdf:rest _:genid1 .
-
-_:genid1 a rdf:List;
-  rdf:first obo:BFO_0000176;
-  rdf:rest rdf:nil .
-
-cco:ont00001899 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001942;
-  owl:inverseOf cco:ont00001976;
-  rdfs:domain cco:ont00001175;
-  rdfs:range cco:ont00000253;
-  rdfs:label "language used in"@en;
-  skos:definition "x language_used_by y iff y is an instance of Information Bearing Entity and x is an instance of Language, such that the literal value of y is a string that is encoded according to the syntax of x."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001900 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001997;
-  owl:inverseOf cco:ont00001913;
-  rdfs:domain cco:ont00000469;
-  rdfs:range cco:ont00000253;
-  rdfs:label "is geospatial coordinate reference system of"@en;
-  skos:definition "x is_geospatial_coordinate_reference_system_of y iff y is an instance of Information Bearing Entity and x is an instance of Geospatial Coordinate Reference System, such that x describes the set of standards mentioned in y."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001904 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001917;
-  owl:inverseOf cco:ont00001966;
-  rdfs:domain obo:BFO_0000001;
-  rdfs:range cco:ont00001163;
-  rdfs:label "is measured by"@en;
-  skos:definition "y is_measured_by x iff x is an instance of Measurement Information Content Entity and y is an instance of Entity and y is_a_measurement_of x."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001908 a owl:ObjectProperty;
-  rdfs:subPropertyOf obo:BFO_0000101;
-  rdfs:domain cco:ont00000253;
-  rdfs:range cco:ont00000829;
-  rdfs:label "uses time zone identifier"@en;
-  skos:definition "x uses_time_zone_identifier y iff x is an instance of Information Bearing Entity and y is an instance of Time Zone Identifier, such that y designates the spatial region associated with the time zone mentioned in x."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001912 a owl:ObjectProperty;
-  rdfs:subPropertyOf obo:BFO_0000101;
-  owl:inverseOf cco:ont00001997;
-  rdfs:domain cco:ont00000253;
-  rdfs:range cco:ont00000398;
-  rdfs:label "uses reference system"@en;
-  skos:definition "y uses_reference_system x iff y is an instance of Information Bearing Entity and x is an instance of Reference System, such that x describes the set of standards mentioned in y."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001913 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001912;
-  rdfs:domain cco:ont00000253;
-  rdfs:range cco:ont00000469;
-  rdfs:label "uses geospatial coordinate reference system"@en;
-  skos:definition "y uses_geospatial_coordinate_reference_system x iff y is an instance of Information Bearing Entity and x is an instance of Geospatial Coordinate Reference System, such that x describes the set of standards mentioned in y."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001914 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001904;
-  rdfs:domain obo:BFO_0000001;
-  rdfs:range cco:ont00000293;
-  rdfs:label "is measured by nominal"@en;
-  skos:definition "x is_measured_by_nominal y iff y is an instance of Nominal Measurement Information Content Entity and x is an instance of Entity, such that y classifies x relative to some set of shared, possibly arbitrary, characteristics."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001916 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001808;
-  rdfs:domain cco:ont00000686;
-  rdfs:range obo:BFO_0000001;
-  rdfs:label "designates"@en;
-  skos:definition "x designates y iff x is an instance of a Designative Information Content Entity, and y is an instance of an Entity, such that given some context, x uniquely distinguishes y from other entities."@en;
-  skos:example "a URL designates the location of a Web Page on the internet", "a person's name designates that person",
-    "a vehicle identification number designates some vehicle";
-  skos:scopeNote "Given a stronger temporal interpretation, this property may be functional. For more info please refer to https://github.com/BFO-ontology/BFO-2020/tree/master/src/owl/temporal%20extensions."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001917 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001801;
-  owl:inverseOf cco:ont00001982;
-  rdfs:domain obo:BFO_0000001;
-  rdfs:range cco:ont00000853;
-  rdfs:label "described by"@en;
-  skos:definition "x described_by y iff y is an instance of Descriptive Information Content Entity and x is an instance of Entity and y describes x."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001919 a owl:ObjectProperty;
-  rdfs:domain obo:BFO_0000001;
-  rdfs:range cco:ont00000253;
-  rdfs:label "is mentioned by"@en;
-  skos:definition "x is_mentioned_by y iff y is an instance of Information Bearing Entity and x is an instance of Entity, such that y is used as a reference to x."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001920 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001801;
-  owl:inverseOf cco:ont00001942;
-  rdfs:domain obo:BFO_0000001;
-  rdfs:range cco:ont00000965;
-  rdfs:label "prescribed by"@en;
-  skos:definition "x prescribed_by y iff y is an instance of Directive Information Content Entity and x is an instance of Entity and y prescribes x."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001938 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001808;
-  rdfs:domain cco:ont00000958;
-  rdfs:range obo:BFO_0000001;
-  rdfs:comment "Isomorphism between the carrier of x and the represented entity can be via a direct similarity relation, e.g., grooves in a vinyl record corresponding to sound waves, or linguistic convention, e.g., a court stenographer's transcription of spoken words, as well as others, such as encoding processes for images."@en;
-  rdfs:label "represents"@en;
-  skos:definition "x represents y iff x is an instance of Information Content Entity, y is an instance of Entity, and z is carrier of x, such that x is about y in virtue of there existing an isomorphism between characteristics of z and y."@en;
-  skos:scopeNote "Given a stronger temporal interpretation, this property may be functional. For more info please refer to https://github.com/BFO-ontology/BFO-2020/tree/master/src/owl/temporal%20extensions."@en,
-    "The relationship that is being defined here is that between the content of a photographic image and its object, between the content of a video and its objects and events, between the content of an audio recording and the sounds or events generating those sounds, or between the content of a written transcript and the verbal event that it transcribes."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001942 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001808;
-  rdfs:domain cco:ont00000965;
-  rdfs:range obo:BFO_0000001;
-  rdfs:label "prescribes"@en;
-  skos:definition "x prescribes y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x serves as a rule or guide for y if y an Occurrent, or x serves as a model for y if y is a Continuant."@en;
-  skos:example "A blueprint prescribes some artifact or facility by being a model for it.",
-    "A professional code of conduct prescribes some realizations of a profession (role) by giving rules for how the bearer should act in those realizations.",
-    "An operations plan prescribes an operation by enumerating the tasks that need to be performed in order to achieve the objectives of the operation.";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001961 a owl:ObjectProperty;
-  rdfs:subPropertyOf obo:BFO_0000084;
-  rdfs:domain cco:ont00000120;
-  rdfs:range cco:ont00000253;
-  rdfs:label "is measurement unit of"@en;
-  skos:definition "x is_measurement_unit_of y iff y is an instance of Information Bearing Entity and x is an instance of Measurement Unit, such that x describes the magnitude of measured physical quantity mentioned in y."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001963 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001904;
-  rdfs:domain obo:BFO_0000001;
-  rdfs:range cco:ont00001010;
-  rdfs:label "is measured by ordinal"@en;
-  skos:definition "x is_measured_by_ordinal y iff y is an instance of Ordinal Measurement Information Content Entity and x is an instance of Entity, such that y describes some attribute of x relative to a scale ordered by rank."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001964 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001904;
-  rdfs:domain obo:BFO_0000001;
-  rdfs:range cco:ont00001364;
-  rdfs:label "is measured by interval"@en;
-  skos:definition "y is_measured_by_interval x iff x is an instance of Interval Measurement Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale which has uniform intervals but has a zero value that does not correspond to an absence of the attribute being measured."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001965 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001904;
-  owl:inverseOf cco:ont00001983;
-  rdfs:domain obo:BFO_0000001;
-  rdfs:range cco:ont00001022;
-  rdfs:label "is measured by ratio"@en;
-  skos:definition "y is_measured_by_ratio x iff x is an instance of Ratio Measurement Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale having equal unit values and a zero value that corresponds to the absence of the attribute being measured."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001966 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001982;
-  rdfs:domain cco:ont00001163;
-  rdfs:range obo:BFO_0000001;
-  rdfs:comment "This object property, as well as all of its children are typified as functional properties. This means that for instances x, y, and z if x is a measurement of y and x is a measurement of z, then y = z."@en;
-  rdfs:label "is a measurement of"@en;
-  skos:definition "x is_a_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to some scale or classification scheme."@en;
-  skos:scopeNote "Given a stronger temporal interpretation, this property may be functional. For more info please refer to https://github.com/BFO-ontology/BFO-2020/tree/master/src/owl/temporal%20extensions."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001976 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001920;
-  rdfs:domain cco:ont00000253;
-  rdfs:range cco:ont00001175;
-  rdfs:label "uses language"@en;
-  skos:definition "x uses_language y iff x is an instance of an Information Bearing Entity and y is an instance of a Language such that the literal value of x is a string that is encoded according to the syntax of y."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001980 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001808;
-  rdfs:domain cco:ont00000127;
-  rdfs:range obo:BFO_0000001;
-  owl:propertyChainAxiom _:genid4;
-  rdfs:label "describes condition"@en;
-  skos:definition "p describes_condition c iff p is an instance of a Performance Specification and c is an instance of Entity and p has part d, and d is an instance of a Descriptive Information Content Entity, and p prescribes an entity s, and d describes c, and c is an entity that is causally relevant to s existing as prescribed by p."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid4 a rdf:List;
-  rdf:first obo:BFO_0000178;
-  rdf:rest _:genid3 .
-
-_:genid3 a rdf:List;
-  rdf:first cco:ont00001982;
-  rdf:rest rdf:nil .
-
-cco:ont00001982 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001808;
-  rdfs:domain cco:ont00000853;
-  rdfs:range obo:BFO_0000001;
-  rdfs:comment "It is possible that this relation should be a functional property, that is for all x, y, z if x describes y and x describes z then y = z. For example, if a financial report x describes the quarterly results of a company y and that same financial report describes the quarterly results of a company z, then it should be inferred that companies y and z are the same. We refrained from classifying the relation as a functional property on the concern that descriptions are multifaceted and so consequently it may be that the same report would contain descriptions of multiple entities."@en;
-  rdfs:label "describes"@en;
-  skos:definition "x describes y iff x is an instance of Descriptive Information Content Entity, and y is an instance of Entity, such that x is_about the characteristics that identify y."@en;
-  skos:example "the content of a newspaper article describes some current event", "the content of a visitor's log describes some facility visit",
-    "the content of an accident report describes some accident";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001983 a owl:ObjectProperty;
-  rdfs:subPropertyOf cco:ont00001966;
-  rdfs:domain cco:ont00001022;
-  rdfs:range obo:BFO_0000001;
-  rdfs:label "is a ratio measurement of"@en;
-  skos:definition "x is_a_ratio_measurement_of y iff x is an instance of Ratio Measurement Information Content Entity and y is an instance of Entity and x describes some attribute of y relative to a scale having equal unit values and a zero value that corresponds to the absence of the attribute being measured."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001997 a owl:ObjectProperty;
-  rdfs:subPropertyOf obo:BFO_0000084;
-  rdfs:domain cco:ont00000398;
-  rdfs:range cco:ont00000253;
-  rdfs:label "is reference system of"@en;
-  skos:definition "x is_reference_system_of y iff y is an instance of Information Bearing Entity and x is an instance of Reference System, such that x describes the set of standards mentioned in y."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001765 a owl:DatatypeProperty;
-  rdfs:domain cco:ont00000253;
-  rdfs:label "has text value"@en;
-  skos:definition "A data property that has as its range a string value."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001767 a owl:DatatypeProperty;
-  rdfs:domain cco:ont00000253;
-  rdfs:range xsd:dateTime;
-  rdfs:label "has datetime value"@en;
-  skos:definition "A data property that has as its value a datetime value."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001768 a owl:DatatypeProperty;
-  rdfs:domain cco:ont00000253;
-  rdfs:range xsd:anyURI;
-  rdfs:label "has URI value"@en;
-  skos:definition "A data property that has as its range a URI value."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001769 a owl:DatatypeProperty;
-  rdfs:domain cco:ont00000253;
-  rdfs:range xsd:decimal;
-  rdfs:label "has decimal value"@en;
-  skos:definition "A data property that has as its range a decimal value."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001770 a owl:DatatypeProperty;
-  rdfs:domain cco:ont00000253;
-  rdfs:range xsd:double;
-  rdfs:label "has double value"@en;
-  skos:definition "A data property that has as its range a double value."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001771 a owl:DatatypeProperty;
-  rdfs:domain cco:ont00000253;
-  rdfs:label "has date value"@en;
-  skos:definition "A data property that has as its range a date value."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001772 a owl:DatatypeProperty;
-  rdfs:domain cco:ont00000253;
-  rdfs:range xsd:boolean;
-  rdfs:label "has boolean value"@en;
-  skos:definition "A data property that has as its range a boolean value."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001773 a owl:DatatypeProperty;
-  rdfs:domain cco:ont00000253;
-  rdfs:range xsd:integer;
-  rdfs:label "has integer value"@en;
-  skos:definition "A data property that has as its range an integer value."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000003 a owl:Class;
-  rdfs:subClassOf cco:ont00000686;
-  owl:disjointWith cco:ont00000649;
-  rdfs:label "Designative Name"@en;
-  skos:altLabel "Name"@en;
-  skos:definition "A Designative Information Content Entity that consists of a string of characters that designates an entity within a specified cultural or social namespace and which is typically a word or phrase in a natural language that has an accepted cultural or social significance."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000029 a owl:Class;
-  rdfs:subClassOf cco:ont00000745;
-  rdfs:label "Median Point Estimate Information Content Entity"@en;
-  skos:altLabel "Median"@en;
-  skos:definition "A Point Estimate Information Content Entity that is a measurement of a set of values and is equal to either the middle value or the average of the two values which separate the set into two equally populated upper and lower sets."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000067 a owl:Class;
-  rdfs:subClassOf cco:ont00001328;
-  rdfs:comment "In traditional astronomical usage, civil time is mean solar time as calculated from midnight as the beginning of the Civil Day."@en,
-    "Note that Civil Time Reference System is more accurately represented as a Temporal Reference System that participates in an act of usage that is sanctioned by an appropriate civil authority. As such, it should be represented as a defined class."@en;
-  rdfs:label "Civil Time Reference System"@en;
-  skos:definition "A Temporal Reference System that is a statutory time scale as designated by civilian authorities to determine local time(s)."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000073 a owl:Class;
-  owl:equivalentClass _:genid5;
-  rdfs:subClassOf cco:ont00000399;
-  rdfs:label "Temporal Interval Identifier"@en;
-  skos:altLabel "One-Dimensional Temporal Region Identifier"@en;
-  skos:definition "A Temporal Region Identifier that designates some Temporal Interval."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid5 a owl:Class;
-  owl:intersectionOf _:genid8 .
-
-_:genid8 a rdf:List;
-  rdf:first cco:ont00000399;
-  rdf:rest _:genid6 .
-
-_:genid6 a rdf:List;
-  rdf:first _:genid7;
-  rdf:rest rdf:nil .
-
-_:genid7 a owl:Restriction;
-  owl:someValuesFrom obo:BFO_0000038;
-  owl:onProperty cco:ont00001916 .
-
-cco:ont00000077 a owl:Class;
-  rdfs:subClassOf cco:ont00000649;
-  owl:disjointWith cco:ont00000923;
-  rdfs:label "Code Identifier"@en;
-  skos:altLabel "Code ID"@en, "ID Code"@en, "Identifier Code"@en;
-  skos:definition "A Non-Name Identifier that consists of a string of characters that was created and assigned according to an encoding system such that metadata can be derived from the identifier."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000080 a owl:Class;
-  rdfs:subClassOf cco:ont00000827;
-  rdfs:label "Standard Time of Day Identifier"@en;
-  skos:definition "A Time of Day Identifier that designates an approximate Temporal Instant that is part of some Day and is specified using the Hours, Minutes, and Seconds of the Day that preceded the Temporal Instant."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000087 a owl:Class;
-  rdfs:subClassOf cco:ont00000894;
-  rdfs:comment "An Ordinal Date Identifier may or may not also contain a number indicating a specific Year. If both numbers are included, the ISO 8601 ordinal date format stipulates that the two numbers be formatted as YYYY-DDD or YYYYDDD where [YYYY] indicates a year and [DDD] is the day of that year, from 001 through 365 (or 366 in leap years)."@en;
-  rdfs:label "Ordinal Date Identifier"@en;
-  skos:altLabel "Ordinal Date"@en;
-  skos:definition "A Decimal Date Identifier that designates some Day by using a number to indicate the sequential ordering of the Day since the beginning of the Year."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ordinal_date&oldid=1061989434"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000120 a owl:Class;
-  rdfs:subClassOf cco:ont00000853;
-  rdfs:label "Measurement Unit"@en;
-  skos:definition "A Descriptive Information Content Entity that describes a definite magnitude of a physical quantity, defined and adopted by convention and/or by law, that is used as a standard for measurement of the same physical quantity."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Unit_of_measurement&oldid=1061038125"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000124 a owl:Class;
-  rdfs:subClassOf cco:ont00001328;
-  rdfs:label "Solar Time Reference System"@en;
-  skos:definition "A Temporal Reference System that is based on the position of the Sun in the sky."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000127 a owl:Class;
-  rdfs:subClassOf cco:ont00000965, _:genid9;
-  rdfs:label "Performance Specification"@en;
-  skos:definition "A Directive Information Content Entity that prescribes some aspect of the behavior of a participant in a Process given one or more operating conditions."@en;
-  skos:example "Maximum Speed at high altitude; Rate of Ascent at 10 degrees celsius with nominal payload.";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid9 a owl:Restriction;
-  owl:someValuesFrom obo:BFO_0000001;
-  owl:onProperty cco:ont00001980 .
-
-cco:ont00000146 a owl:Class;
-  rdfs:subClassOf cco:ont00001175;
-  owl:disjointWith cco:ont00000496;
-  rdfs:label "Artificial Language"@en;
-  skos:definition "A Language that is developed through conscious planning and premeditation, rather than one that was developed through use and repetition."@en;
-  skos:example "Esperanto", "Python Programming Language";
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Constructed_language&oldid=1062733589"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000154 a owl:Class;
-  rdfs:subClassOf cco:ont00000745;
-  rdfs:comment "While there is always at least one Mode for every set of data, it is possible for any given set of data to have multiple Modes. The Mode is typically most useful when the members of the set are all Nominal Measurement Information Content Entities."@en;
-  rdfs:label "Mode Point Estimate Information Content Entity"@en;
-  skos:altLabel "Mode"@en, "Statistical Mode"@en;
-  skos:definition "A Point Estimate Information Content Entity that is a measurement of a set of values and is equal to the value or values that occur most often in the set."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000164 a owl:Class;
-  rdfs:subClassOf cco:ont00001010;
-  rdfs:label "Minimum Ordinal Measurement Information Content Entity"@en;
-  skos:definition "An Ordinal Measurement Information Content Entity that is a measurement of some entity in virtue of it being the smallest or having the least amount relative to a nominally described set of like entities."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000186 a owl:Class;
-  rdfs:subClassOf cco:ont00001010;
-  rdfs:label "Artifact Version Ordinality"@en;
-  skos:definition "An Ordinal Measurement Information Content Entity that is about the form of an Artifact which differs in some respects from previous or future forms of that Artifact."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000203 a owl:Class;
-  rdfs:subClassOf cco:ont00000293;
-  rdfs:label "Event Status Nominal Information Content Entity"@en;
-  skos:definition "A Nominal Measurement Information Content Entity that is a measurement of the current state of a process."@en;
-  skos:example "proposed, approved, planned, in progress, completed, failed, or successful";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000223 a owl:Class .
-
-cco:ont00000253 a owl:Class;
-  owl:equivalentClass _:genid10;
-  rdfs:subClassOf obo:BFO_0000030;
-  rdfs:comment "This class continues to use the word ‘bearing’ in its rdfslabel because of potential confusion with the acronym ‘ICE’, which is widely used for information content entity."@en;
-  rdfs:label "Information Bearing Entity"@en;
-  skos:altLabel "IBE"@en, "Information Carrying Entity"@en;
-  skos:definition "An Object upon which an Information Content Entity generically depends."@en;
-  cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000178"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid10 a owl:Class;
-  owl:intersectionOf _:genid13 .
-
-_:genid13 a rdf:List;
-  rdf:first obo:BFO_0000030;
-  rdf:rest _:genid11 .
-
-_:genid11 a rdf:List;
-  rdf:first _:genid12;
-  rdf:rest rdf:nil .
-
-_:genid12 a owl:Restriction;
-  owl:someValuesFrom cco:ont00000958;
-  owl:onProperty obo:BFO_0000101 .
-
-cco:ont00000263 a owl:Class;
-  rdfs:subClassOf cco:ont00001328;
-  rdfs:comment "A single Clock Time System does not provide a complete means for identifying or measuring times. Depending on the particular Clock Time System, it may be compatible for use with one or more other Temporal Reference Systems."@en;
-  rdfs:label "Clock Time System"@en;
-  skos:definition "A Temporal Reference System that is a convention for keeping and displaying the Time of Day."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000275 a owl:Class;
-  rdfs:subClassOf cco:ont00000398;
-  rdfs:comment "Note that, while reference systems and reference frames are treated as synonyms here, some people treat them as related but separate entities. See: http://www.ggos-portal.org/lang_en/GGOS-Portal/EN/Topics/GeodeticApplications/GeodeticReferenceSystemsAndFrames/GeodeticReferenceSystemsAndFrames.html"@en;
-  rdfs:label "Spatial Reference System"@en;
-  skos:altLabel "Coordinate System"@en, "Spatial Coordinate System"@en, "Spatial Reference Frame"@en;
-  skos:definition "A Reference System that describes a set of standards for uniquely identifying the position of an entity or the direction of a vector within a defined spatial region by means of measurements along one or more Coordinate System Axes."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Coordinate_system&oldid=1060461397"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000276 a owl:Class;
-  rdfs:subClassOf cco:ont00000891;
-  rdfs:label "Solar Calendar System"@en;
-  skos:definition "A Calendar System that is designed to organize and identify dates based on the cycles of an Astronomical Body's Orbit around the Sun."@en;
-  skos:scopeNote "Unless otherwise specified, a Solar Calendar System is assumed to be relative to the Orbit of the Earth around the Sun."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Solar_calendar&oldid=1058016588"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000293 a owl:Class;
-  owl:equivalentClass _:genid14;
-  rdfs:subClassOf cco:ont00001163;
-  owl:disjointWith cco:ont00001010, cco:ont00001022, cco:ont00001364;
-  rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en;
-  rdfs:label "Nominal Measurement Information Content Entity"@en;
-  skos:definition "A Measurement Information Content Entity that consists of a symbol that classifies Entities according to some shared, possibly arbitrary, characteristic."@en;
-  skos:example "The sentence \"January 20, 1985 was a cold day in Chicago, IL\" is the carrier of a nominal measurement."@en,
-    "a measurement that classifies automobiles as sedans, coupes, hatchbacks, or convertibles",
-    "a measurement that classifies military intelligence as strategic, operational, or tactical",
-    "a measurement that classifies rocks as igneous, sedimentary, or metamorphic";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid14 a owl:Class;
-  owl:intersectionOf _:genid17 .
-
-_:genid17 a rdf:List;
-  rdf:first cco:ont00001163;
-  rdf:rest _:genid15 .
-
-_:genid15 a rdf:List;
-  rdf:first _:genid16;
-  rdf:rest rdf:nil .
-
-_:genid16 a owl:Restriction;
-  owl:someValuesFrom obo:BFO_0000001;
-  owl:onProperty cco:ont00001868 .
-
-cco:ont00000314 a owl:Class;
-  rdfs:subClassOf obo:BFO_0000019, _:genid18;
-  rdfs:comment "Typically, an IQE will be a complex pattern made up of multiple qualities joined together spatially."@en;
-  rdfs:label "Information Quality Entity"@en;
-  skos:altLabel "IQE"@en;
-  skos:definition "A Quality that concretizes some Information Content Entity."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid18 a owl:Restriction;
-  owl:someValuesFrom cco:ont00000253;
-  owl:onProperty obo:BFO_0000197 .
-
-cco:ont00000326 a owl:Class .
-
-cco:ont00000359 a owl:Class .
-
-cco:ont00000369 a owl:Class;
-  rdfs:subClassOf cco:ont00001010;
-  rdfs:label "Priority Measurement Information Content Entity"@en;
-  skos:altLabel "Criticality Measurement"@en, "Importance Measurement"@en, "Priority Measurement"@en;
-  skos:definition "An Ordinal Measurement Information Content Entity that is a measurement of the relative importance of an entity."@en;
-  skos:example "low, normal, high, urgent, or immediate priority";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000390 a owl:Class;
-  owl:equivalentClass _:genid19;
-  rdfs:subClassOf cco:ont00000686;
-  rdfs:label "Spatial Region Identifier"@en;
-  skos:definition "A Designative Information Content Entity that designates some Spatial Region."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid19 a owl:Class;
-  owl:intersectionOf _:genid22 .
-
-_:genid22 a rdf:List;
-  rdf:first cco:ont00000686;
-  rdf:rest _:genid20 .
-
-_:genid20 a rdf:List;
-  rdf:first _:genid21;
-  rdf:rest rdf:nil .
-
-_:genid21 a owl:Restriction;
-  owl:someValuesFrom obo:BFO_0000006;
-  owl:onProperty cco:ont00001916 .
-
-cco:ont00000398 a owl:Class;
-  rdfs:subClassOf cco:ont00000853;
-  rdfs:label "Reference System"@en;
-  skos:definition "A Descriptive Information Content Entity that describes a set of standards for organizing and understanding data of the specified type or domain."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000399 a owl:Class;
-  owl:equivalentClass _:genid23;
-  rdfs:subClassOf cco:ont00000686;
-  rdfs:label "Temporal Region Identifier"@en;
-  skos:definition "A Designative Information Content Entity that designates some Temporal Region."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid23 a owl:Class;
-  owl:intersectionOf _:genid26 .
-
-_:genid26 a rdf:List;
-  rdf:first cco:ont00000686;
-  rdf:rest _:genid24 .
-
-_:genid24 a rdf:List;
-  rdf:first _:genid25;
-  rdf:rest rdf:nil .
-
-_:genid25 a owl:Restriction;
-  owl:someValuesFrom obo:BFO_0000008;
-  owl:onProperty cco:ont00001916 .
-
-cco:ont00000406 a owl:Class;
-  rdfs:subClassOf cco:ont00000120;
-  rdfs:label "Measurement Unit of Geocoordinate"@en;
-  skos:definition "A Measurement Unit specifying the geospatial coordinates of a location."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000419 a owl:Class;
-  rdfs:subClassOf cco:ont00000077;
-  rdfs:label "Part Number"@en;
-  skos:definition "A Code Identifier that designates a type of part whose instances are designed to be part of some Artifact."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000469 a owl:Class;
-  rdfs:subClassOf cco:ont00000275;
-  rdfs:label "Geospatial Coordinate Reference System"@en;
-  skos:altLabel "Geographic Coordinate System"@en;
-  skos:definition "A Spatial Reference System that is used to determine and identify the location of a point or object at or near the surface of the Earth."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000496 a owl:Class;
-  rdfs:subClassOf cco:ont00001175;
-  rdfs:label "Natural Language"@en;
-  skos:definition "A Language that is developed and evolves through use and repetition, rather than through conscious planning or premeditation."@en;
-  skos:example "English", "Mandarin (Chinese)", "Spanish";
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Natural_language&oldid=1060890461"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000498 a owl:Class .
-
-cco:ont00000529 a owl:Class;
-  owl:equivalentClass _:genid27;
-  rdfs:subClassOf cco:ont00000073;
-  rdfs:label "Date Identifier"@en;
-  skos:altLabel "Day Identifier"@en;
-  skos:definition "A Temporal Interval Identifier that designates some Day."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid27 a owl:Class;
-  owl:intersectionOf _:genid30 .
-
-_:genid30 a rdf:List;
-  rdf:first cco:ont00000073;
-  rdf:rest _:genid28 .
-
-_:genid28 a rdf:List;
-  rdf:first _:genid29;
-  rdf:rest rdf:nil .
-
-_:genid29 a owl:Restriction;
-  owl:someValuesFrom cco:ont00000800;
-  owl:onProperty cco:ont00001916 .
-
-cco:ont00000539 a owl:Class;
-  rdfs:subClassOf cco:ont00001022;
-  rdfs:label "Count Measurement Information Content Entity"@en;
-  skos:definition "A Ratio Measurement Information Content Entity that is a measurement of the number of members of some aggregate."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000540 a owl:Class;
-  owl:equivalentClass _:genid31;
-  rdfs:subClassOf cco:ont00000399;
-  rdfs:label "Temporal Instant Identifier"@en;
-  skos:altLabel "Zero-Dimensional Temporal Region Identifier"@en;
-  skos:definition "A Temporal Region Identifier that designates some Temporal Instant."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid31 a owl:Class;
-  owl:intersectionOf _:genid34 .
-
-_:genid34 a rdf:List;
-  rdf:first cco:ont00000399;
-  rdf:rest _:genid32 .
-
-_:genid32 a rdf:List;
-  rdf:first _:genid33;
-  rdf:rest rdf:nil .
-
-_:genid33 a owl:Restriction;
-  owl:someValuesFrom obo:BFO_0000203;
-  owl:onProperty cco:ont00001916 .
-
-cco:ont00000589 a owl:Class;
-  rdfs:subClassOf cco:ont00000973;
-  rdfs:label "Julian Date Fraction"@en;
-  skos:altLabel "Julian Date Time Identifier"@en, "Julian Day Fraction"@en;
-  skos:definition "A Decimal Time of Day Identifier that designates an approximate Temporal Instant that is part of some Julian Day."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000592 a owl:Class;
-  rdfs:subClassOf cco:ont00001163;
-  rdfs:comment "'Deviation Measurement Information Content Entity' and 'Veracity Measurement Information Content Entity' are complementary notions. Deviation is a measure of whether reality conforms to an ICE (e.g., a plan or prediction), whereas Veracity is a measure of whether a Descriptive ICE conforms to reality."@en,
-    "Note, the term 'accuracy' is avoided due to its ambiguity between: correctness-of-performance (see: 'Reliability Measurement Information Content Entity'), correctness-of-information ('Veracity Measurement Information Content Entity'), and adherance-to-expectations (see: 'Deviation Measurement Information Content Entity')."@en;
-  rdfs:label "Veracity Measurement Information Content Entity"@en;
-  skos:altLabel "Accuracy of Information"@en, "Trueness Measurement"@en, "Veracity Measurement"@en;
-  skos:definition "A Measurement Information Content Entity that is a measurement of the extent to which a description conforms to the reality it describes."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000604 a owl:Class;
-  rdfs:subClassOf cco:ont00001010;
-  rdfs:label "Maximum Ordinal Measurement Information Content Entity"@en;
-  skos:definition "An Ordinal Measurement Information Content Entity that is a measurement of some entity in virtue of it being the largest or having the greatest amount relative to a nominally described set of like entities."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000605 a owl:Class;
-  rdfs:subClassOf cco:ont00000003;
-  rdfs:label "Abbreviated Name"@en;
-  skos:definition "A Designative Name that is a shortened form of a Proper Name."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000626 a owl:Class;
-  rdfs:subClassOf cco:ont00000853;
-  rdfs:comment "Since predictions are inherently about not-yet-existant things, the Modal Relation Ontology term 'describes' (i.e. mro:describes) should be used (instead of the standard cco:describes) to relate instances of Predictive Information Content Entity to the entities they are about."@en;
-  rdfs:label "Predictive Information Content Entity"@en;
-  skos:altLabel "Prediction"@en, "Prediction Information Content Entity"@en;
-  skos:definition "A Descriptive Information Content Entity that describes an uncertain future event."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000630 a owl:Class;
-  rdfs:subClassOf cco:ont00000124;
-  rdfs:label "Universal Time Reference System"@en;
-  skos:definition "A Solar Time Reference System that is based on the average speed of the Earth's rotation and which uses the prime meridian at 0° longitude as a reference point."@en;
-  cco:ont00001753 "UT";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000649 a owl:Class;
-  rdfs:subClassOf cco:ont00000686;
-  rdfs:label "Non-Name Identifier"@en;
-  skos:altLabel "ID"@en, "Identifier"@en;
-  skos:definition "A Designative Information Content Entity that consists of a string of characters that designates an entity within a specified namespace or context, is not a Designative Name, may be automatically or randomly generated, and typically has no preexisting cultural or social significance."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000653 a owl:Class;
-  rdfs:subClassOf cco:ont00000965;
-  rdfs:label "Algorithm"@en;
-  skos:definition "A Directive Information Content Entity that prescribes some Process and contains a finite sequence of unambiguous instructions in order to achieve some Objective."@en;
-  cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000064"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000669 a owl:Class;
-  rdfs:subClassOf cco:ont00001022;
-  rdfs:label "Distance Measurement Information Content Entity"@en;
-  skos:definition "A Ratio Measurement Information Content Entity that is a measurement of a One-Dimensional Extent inhering in some Site that is externally connected to two Independent Continuants."@en;
-  skos:scopeNote "Displacement (vector) is the shortest possible distance (scalar) between two points. Further thought is needed to adequately handle measurements of distance traveled along a path, e.g., a circuitous path or an arc (such as the surface of a planet), versus the simple case of a direct, straight line between two points."@en,
-    "Distance is a measure between two reference points, which are located on or in, or in some manner part of, the two obejcts for which the length of the extent between is sought. For exmple, the center point of the indentation of a ball in the sand and the edge of the foul line, the forwardmost point on a car's bumper and the closest point on the 2-dimensional plane that serves as the fiat boundary of a crosswalk, the center of an antenna array and closest point on ground."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000683 a owl:Class;
-  rdfs:subClassOf cco:ont00000605;
-  rdfs:label "Diminutive Name"@en;
-  skos:definition "An Abbreviated Name that is a familiar form of a Proper Name."@en;
-  skos:example "Alex, Bob, Cathy";
-  skos:scopeNote "\"Familiar form of a Proper Name\" means: that the name is (originally) a short, affectionate version of the fuller name, used (originally) by family or friends."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000686 a owl:Class;
-  owl:equivalentClass _:genid35;
-  rdfs:subClassOf cco:ont00000958;
-  owl:disjointWith cco:ont00000853, cco:ont00000965;
-  rdfs:label "Designative Information Content Entity"@en;
-  skos:altLabel "Designative ICE"@en;
-  skos:definition "An Information Content Entity that consists of a set of symbols that designate some Entity."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid35 a owl:Class;
-  owl:intersectionOf _:genid38 .
-
-_:genid38 a rdf:List;
-  rdf:first cco:ont00000958;
-  rdf:rest _:genid36 .
-
-_:genid36 a rdf:List;
-  rdf:first _:genid37;
-  rdf:rest rdf:nil .
-
-_:genid37 a owl:Restriction;
-  owl:someValuesFrom obo:BFO_0000001;
-  owl:onProperty cco:ont00001916 .
-
-cco:ont00000692 a owl:Class;
-  rdfs:subClassOf cco:ont00001163;
-  rdfs:comment "Every probability measurement is made within a particular context given certain background assumptions."@en;
-  rdfs:label "Probability Measurement Information Content Entity"@en;
-  skos:altLabel "Likelihood Measurement"@en, "Probability Measurement"@en;
-  skos:definition "A Measurement Information Content Entity that is a measurement of the likelihood that a Process or Process Aggregate occurs."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Probability&oldid=1059657543"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000702 a owl:Class .
-
-cco:ont00000729 a owl:Class;
-  rdfs:subClassOf cco:ont00000275;
-  rdfs:label "Spherical Coordinate System"@en;
-  skos:definition "A Spatial Reference System for three-dimensional spatial regions that identifies each point using an ordered triple of numerical coordinates that consist of the radial distance of the point of interest from a fixed origin, its polar angle measured from a fixed zenith direction, and the azimuth angle of its orthogonal projection measured from a fixed direction on a reference plane that passes through the origin and is orthogonal to the zenith."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Spherical_coordinate_system&oldid=1061029174"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000731 a owl:Class;
-  rdfs:subClassOf cco:ont00001163;
-  rdfs:comment "'Deviation Measurement Information Content Entity' and 'Veracity Measurement Information Content Entity' are complementary notions. Deviation is a measure of whether reality conforms to an ICE (e.g., a plan or prediction), whereas Veracity is a measure of whether a Descriptive ICE conforms to reality."@en,
-    "Note, the term 'accuracy' is avoided due to its ambiguity between: correctness-of-performance (see: 'Reliability Measurement Information Content Entity'), correctness-of-information (see: 'Veracity Measurement Information Content Entity'), and adherance-to-expectations ('Deviation Measurement Information Content Entity')."@en;
-  rdfs:label "Deviation Measurement Information Content Entity"@en;
-  skos:altLabel "Conformance Measurement"@en, "Degree of Conformance"@en, "Degree of Deviation"@en,
-    "Deviation Measurement"@en;
-  skos:definition "A Measurement Information Content Entity that is a measurement of the extent to which an entity conforms to how it is expected or supposed to be."@en;
-  skos:example "a missile impact deviates from its target location by 100 feet", "a satellite deviaties from its predicted orbital path by 5 kilometers",
-    "an overweight piece of luggage deviates from an airline's maximum allowed weight by +10 pounds";
-  skos:scopeNote "In order for a Deviation to exist, an entity must first be expected, represented, prescribed, or predicted as being a certain way. Then, at a future time, this value can be compared to its actual, reported, or measured value to determine the Deviation between these values."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000735 a owl:Class;
-  rdfs:subClassOf cco:ont00000406;
-  rdfs:label "Geospatial Region Bounding Box Identifier List"@en;
-  skos:definition "A Measurement Unit of Geocoordinate that is comprised of 4 pairs of coordinates, one for each of the 4 defining points (North, West, South, East) of a Geospatial Region Bounding Box."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000745 a owl:Class;
-  rdfs:subClassOf cco:ont00001176;
-  rdfs:label "Point Estimate Information Content Entity"@en;
-  skos:altLabel "Best Estimate"@en, "Point Estimate"@en, "Point Estimate Measurement Information Content Entity"@en;
-  skos:definition "An Estimate Information Content Entity that consists of a single value for the measured entity."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000749 a owl:Class;
-  rdfs:subClassOf cco:ont00000894, _:genid39;
-  rdfs:label "Julian Day Number"@en;
-  skos:definition "A Decimal Date Identifier that designates some Julian Day by using a number to indicate the sequential ordering of the Day since the Julian Date epoch."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid39 a owl:Restriction;
-  owl:someValuesFrom cco:ont00000498;
-  owl:onProperty cco:ont00001916 .
-
-cco:ont00000798 a owl:Class .
-
-cco:ont00000800 a owl:Class .
-
-cco:ont00000827 a owl:Class;
-  owl:equivalentClass _:genid40;
-  rdfs:subClassOf cco:ont00000540;
-  rdfs:label "Time of Day Identifier"@en;
-  skos:definition "A Temporal Instant Identifier that designates some Time of Day."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid40 a owl:Class;
-  owl:intersectionOf _:genid43 .
-
-_:genid43 a rdf:List;
-  rdf:first cco:ont00000540;
-  rdf:rest _:genid41 .
-
-_:genid41 a rdf:List;
-  rdf:first _:genid42;
-  rdf:rest rdf:nil .
-
-_:genid42 a owl:Restriction;
-  owl:someValuesFrom cco:ont00000223;
-  owl:onProperty cco:ont00001916 .
-
-cco:ont00000829 a owl:Class;
-  rdfs:subClassOf cco:ont00000390;
-  rdfs:comment """Standards of date, time, and time zone data formats:
+@base <https://www.commoncoreontologies.org/InformationEntityOntology/> .
+
+<https://www.commoncoreontologies.org/InformationEntityOntology> rdf:type owl:Ontology ;
+                                                                  owl:versionIRI <https://www.commoncoreontologies.org/2024-11-06/InformationEntityOntology> ;
+                                                                  owl:imports cco:GeospatialOntology ,
+                                                                              cco:TimeOntology ;
+                                                                  dcterms:license "BSD 3-Clause: https://github.com/CommonCoreOntology/CommonCoreOntologies/blob/master/LICENSE"@en ;
+                                                                  dcterms:rights "CUBRC Inc., see full license."@en ;
+                                                                  rdfs:comment "This ontology is designed to represent generic types of information as well as the relationships between information and other entities."@en ;
+                                                                  rdfs:label "Information Entity Ontology"@en ;
+                                                                  owl:versionInfo "Version 2.0"@en .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/terms/rights
+dcterms:rights rdf:type owl:AnnotationProperty .
+
+
+###  https://www.commoncoreontologies.org/ont00001753
+cco:ont00001753 rdf:type owl:AnnotationProperty .
+
+
+###  https://www.commoncoreontologies.org/ont00001754
+cco:ont00001754 rdf:type owl:AnnotationProperty .
+
+
+###  https://www.commoncoreontologies.org/ont00001760
+cco:ont00001760 rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  https://www.commoncoreontologies.org/ont00001801
+cco:ont00001801 rdf:type owl:ObjectProperty ;
+                owl:inverseOf cco:ont00001808 ;
+                rdfs:domain obo:BFO_0000001 ;
+                rdfs:range cco:ont00000958 ;
+                rdfs:label "is subject of"@en ;
+                skos:definition "x is_subject_of y iff x is an instance of Entity and y is an instance of Information Content Entity and y is_about x."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001808
+cco:ont00001808 rdf:type owl:ObjectProperty ;
+                rdfs:domain cco:ont00000958 ;
+                rdfs:range obo:BFO_0000001 ;
+                rdfs:label "is about"@en ;
+                skos:definition "x is_about y is a primitive relationship between an instance of Information Content Entity x and an instance of Entity y."@en ;
+                cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000136" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001811
+cco:ont00001811 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001966 ;
+                owl:inverseOf cco:ont00001963 ;
+                rdfs:domain cco:ont00001010 ;
+                rdfs:range obo:BFO_0000001 ;
+                rdfs:label "is an ordinal measurement of"@en ;
+                skos:definition "x is_an_ordinal_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity and y is_measured_by_ordinal x."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001824
+cco:ont00001824 rdf:type owl:ObjectProperty ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range cco:ont00000253 ;
+                rdfs:label "is excerpted from"@en ;
+                skos:definition "An Information Bearing Entity b1 is excerpted from another Information Bearing Entity B2 iff b1 is part of some Information Bearing Entity B1 that is carrier of some Information Content Entity C1, B2 is carrier of some Information Content Entity C2, C1 is not identical with C2, b1 is carrier of some Information Content Entity c1, b2 is an Information Bearing Entity that is part of B2 and b2 is carrier of c1 (i.e. the same Information Content Entity as borne by b1)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001837
+cco:ont00001837 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf obo:BFO_0000084 ;
+                owl:inverseOf cco:ont00001908 ;
+                rdfs:domain cco:ont00000829 ;
+                rdfs:range cco:ont00000253 ;
+                rdfs:label "time zone identifier used by"@en ;
+                skos:definition "x time_zone_identifier_used_by y iff y is an instance of Information Bearing Entity and x is an instance of Time Zone Identifier, such that x designates the spatial region associated with the time zone mentioned in y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001863
+cco:ont00001863 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf obo:BFO_0000101 ;
+                owl:inverseOf cco:ont00001961 ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range cco:ont00000120 ;
+                rdfs:label "uses measurement unit"@en ;
+                skos:definition "y uses_measurement_unit x iff y is an instance of Information Bearing Entity and x is an instance of Measurement Unit, such that x describes the magnitude of measured physical quantity mentioned in y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001868
+cco:ont00001868 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001966 ;
+                owl:inverseOf cco:ont00001914 ;
+                rdfs:domain cco:ont00000293 ;
+                rdfs:range obo:BFO_0000001 ;
+                rdfs:label "is a nominal measurement of"@en ;
+                skos:definition "x is_a_nominal_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x classifies y relative to some set of shared, possibly arbitrary, characteristics."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001873
+cco:ont00001873 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001801 ;
+                owl:inverseOf cco:ont00001938 ;
+                rdfs:range cco:ont00001069 ;
+                rdfs:comment "See notes for inverse property." ;
+                rdfs:label "represented by"@en ;
+                skos:definition "y represented_by x iff x is an instance of Representational Information Content Entity, and y is an instance of Entity, and z is carrier of x, such that x is about y in virtue of there existing an isomorphism between characteristics of z and y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001877
+cco:ont00001877 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001966 ;
+                owl:inverseOf cco:ont00001964 ;
+                rdfs:domain cco:ont00001364 ;
+                rdfs:range obo:BFO_0000001 ;
+                rdfs:label "is an interval measurement of"@en ;
+                skos:definition "x is_an_interval_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity and y is_measured_by_interval x."@en ;
+                skos:example "a measurement of air temperature on the Celsius scale." ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001878
+cco:ont00001878 rdf:type owl:ObjectProperty ;
+                owl:inverseOf cco:ont00001919 ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range obo:BFO_0000001 ;
+                rdfs:label "is mention of"@en ;
+                skos:definition "x is_mention_of y iff x is an instance Information Bearing Entity and y is an instance of Entity, such that x is used as a reference to y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001879
+cco:ont00001879 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001801 ;
+                owl:inverseOf cco:ont00001916 ;
+                rdfs:domain obo:BFO_0000001 ;
+                rdfs:range cco:ont00000686 ;
+                rdfs:label "designated by"@en ;
+                skos:definition "x designated_by y iff y is an instance of Designative Information Content Entity and x is an instance of Entity and y designates x."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001884
+cco:ont00001884 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001801 ;
+                owl:inverseOf cco:ont00001980 ;
+                rdfs:domain obo:BFO_0000001 ;
+                rdfs:range cco:ont00000127 ;
+                owl:propertyChainAxiom ( cco:ont00001917
+                                         obo:BFO_0000176
+                                       ) ;
+                rdfs:label "condition described by"@en ;
+                skos:definition "x condition_described_by y iff y is an instance of Performance Specification and x is an instance of Entity and y describes_condition x."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001899
+cco:ont00001899 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001942 ;
+                owl:inverseOf cco:ont00001976 ;
+                rdfs:domain cco:ont00001175 ;
+                rdfs:range cco:ont00000253 ;
+                rdfs:label "language used in"@en ;
+                skos:definition "x language_used_by y iff y is an instance of Information Bearing Entity and x is an instance of Language, such that the literal value of y is a string that is encoded according to the syntax of x."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001900
+cco:ont00001900 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001997 ;
+                owl:inverseOf cco:ont00001913 ;
+                rdfs:domain cco:ont00000469 ;
+                rdfs:range cco:ont00000253 ;
+                rdfs:label "is geospatial coordinate reference system of"@en ;
+                skos:definition "x is_geospatial_coordinate_reference_system_of y iff y is an instance of Information Bearing Entity and x is an instance of Geospatial Coordinate Reference System, such that x describes the set of standards mentioned in y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001904
+cco:ont00001904 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001917 ;
+                owl:inverseOf cco:ont00001966 ;
+                rdfs:domain obo:BFO_0000001 ;
+                rdfs:range cco:ont00001163 ;
+                rdfs:label "is measured by"@en ;
+                skos:definition "y is_measured_by x iff x is an instance of Measurement Information Content Entity and y is an instance of Entity and y is_a_measurement_of x."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001908
+cco:ont00001908 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf obo:BFO_0000101 ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range cco:ont00000829 ;
+                rdfs:label "uses time zone identifier"@en ;
+                skos:definition "x uses_time_zone_identifier y iff x is an instance of Information Bearing Entity and y is an instance of Time Zone Identifier, such that y designates the spatial region associated with the time zone mentioned in x."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001912
+cco:ont00001912 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf obo:BFO_0000101 ;
+                owl:inverseOf cco:ont00001997 ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range cco:ont00000398 ;
+                rdfs:label "uses reference system"@en ;
+                skos:definition "y uses_reference_system x iff y is an instance of Information Bearing Entity and x is an instance of Reference System, such that x describes the set of standards mentioned in y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001913
+cco:ont00001913 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001912 ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range cco:ont00000469 ;
+                rdfs:label "uses geospatial coordinate reference system"@en ;
+                skos:definition "y uses_geospatial_coordinate_reference_system x iff y is an instance of Information Bearing Entity and x is an instance of Geospatial Coordinate Reference System, such that x describes the set of standards mentioned in y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001914
+cco:ont00001914 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001904 ;
+                rdfs:domain obo:BFO_0000001 ;
+                rdfs:range cco:ont00000293 ;
+                rdfs:label "is measured by nominal"@en ;
+                skos:definition "x is_measured_by_nominal y iff y is an instance of Nominal Measurement Information Content Entity and x is an instance of Entity, such that y classifies x relative to some set of shared, possibly arbitrary, characteristics."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001916
+cco:ont00001916 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001808 ;
+                rdfs:domain cco:ont00000686 ;
+                rdfs:range obo:BFO_0000001 ;
+                rdfs:label "designates"@en ;
+                skos:definition "x designates y iff x is an instance of a Designative Information Content Entity, and y is an instance of an Entity, such that given some context, x uniquely distinguishes y from other entities."@en ;
+                skos:example "a URL designates the location of a Web Page on the internet" ,
+                             "a person's name designates that person" ,
+                             "a vehicle identification number designates some vehicle" ;
+                skos:scopeNote "Given a stronger temporal interpretation, this property may be functional. For more info please refer to https://github.com/BFO-ontology/BFO-2020/tree/master/src/owl/temporal%20extensions."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001917
+cco:ont00001917 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001801 ;
+                owl:inverseOf cco:ont00001982 ;
+                rdfs:domain obo:BFO_0000001 ;
+                rdfs:range cco:ont00000853 ;
+                rdfs:label "described by"@en ;
+                skos:definition "x described_by y iff y is an instance of Descriptive Information Content Entity and x is an instance of Entity and y describes x."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001919
+cco:ont00001919 rdf:type owl:ObjectProperty ;
+                rdfs:domain obo:BFO_0000001 ;
+                rdfs:range cco:ont00000253 ;
+                rdfs:label "is mentioned by"@en ;
+                skos:definition "x is_mentioned_by y iff y is an instance of Information Bearing Entity and x is an instance of Entity, such that y is used as a reference to x."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001920
+cco:ont00001920 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001801 ;
+                owl:inverseOf cco:ont00001942 ;
+                rdfs:domain obo:BFO_0000001 ;
+                rdfs:range cco:ont00000965 ;
+                rdfs:label "prescribed by"@en ;
+                skos:definition "x prescribed_by y iff y is an instance of Directive Information Content Entity and x is an instance of Entity and y prescribes x."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001938
+cco:ont00001938 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001808 ;
+                rdfs:domain cco:ont00000958 ;
+                rdfs:range obo:BFO_0000001 ;
+                rdfs:comment "Isomorphism between the carrier of x and the represented entity can be via a direct similarity relation, e.g., grooves in a vinyl record corresponding to sound waves, or linguistic convention, e.g., a court stenographer's transcription of spoken words, as well as others, such as encoding processes for images."@en ;
+                rdfs:label "represents"@en ;
+                skos:definition "x represents y iff x is an instance of Information Content Entity, y is an instance of Entity, and z is carrier of x, such that x is about y in virtue of there existing an isomorphism between characteristics of z and y."@en ;
+                skos:scopeNote "Given a stronger temporal interpretation, this property may be functional. For more info please refer to https://github.com/BFO-ontology/BFO-2020/tree/master/src/owl/temporal%20extensions."@en ,
+                               "The relationship that is being defined here is that between the content of a photographic image and its object, between the content of a video and its objects and events, between the content of an audio recording and the sounds or events generating those sounds, or between the content of a written transcript and the verbal event that it transcribes."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001942
+cco:ont00001942 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001808 ;
+                rdfs:domain cco:ont00000965 ;
+                rdfs:range obo:BFO_0000001 ;
+                rdfs:label "prescribes"@en ;
+                skos:definition "x prescribes y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x serves as a rule or guide for y if y an Occurrent, or x serves as a model for y if y is a Continuant."@en ;
+                skos:example "A blueprint prescribes some artifact or facility by being a model for it." ,
+                             "A professional code of conduct prescribes some realizations of a profession (role) by giving rules for how the bearer should act in those realizations." ,
+                             "An operations plan prescribes an operation by enumerating the tasks that need to be performed in order to achieve the objectives of the operation." ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001961
+cco:ont00001961 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf obo:BFO_0000084 ;
+                rdfs:domain cco:ont00000120 ;
+                rdfs:range cco:ont00000253 ;
+                rdfs:label "is measurement unit of"@en ;
+                skos:definition "x is_measurement_unit_of y iff y is an instance of Information Bearing Entity and x is an instance of Measurement Unit, such that x describes the magnitude of measured physical quantity mentioned in y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001963
+cco:ont00001963 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001904 ;
+                rdfs:domain obo:BFO_0000001 ;
+                rdfs:range cco:ont00001010 ;
+                rdfs:label "is measured by ordinal"@en ;
+                skos:definition "x is_measured_by_ordinal y iff y is an instance of Ordinal Measurement Information Content Entity and x is an instance of Entity, such that y describes some attribute of x relative to a scale ordered by rank."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001964
+cco:ont00001964 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001904 ;
+                rdfs:domain obo:BFO_0000001 ;
+                rdfs:range cco:ont00001364 ;
+                rdfs:label "is measured by interval"@en ;
+                skos:definition "y is_measured_by_interval x iff x is an instance of Interval Measurement Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale which has uniform intervals but has a zero value that does not correspond to an absence of the attribute being measured."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001965
+cco:ont00001965 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001904 ;
+                owl:inverseOf cco:ont00001983 ;
+                rdfs:domain obo:BFO_0000001 ;
+                rdfs:range cco:ont00001022 ;
+                rdfs:label "is measured by ratio"@en ;
+                skos:definition "y is_measured_by_ratio x iff x is an instance of Ratio Measurement Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale having equal unit values and a zero value that corresponds to the absence of the attribute being measured."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001966
+cco:ont00001966 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001982 ;
+                rdfs:domain cco:ont00001163 ;
+                rdfs:range obo:BFO_0000001 ;
+                rdfs:comment "This object property, as well as all of its children are typified as functional properties. This means that for instances x, y, and z if x is a measurement of y and x is a measurement of z, then y = z."@en ;
+                rdfs:label "is a measurement of"@en ;
+                skos:definition "x is_a_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to some scale or classification scheme."@en ;
+                skos:scopeNote "Given a stronger temporal interpretation, this property may be functional. For more info please refer to https://github.com/BFO-ontology/BFO-2020/tree/master/src/owl/temporal%20extensions."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001976
+cco:ont00001976 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001920 ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range cco:ont00001175 ;
+                rdfs:label "uses language"@en ;
+                skos:definition "x uses_language y iff x is an instance of an Information Bearing Entity and y is an instance of a Language such that the literal value of x is a string that is encoded according to the syntax of y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001980
+cco:ont00001980 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001808 ;
+                rdfs:domain cco:ont00000127 ;
+                rdfs:range obo:BFO_0000001 ;
+                owl:propertyChainAxiom ( obo:BFO_0000178
+                                         cco:ont00001982
+                                       ) ;
+                rdfs:label "describes condition"@en ;
+                skos:definition "p describes_condition c iff p is an instance of a Performance Specification and c is an instance of Entity and p has part d, and d is an instance of a Descriptive Information Content Entity, and p prescribes an entity s, and d describes c, and c is an entity that is causally relevant to s existing as prescribed by p."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001982
+cco:ont00001982 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001808 ;
+                rdfs:domain cco:ont00000853 ;
+                rdfs:range obo:BFO_0000001 ;
+                rdfs:comment "It is possible that this relation should be a functional property, that is for all x, y, z if x describes y and x describes z then y = z. For example, if a financial report x describes the quarterly results of a company y and that same financial report describes the quarterly results of a company z, then it should be inferred that companies y and z are the same. We refrained from classifying the relation as a functional property on the concern that descriptions are multifaceted and so consequently it may be that the same report would contain descriptions of multiple entities."@en ;
+                rdfs:label "describes"@en ;
+                skos:definition "x describes y iff x is an instance of Descriptive Information Content Entity, and y is an instance of Entity, such that x is_about the characteristics that identify y."@en ;
+                skos:example "the content of a newspaper article describes some current event" ,
+                             "the content of a visitor's log describes some facility visit" ,
+                             "the content of an accident report describes some accident" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001983
+cco:ont00001983 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf cco:ont00001966 ;
+                rdfs:domain cco:ont00001022 ;
+                rdfs:range obo:BFO_0000001 ;
+                rdfs:label "is a ratio measurement of"@en ;
+                skos:definition "x is_a_ratio_measurement_of y iff x is an instance of Ratio Measurement Information Content Entity and y is an instance of Entity and x describes some attribute of y relative to a scale having equal unit values and a zero value that corresponds to the absence of the attribute being measured."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001997
+cco:ont00001997 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf obo:BFO_0000084 ;
+                rdfs:domain cco:ont00000398 ;
+                rdfs:range cco:ont00000253 ;
+                rdfs:label "is reference system of"@en ;
+                skos:definition "x is_reference_system_of y iff y is an instance of Information Bearing Entity and x is an instance of Reference System, such that x describes the set of standards mentioned in y."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+#################################################################
+#    Data properties
+#################################################################
+
+###  https://www.commoncoreontologies.org/ont00001765
+cco:ont00001765 rdf:type owl:DatatypeProperty ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:label "has text value"@en ;
+                skos:definition "A data property that has as its range a string value."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001767
+cco:ont00001767 rdf:type owl:DatatypeProperty ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range xsd:dateTime ;
+                rdfs:label "has datetime value"@en ;
+                skos:definition "A data property that has as its value a datetime value."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001768
+cco:ont00001768 rdf:type owl:DatatypeProperty ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range xsd:anyURI ;
+                rdfs:label "has URI value"@en ;
+                skos:definition "A data property that has as its range a URI value."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001769
+cco:ont00001769 rdf:type owl:DatatypeProperty ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range xsd:decimal ;
+                rdfs:label "has decimal value"@en ;
+                skos:definition "A data property that has as its range a decimal value."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001770
+cco:ont00001770 rdf:type owl:DatatypeProperty ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range xsd:double ;
+                rdfs:label "has double value"@en ;
+                skos:definition "A data property that has as its range a double value."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001771
+cco:ont00001771 rdf:type owl:DatatypeProperty ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:label "has date value"@en ;
+                skos:definition "A data property that has as its range a date value."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001772
+cco:ont00001772 rdf:type owl:DatatypeProperty ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range xsd:boolean ;
+                rdfs:label "has boolean value"@en ;
+                skos:definition "A data property that has as its range a boolean value."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001773
+cco:ont00001773 rdf:type owl:DatatypeProperty ;
+                rdfs:domain cco:ont00000253 ;
+                rdfs:range xsd:integer ;
+                rdfs:label "has integer value"@en ;
+                skos:definition "A data property that has as its range an integer value."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  https://www.commoncoreontologies.org/ont00000003
+cco:ont00000003 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000686 ;
+                owl:disjointWith cco:ont00000649 ;
+                rdfs:label "Designative Name"@en ;
+                skos:altLabel "Name"@en ;
+                skos:definition "A Designative Information Content Entity that consists of a string of characters that designates an entity within a specified cultural or social namespace and which is typically a word or phrase in a natural language that has an accepted cultural or social significance."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000029
+cco:ont00000029 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000745 ;
+                rdfs:label "Median Point Estimate Information Content Entity"@en ;
+                skos:altLabel "Median"@en ;
+                skos:definition "A Point Estimate Information Content Entity that is a measurement of a set of values and is equal to either the middle value or the average of the two values which separate the set into two equally populated upper and lower sets."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000067
+cco:ont00000067 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001328 ;
+                rdfs:comment "In traditional astronomical usage, civil time is mean solar time as calculated from midnight as the beginning of the Civil Day."@en ,
+                             "Note that Civil Time Reference System is more accurately represented as a Temporal Reference System that participates in an act of usage that is sanctioned by an appropriate civil authority. As such, it should be represented as a defined class."@en ;
+                rdfs:label "Civil Time Reference System"@en ;
+                skos:definition "A Temporal Reference System that is a statutory time scale as designated by civilian authorities to determine local time(s)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000073
+cco:ont00000073 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000399
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001916 ;
+                                                             owl:someValuesFrom obo:BFO_0000038
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000399 ;
+                rdfs:label "Temporal Interval Identifier"@en ;
+                skos:altLabel "One-Dimensional Temporal Region Identifier"@en ;
+                skos:definition "A Temporal Region Identifier that designates some Temporal Interval."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000077
+cco:ont00000077 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000649 ;
+                owl:disjointWith cco:ont00000923 ;
+                rdfs:label "Code Identifier"@en ;
+                skos:altLabel "Code ID"@en ,
+                              "ID Code"@en ,
+                              "Identifier Code"@en ;
+                skos:definition "A Non-Name Identifier that consists of a string of characters that was created and assigned according to an encoding system such that metadata can be derived from the identifier."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000080
+cco:ont00000080 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000827 ;
+                rdfs:label "Standard Time of Day Identifier"@en ;
+                skos:definition "A Time of Day Identifier that designates an approximate Temporal Instant that is part of some Day and is specified using the Hours, Minutes, and Seconds of the Day that preceded the Temporal Instant."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000087
+cco:ont00000087 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000894 ;
+                rdfs:comment "An Ordinal Date Identifier may or may not also contain a number indicating a specific Year. If both numbers are included, the ISO 8601 ordinal date format stipulates that the two numbers be formatted as YYYY-DDD or YYYYDDD where [YYYY] indicates a year and [DDD] is the day of that year, from 001 through 365 (or 366 in leap years)."@en ;
+                rdfs:label "Ordinal Date Identifier"@en ;
+                skos:altLabel "Ordinal Date"@en ;
+                skos:definition "A Decimal Date Identifier that designates some Day by using a number to indicate the sequential ordering of the Day since the beginning of the Year."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ordinal_date&oldid=1061989434"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000120
+cco:ont00000120 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000853 ;
+                rdfs:label "Measurement Unit"@en ;
+                skos:definition "A Descriptive Information Content Entity that describes a definite magnitude of a physical quantity, defined and adopted by convention and/or by law, that is used as a standard for measurement of the same physical quantity."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Unit_of_measurement&oldid=1061038125"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000124
+cco:ont00000124 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001328 ;
+                rdfs:label "Solar Time Reference System"@en ;
+                skos:definition "A Temporal Reference System that is based on the position of the Sun in the sky."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000127
+cco:ont00000127 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000965 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty cco:ont00001980 ;
+                                  owl:someValuesFrom obo:BFO_0000001
+                                ] ;
+                rdfs:label "Performance Specification"@en ;
+                skos:definition "A Directive Information Content Entity that prescribes some aspect of the behavior of a participant in a Process given one or more operating conditions."@en ;
+                skos:example "Maximum Speed at high altitude; Rate of Ascent at 10 degrees celsius with nominal payload." ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000146
+cco:ont00000146 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001175 ;
+                owl:disjointWith cco:ont00000496 ;
+                rdfs:label "Artificial Language"@en ;
+                skos:definition "A Language that is developed through conscious planning and premeditation, rather than one that was developed through use and repetition."@en ;
+                skos:example "Esperanto" ,
+                             "Python Programming Language" ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Constructed_language&oldid=1062733589"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000154
+cco:ont00000154 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000745 ;
+                rdfs:comment "While there is always at least one Mode for every set of data, it is possible for any given set of data to have multiple Modes. The Mode is typically most useful when the members of the set are all Nominal Measurement Information Content Entities."@en ;
+                rdfs:label "Mode Point Estimate Information Content Entity"@en ;
+                skos:altLabel "Mode"@en ,
+                              "Statistical Mode"@en ;
+                skos:definition "A Point Estimate Information Content Entity that is a measurement of a set of values and is equal to the value or values that occur most often in the set."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000164
+cco:ont00000164 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001010 ;
+                rdfs:label "Minimum Ordinal Measurement Information Content Entity"@en ;
+                skos:definition "An Ordinal Measurement Information Content Entity that is a measurement of some entity in virtue of it being the smallest or having the least amount relative to a nominally described set of like entities."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000186
+cco:ont00000186 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001010 ;
+                rdfs:label "Artifact Version Ordinality"@en ;
+                skos:definition "An Ordinal Measurement Information Content Entity that is about the form of an Artifact which differs in some respects from previous or future forms of that Artifact."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000203
+cco:ont00000203 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000293 ;
+                rdfs:label "Event Status Nominal Information Content Entity"@en ;
+                skos:definition "A Nominal Measurement Information Content Entity that is a measurement of the current state of a process."@en ;
+                skos:example "proposed, approved, planned, in progress, completed, failed, or successful" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000223
+cco:ont00000223 rdf:type owl:Class .
+
+
+###  https://www.commoncoreontologies.org/ont00000253
+cco:ont00000253 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000030
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:BFO_0000101 ;
+                                                             owl:someValuesFrom cco:ont00000958
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:BFO_0000030 ;
+                rdfs:comment "This class continues to use the word ‘bearing’ in its rdfslabel because of potential confusion with the acronym ‘ICE’, which is widely used for information content entity."@en ;
+                rdfs:label "Information Bearing Entity"@en ;
+                skos:altLabel "IBE"@en ,
+                              "Information Carrying Entity"@en ;
+                skos:definition "An Object upon which an Information Content Entity generically depends."@en ;
+                cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000178"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000263
+cco:ont00000263 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001328 ;
+                rdfs:comment "A single Clock Time System does not provide a complete means for identifying or measuring times. Depending on the particular Clock Time System, it may be compatible for use with one or more other Temporal Reference Systems."@en ;
+                rdfs:label "Clock Time System"@en ;
+                skos:definition "A Temporal Reference System that is a convention for keeping and displaying the Time of Day."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000275
+cco:ont00000275 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000398 ;
+                rdfs:comment "Note that, while reference systems and reference frames are treated as synonyms here, some people treat them as related but separate entities. See: http://www.ggos-portal.org/lang_en/GGOS-Portal/EN/Topics/GeodeticApplications/GeodeticReferenceSystemsAndFrames/GeodeticReferenceSystemsAndFrames.html"@en ;
+                rdfs:label "Spatial Reference System"@en ;
+                skos:altLabel "Coordinate System"@en ,
+                              "Spatial Coordinate System"@en ,
+                              "Spatial Reference Frame"@en ;
+                skos:definition "A Reference System that describes a set of standards for uniquely identifying the position of an entity or the direction of a vector within a defined spatial region by means of measurements along one or more Coordinate System Axes."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Coordinate_system&oldid=1060461397"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000276
+cco:ont00000276 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000891 ;
+                rdfs:label "Solar Calendar System"@en ;
+                skos:definition "A Calendar System that is designed to organize and identify dates based on the cycles of an Astronomical Body's Orbit around the Sun."@en ;
+                skos:scopeNote "Unless otherwise specified, a Solar Calendar System is assumed to be relative to the Orbit of the Earth around the Sun."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Solar_calendar&oldid=1058016588"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000293
+cco:ont00000293 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00001163
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001868 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00001163 ;
+                owl:disjointWith cco:ont00001010 ,
+                                 cco:ont00001022 ,
+                                 cco:ont00001364 ;
+                rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en ;
+                rdfs:label "Nominal Measurement Information Content Entity"@en ;
+                skos:definition "A Measurement Information Content Entity that consists of a symbol that classifies Entities according to some shared, possibly arbitrary, characteristic."@en ;
+                skos:example "The sentence \"January 20, 1985 was a cold day in Chicago, IL\" is the carrier of a nominal measurement."@en ,
+                             "a measurement that classifies automobiles as sedans, coupes, hatchbacks, or convertibles" ,
+                             "a measurement that classifies military intelligence as strategic, operational, or tactical" ,
+                             "a measurement that classifies rocks as igneous, sedimentary, or metamorphic" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000314
+cco:ont00000314 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000019 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000197 ;
+                                  owl:someValuesFrom cco:ont00000253
+                                ] ;
+                rdfs:comment "Typically, an IQE will be a complex pattern made up of multiple qualities joined together spatially."@en ;
+                rdfs:label "Information Quality Entity"@en ;
+                skos:altLabel "IQE"@en ;
+                skos:definition "A Quality that concretizes some Information Content Entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000326
+cco:ont00000326 rdf:type owl:Class .
+
+
+###  https://www.commoncoreontologies.org/ont00000359
+cco:ont00000359 rdf:type owl:Class .
+
+
+###  https://www.commoncoreontologies.org/ont00000369
+cco:ont00000369 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001010 ;
+                rdfs:label "Priority Measurement Information Content Entity"@en ;
+                skos:altLabel "Criticality Measurement"@en ,
+                              "Importance Measurement"@en ,
+                              "Priority Measurement"@en ;
+                skos:definition "An Ordinal Measurement Information Content Entity that is a measurement of the relative importance of an entity."@en ;
+                skos:example "low, normal, high, urgent, or immediate priority" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000390
+cco:ont00000390 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000686
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001916 ;
+                                                             owl:someValuesFrom obo:BFO_0000006
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000686 ;
+                rdfs:label "Spatial Region Identifier"@en ;
+                skos:definition "A Designative Information Content Entity that designates some Spatial Region."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000398
+cco:ont00000398 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000853 ;
+                rdfs:label "Reference System"@en ;
+                skos:definition "A Descriptive Information Content Entity that describes a set of standards for organizing and understanding data of the specified type or domain."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000399
+cco:ont00000399 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000686
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001916 ;
+                                                             owl:someValuesFrom obo:BFO_0000008
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000686 ;
+                rdfs:label "Temporal Region Identifier"@en ;
+                skos:definition "A Designative Information Content Entity that designates some Temporal Region."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000406
+cco:ont00000406 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000120 ;
+                rdfs:label "Measurement Unit of Geocoordinate"@en ;
+                skos:definition "A Measurement Unit specifying the geospatial coordinates of a location."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000419
+cco:ont00000419 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000077 ;
+                rdfs:label "Part Number"@en ;
+                skos:definition "A Code Identifier that designates a type of part whose instances are designed to be part of some Artifact."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000469
+cco:ont00000469 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000275 ;
+                rdfs:label "Geospatial Coordinate Reference System"@en ;
+                skos:altLabel "Geographic Coordinate System"@en ;
+                skos:definition "A Spatial Reference System that is used to determine and identify the location of a point or object at or near the surface of the Earth."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000496
+cco:ont00000496 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001175 ;
+                rdfs:label "Natural Language"@en ;
+                skos:definition "A Language that is developed and evolves through use and repetition, rather than through conscious planning or premeditation."@en ;
+                skos:example "English" ,
+                             "Mandarin (Chinese)" ,
+                             "Spanish" ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Natural_language&oldid=1060890461"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000498
+cco:ont00000498 rdf:type owl:Class .
+
+
+###  https://www.commoncoreontologies.org/ont00000529
+cco:ont00000529 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000073
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001916 ;
+                                                             owl:someValuesFrom cco:ont00000800
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000073 ;
+                rdfs:label "Date Identifier"@en ;
+                skos:altLabel "Day Identifier"@en ;
+                skos:definition "A Temporal Interval Identifier that designates some Day."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000539
+cco:ont00000539 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001022 ;
+                rdfs:label "Count Measurement Information Content Entity"@en ;
+                skos:definition "A Ratio Measurement Information Content Entity that is a measurement of the number of members of some aggregate."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000540
+cco:ont00000540 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000399
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001916 ;
+                                                             owl:someValuesFrom obo:BFO_0000203
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000399 ;
+                rdfs:label "Temporal Instant Identifier"@en ;
+                skos:altLabel "Zero-Dimensional Temporal Region Identifier"@en ;
+                skos:definition "A Temporal Region Identifier that designates some Temporal Instant."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000589
+cco:ont00000589 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000973 ;
+                rdfs:label "Julian Date Fraction"@en ;
+                skos:altLabel "Julian Date Time Identifier"@en ,
+                              "Julian Day Fraction"@en ;
+                skos:definition "A Decimal Time of Day Identifier that designates an approximate Temporal Instant that is part of some Julian Day."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000592
+cco:ont00000592 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001163 ;
+                rdfs:comment "'Deviation Measurement Information Content Entity' and 'Veracity Measurement Information Content Entity' are complementary notions. Deviation is a measure of whether reality conforms to an ICE (e.g., a plan or prediction), whereas Veracity is a measure of whether a Descriptive ICE conforms to reality."@en ,
+                             "Note, the term 'accuracy' is avoided due to its ambiguity between: correctness-of-performance (see: 'Reliability Measurement Information Content Entity'), correctness-of-information ('Veracity Measurement Information Content Entity'), and adherance-to-expectations (see: 'Deviation Measurement Information Content Entity')."@en ;
+                rdfs:label "Veracity Measurement Information Content Entity"@en ;
+                skos:altLabel "Accuracy of Information"@en ,
+                              "Trueness Measurement"@en ,
+                              "Veracity Measurement"@en ;
+                skos:definition "A Measurement Information Content Entity that is a measurement of the extent to which a description conforms to the reality it describes."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000604
+cco:ont00000604 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001010 ;
+                rdfs:label "Maximum Ordinal Measurement Information Content Entity"@en ;
+                skos:definition "An Ordinal Measurement Information Content Entity that is a measurement of some entity in virtue of it being the largest or having the greatest amount relative to a nominally described set of like entities."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000605
+cco:ont00000605 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000003 ;
+                rdfs:label "Abbreviated Name"@en ;
+                skos:definition "A Designative Name that is a shortened form of a Proper Name."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000626
+cco:ont00000626 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000853 ;
+                rdfs:comment "Since predictions are inherently about not-yet-existant things, the Modal Relation Ontology term 'describes' (i.e. mro:describes) should be used (instead of the standard cco:describes) to relate instances of Predictive Information Content Entity to the entities they are about."@en ;
+                rdfs:label "Predictive Information Content Entity"@en ;
+                skos:altLabel "Prediction"@en ,
+                              "Prediction Information Content Entity"@en ;
+                skos:definition "A Descriptive Information Content Entity that describes an uncertain future event."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000630
+cco:ont00000630 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000124 ;
+                rdfs:label "Universal Time Reference System"@en ;
+                skos:definition "A Solar Time Reference System that is based on the average speed of the Earth's rotation and which uses the prime meridian at 0° longitude as a reference point."@en ;
+                cco:ont00001753 "UT" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000649
+cco:ont00000649 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000686 ;
+                rdfs:label "Non-Name Identifier"@en ;
+                skos:altLabel "ID"@en ,
+                              "Identifier"@en ;
+                skos:definition "A Designative Information Content Entity that consists of a string of characters that designates an entity within a specified namespace or context, is not a Designative Name, may be automatically or randomly generated, and typically has no preexisting cultural or social significance."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000653
+cco:ont00000653 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000965 ;
+                rdfs:label "Algorithm"@en ;
+                skos:definition "A Directive Information Content Entity that prescribes some Process and contains a finite sequence of unambiguous instructions in order to achieve some Objective."@en ;
+                cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000064"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000669
+cco:ont00000669 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001022 ;
+                rdfs:label "Distance Measurement Information Content Entity"@en ;
+                skos:definition "A Ratio Measurement Information Content Entity that is a measurement of a One-Dimensional Extent inhering in some Site that is externally connected to two Independent Continuants."@en ;
+                skos:scopeNote "Displacement (vector) is the shortest possible distance (scalar) between two points. Further thought is needed to adequately handle measurements of distance traveled along a path, e.g., a circuitous path or an arc (such as the surface of a planet), versus the simple case of a direct, straight line between two points."@en ,
+                               "Distance is a measure between two reference points, which are located on or in, or in some manner part of, the two obejcts for which the length of the extent between is sought. For exmple, the center point of the indentation of a ball in the sand and the edge of the foul line, the forwardmost point on a car's bumper and the closest point on the 2-dimensional plane that serves as the fiat boundary of a crosswalk, the center of an antenna array and closest point on ground."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000683
+cco:ont00000683 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000605 ;
+                rdfs:label "Diminutive Name"@en ;
+                skos:definition "An Abbreviated Name that is a familiar form of a Proper Name."@en ;
+                skos:example "Alex, Bob, Cathy" ;
+                skos:scopeNote "\"Familiar form of a Proper Name\" means: that the name is (originally) a short, affectionate version of the fuller name, used (originally) by family or friends."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000686
+cco:ont00000686 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000958
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001916 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000958 ;
+                owl:disjointWith cco:ont00000853 ,
+                                 cco:ont00000965 ;
+                rdfs:label "Designative Information Content Entity"@en ;
+                skos:altLabel "Designative ICE"@en ;
+                skos:definition "An Information Content Entity that consists of a set of symbols that designate some Entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000692
+cco:ont00000692 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001163 ;
+                rdfs:comment "Every probability measurement is made within a particular context given certain background assumptions."@en ;
+                rdfs:label "Probability Measurement Information Content Entity"@en ;
+                skos:altLabel "Likelihood Measurement"@en ,
+                              "Probability Measurement"@en ;
+                skos:definition "A Measurement Information Content Entity that is a measurement of the likelihood that a Process or Process Aggregate occurs."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Probability&oldid=1059657543"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000702
+cco:ont00000702 rdf:type owl:Class .
+
+
+###  https://www.commoncoreontologies.org/ont00000729
+cco:ont00000729 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000275 ;
+                rdfs:label "Spherical Coordinate System"@en ;
+                skos:definition "A Spatial Reference System for three-dimensional spatial regions that identifies each point using an ordered triple of numerical coordinates that consist of the radial distance of the point of interest from a fixed origin, its polar angle measured from a fixed zenith direction, and the azimuth angle of its orthogonal projection measured from a fixed direction on a reference plane that passes through the origin and is orthogonal to the zenith."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Spherical_coordinate_system&oldid=1061029174"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000731
+cco:ont00000731 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001163 ;
+                rdfs:comment "'Deviation Measurement Information Content Entity' and 'Veracity Measurement Information Content Entity' are complementary notions. Deviation is a measure of whether reality conforms to an ICE (e.g., a plan or prediction), whereas Veracity is a measure of whether a Descriptive ICE conforms to reality."@en ,
+                             "Note, the term 'accuracy' is avoided due to its ambiguity between: correctness-of-performance (see: 'Reliability Measurement Information Content Entity'), correctness-of-information (see: 'Veracity Measurement Information Content Entity'), and adherance-to-expectations ('Deviation Measurement Information Content Entity')."@en ;
+                rdfs:label "Deviation Measurement Information Content Entity"@en ;
+                skos:altLabel "Conformance Measurement"@en ,
+                              "Degree of Conformance"@en ,
+                              "Degree of Deviation"@en ,
+                              "Deviation Measurement"@en ;
+                skos:definition "A Measurement Information Content Entity that is a measurement of the extent to which an entity conforms to how it is expected or supposed to be."@en ;
+                skos:example "a missile impact deviates from its target location by 100 feet" ,
+                             "a satellite deviaties from its predicted orbital path by 5 kilometers" ,
+                             "an overweight piece of luggage deviates from an airline's maximum allowed weight by +10 pounds" ;
+                skos:scopeNote "In order for a Deviation to exist, an entity must first be expected, represented, prescribed, or predicted as being a certain way. Then, at a future time, this value can be compared to its actual, reported, or measured value to determine the Deviation between these values."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000735
+cco:ont00000735 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000406 ;
+                rdfs:label "Geospatial Region Bounding Box Identifier List"@en ;
+                skos:definition "A Measurement Unit of Geocoordinate that is comprised of 4 pairs of coordinates, one for each of the 4 defining points (North, West, South, East) of a Geospatial Region Bounding Box."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000745
+cco:ont00000745 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001176 ;
+                rdfs:label "Point Estimate Information Content Entity"@en ;
+                skos:altLabel "Best Estimate"@en ,
+                              "Point Estimate"@en ,
+                              "Point Estimate Measurement Information Content Entity"@en ;
+                skos:definition "An Estimate Information Content Entity that consists of a single value for the measured entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000749
+cco:ont00000749 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000894 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty cco:ont00001916 ;
+                                  owl:someValuesFrom cco:ont00000498
+                                ] ;
+                rdfs:label "Julian Day Number"@en ;
+                skos:definition "A Decimal Date Identifier that designates some Julian Day by using a number to indicate the sequential ordering of the Day since the Julian Date epoch."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000798
+cco:ont00000798 rdf:type owl:Class .
+
+
+###  https://www.commoncoreontologies.org/ont00000800
+cco:ont00000800 rdf:type owl:Class .
+
+
+###  https://www.commoncoreontologies.org/ont00000827
+cco:ont00000827 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000540
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001916 ;
+                                                             owl:someValuesFrom cco:ont00000223
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000540 ;
+                rdfs:label "Time of Day Identifier"@en ;
+                skos:definition "A Temporal Instant Identifier that designates some Time of Day."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000829
+cco:ont00000829 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000390 ;
+                rdfs:comment """Standards of date, time, and time zone data formats:
 ISO/WD 8601-2 (http://www.loc.gov/standards/datetime/iso-tc154-wg5_n0039_iso_wd_8601-2_2016-02-16.pdf)
-W3C (https://www.w3.org/TR/NOTE-datetime)"""@en,
-    "There is no class 'Time Zone' (the region), only 'Time Zone Identifier' (the designator for some region). Instances of 'Time Zone Identifier' should be related to instances of 'Information Bearing Entity' by means of the object properites 'uses time zone identifier' and 'time zone identifier used by' as appropriate. This is supposed to be analogous to the way we represent the relationship between measurement values and measurement units, where the relevant instance of Information Bearing Entity 'uses measurement unit' some instance of Measurement Unit (i.e., an instance of Information Content Entity)."@en;
-  rdfs:label "Time Zone Identifier"@en;
-  skos:definition "A Spatial Region Identifier that designates the region associated with some uniform standard time for legal, commercial, or social purposes."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000833 a owl:Class;
-  rdfs:subClassOf cco:ont00000973, _:genid44, _:genid45, _:genid46;
-  rdfs:label "Julian Date Identifier"@en;
-  skos:definition "A Decimal Time of Day Identifier that designates a Julian Date and is composed of both a Julian Day Number and a Julian Date Fraction."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid44 a owl:Restriction;
-  owl:someValuesFrom cco:ont00000589;
-  owl:onProperty obo:BFO_0000178 .
-
-_:genid45 a owl:Restriction;
-  owl:someValuesFrom cco:ont00000749;
-  owl:onProperty obo:BFO_0000178 .
-
-_:genid46 a owl:Restriction;
-  owl:someValuesFrom cco:ont00000359;
-  owl:onProperty cco:ont00001916 .
-
-cco:ont00000845 a owl:Class;
-  rdfs:subClassOf cco:ont00001022;
-  rdfs:comment "A percentage is one way to express a proportional measure where the decimal expression of the proportion is multiplied by 100, thus giving the proportional value with respect to a whole of 100. E.g., the ratio of pigs to cows on a farm is 44 to 79 (44:79 or 44/79). The proportion of pigs to total animals is 44 to 123 or 44/123. The percentage of pigs is the decimal equivalent of the proportion (0.36) multiplied by a 100 (36%). The percentage can be expressed as a proportion where the numerator value is transformed for a denominator of 100, i.e., 36 of a 100 animals are pigs (36/100)."@en,
-    "We may want to add either a subclass for Percentage or a data property (has percentage value) that links the percentage expression for a proportion to the relevant IBE."@en;
-  rdfs:label "Proportional Ratio Measurement Information Content Entity"@en;
-  skos:definition "A Ratio Measurement Information Content Entity that is a measurement of a portion of a whole (described by the numerator) compared against that whole (described by the denominator) where the whole is a nominally described set of like entities."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000853 a owl:Class;
-  owl:equivalentClass _:genid47;
-  rdfs:subClassOf cco:ont00000958;
-  owl:disjointWith cco:ont00000965;
-  rdfs:label "Descriptive Information Content Entity"@en;
-  skos:altLabel "Descriptive ICE"@en;
-  skos:definition "An Information Content Entity that consists of a set of propositions that describe some Entity."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid47 a owl:Class;
-  owl:intersectionOf _:genid50 .
-
-_:genid50 a rdf:List;
-  rdf:first cco:ont00000958;
-  rdf:rest _:genid48 .
-
-_:genid48 a rdf:List;
-  rdf:first _:genid49;
-  rdf:rest rdf:nil .
-
-_:genid49 a owl:Restriction;
-  owl:someValuesFrom obo:BFO_0000001;
-  owl:onProperty cco:ont00001982 .
-
-cco:ont00000891 a owl:Class;
-  rdfs:subClassOf cco:ont00001328;
-  rdfs:label "Calendar System"@en;
-  skos:definition "A Temporal Reference System that is designed to organize and identify dates."@en;
-  skos:scopeNote "Calendars typically organize dates through the use of naming and temporal conventions based on Days, Weeks, Months, and Years."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000894 a owl:Class;
-  rdfs:subClassOf cco:ont00000529;
-  rdfs:label "Decimal Date Identifier"@en;
-  skos:definition "A Date Identifier that designates some Day by using a number to indicate the sequential ordering of the Day since a specified Reference Time."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000896 a owl:Class;
-  rdfs:subClassOf cco:ont00000745;
-  rdfs:label "Mean Point Estimate Information Content Entity"@en;
-  skos:altLabel "Arithmetic Mean"@en, "Average"@en, "Mean"@en;
-  skos:definition "A Point Estimate Information Content Entity that is a measurement of a set of values and is equal to the sum of all the values in the set divided by the total number of values in the set."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000915 a owl:Class;
-  rdfs:subClassOf cco:ont00000605;
-  rdfs:label "Acronym"@en;
-  skos:definition "An Abbreviated Name that combines the initial letters of a Designative Name and which is pronounced as a word."@en;
-  skos:example "Wi-Fi, ASCII, OPSEC";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000916 a owl:Class;
-  rdfs:subClassOf cco:ont00000891;
-  rdfs:label "Lunar Calendar System"@en;
-  skos:definition "A Calendar System that is designed to organize and identify dates based on the cycles of the Moon's phases."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Lunar_calendar&oldid=1055396837"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000923 a owl:Class;
-  rdfs:subClassOf cco:ont00000649;
-  rdfs:label "Arbitrary Identifier"@en;
-  skos:altLabel "Arbitrary ID"@en;
-  skos:definition "A Non-Name Identifier that consists of a string of characters that does not follow an encoding system."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000958 a owl:Class;
-  owl:equivalentClass _:genid51;
-  rdfs:subClassOf obo:BFO_0000031;
-  rdfs:label "Information Content Entity"@en;
-  skos:altLabel "ICE"@en;
-  skos:definition "A Generically Dependent Continuant that generically depends on some Information Bearing Entity and stands in relation of aboutness to some Entity."@en;
-  skos:scopeNote "Information Content Entity is here intended to be a class of Entities whose instances are the informational content of Information Bearing Entities. For example, three instances of information bearers -- such as a bar chart, color-coded map, and a written report -- each of which lists the GDP of Countries for the year 2010 are each different carriers of the same information content. It is this content that is generically dependent upon its carrier. This treatment of Informational Content Entity (cf. the Information Artifact Ontology) leads to a principle of subtyping based upon the relationship that ICE's have with the Entity they are about rather than characteristics such as format, language, measurement scale, or media. The latter are treated here as being Qualities of bearers."@en;
-  cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000030";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid51 a owl:Class;
-  owl:intersectionOf _:genid54 .
-
-_:genid54 a rdf:List;
-  rdf:first obo:BFO_0000031;
-  rdf:rest _:genid52 .
-
-_:genid52 a rdf:List;
-  rdf:first _:genid53;
-  rdf:rest rdf:nil .
-
-_:genid53 a owl:Restriction;
-  owl:someValuesFrom obo:BFO_0000001;
-  owl:onProperty cco:ont00001808 .
-
-cco:ont00000965 a owl:Class;
-  owl:equivalentClass _:genid55;
-  rdfs:subClassOf cco:ont00000958;
-  rdfs:label "Prescriptive Information Content Entity"@en;
-  skos:altLabel "Directive ICE"@en;
-  skos:definition "An Information Content Entity that consists of a set of propositions or images (as in the case of a blueprint) that prescribe some Entity."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid55 a owl:Class;
-  owl:intersectionOf _:genid58 .
-
-_:genid58 a rdf:List;
-  rdf:first cco:ont00000958;
-  rdf:rest _:genid56 .
-
-_:genid56 a rdf:List;
-  rdf:first _:genid57;
-  rdf:rest rdf:nil .
-
-_:genid57 a owl:Restriction;
-  owl:someValuesFrom obo:BFO_0000001;
-  owl:onProperty cco:ont00001942 .
-
-cco:ont00000973 a owl:Class;
-  rdfs:subClassOf cco:ont00000827;
-  rdfs:label "Decimal Time of Day Identifier"@en;
-  skos:altLabel "Fractional Time of Day Identifier"@en;
-  skos:definition "A Time of Day Identifier that designates an approximate Temporal Instant that is part of some Day and is specified using a decimal value for the portion of the Day that preceded the Temporal Instant."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00000990 a owl:Class;
-  rdfs:subClassOf cco:ont00000003;
-  rdfs:label "Nickname"@en;
-  skos:definition "A Designative Name that is a familiar or humorous substitute for an entity's Proper Name."@en;
-  skos:example "Ike, Chief, P-Fox";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001010 a owl:Class;
-  owl:equivalentClass _:genid59;
-  rdfs:subClassOf cco:ont00001163;
-  owl:disjointWith cco:ont00001022, cco:ont00001364;
-  rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en;
-  rdfs:label "Ordinal Measurement Information Content Entity"@en;
-  skos:definition "A Measurement Information Content Entity that consists of a symbol that places an Entity into some rank order."@en;
-  skos:example "The sentence \"The coldest day in history in Chicago, IL. is January 20, 1985.\" is the carrier of an ordinal measurment."@en,
-    "a measurement that places Geospatial Regions into a rank order of small, medium, large",
-    "a measurement that places military units onto a readiness rank order of red, yellow, green";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid59 a owl:Class;
-  owl:intersectionOf _:genid62 .
-
-_:genid62 a rdf:List;
-  rdf:first cco:ont00001163;
-  rdf:rest _:genid60 .
-
-_:genid60 a rdf:List;
-  rdf:first _:genid61;
-  rdf:rest rdf:nil .
-
-_:genid61 a owl:Restriction;
-  owl:someValuesFrom obo:BFO_0000001;
-  owl:onProperty cco:ont00001811 .
-
-cco:ont00001014 a owl:Class;
-  rdfs:subClassOf cco:ont00000003;
-  rdfs:label "Proper Name"@en;
-  skos:definition "A Designative Name that is an official name for a particular entity."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001022 a owl:Class;
-  owl:equivalentClass _:genid63;
-  rdfs:subClassOf cco:ont00001163;
-  owl:disjointWith cco:ont00001364 .
-
-_:genid63 a owl:Class;
-  owl:intersectionOf _:genid66 .
-
-_:genid66 a rdf:List;
-  rdf:first cco:ont00001163;
-  rdf:rest _:genid64 .
-
-_:genid64 a rdf:List;
-  rdf:first _:genid65;
-  rdf:rest rdf:nil .
-
-_:genid65 a owl:Restriction;
-  owl:someValuesFrom obo:BFO_0000001;
-  owl:onProperty cco:ont00001983 .
-# 
-# https://www.commoncoreontologies.org/ont00001041
-# 
-# https://www.commoncoreontologies.org/ont00001046
-# 
-# https://www.commoncoreontologies.org/ont00001069
-# 
-# https://www.commoncoreontologies.org/ont00001101
-# 
-# https://www.commoncoreontologies.org/ont00001146
-# 
-# https://www.commoncoreontologies.org/ont00001149
-# 
-# https://www.commoncoreontologies.org/ont00001163
-# 
-# https://www.commoncoreontologies.org/ont00001175
-# 
-# https://www.commoncoreontologies.org/ont00001176
-# 
-# https://www.commoncoreontologies.org/ont00001205
-# 
-# https://www.commoncoreontologies.org/ont00001235
-# 
-# https://www.commoncoreontologies.org/ont00001238
-# 
-# https://www.commoncoreontologies.org/ont00001256
-# 
-# https://www.commoncoreontologies.org/ont00001309
-# 
-# https://www.commoncoreontologies.org/ont00001328
-# 
-# https://www.commoncoreontologies.org/ont00001331
-# 
-# https://www.commoncoreontologies.org/ont00001340
-# 
-# https://www.commoncoreontologies.org/ont00001351
-# 
-# https://www.commoncoreontologies.org/ont00001352
-# 
-# https://www.commoncoreontologies.org/ont00001364
-# 
-# https://www.commoncoreontologies.org/ont00002001
-# 
-# https://www.commoncoreontologies.org/ont00002002
-# 
-# https://www.commoncoreontologies.org/ont00002003
-# 
-# https://www.commoncoreontologies.org/ont00002004
-# 
-# https://www.commoncoreontologies.org/ont00002005
-# 
-# https://www.commoncoreontologies.org/ont00002006
-# 
-# https://www.commoncoreontologies.org/ont00002007
-# 
-# https://www.commoncoreontologies.org/ont00002008
-# 
-# https://www.commoncoreontologies.org/ont00002009
-# 
-# https://www.commoncoreontologies.org/ont00002010
-# 
-# https://www.commoncoreontologies.org/ont00002011
-# 
-# https://www.commoncoreontologies.org/ont00002012
-# 
-# https://www.commoncoreontologies.org/ont00002013
-# 
-# https://www.commoncoreontologies.org/ont00002014
-# 
-# https://www.commoncoreontologies.org/ont00002015
-# 
-# https://www.commoncoreontologies.org/ont00002016
-# 
-# https://www.commoncoreontologies.org/ont00002017
-# 
-# https://www.commoncoreontologies.org/ont00002018
-# 
-# https://www.commoncoreontologies.org/ont00002019
-# 
-# https://www.commoncoreontologies.org/ont00002020
-# 
-# https://www.commoncoreontologies.org/ont00002021
-# 
-# https://www.commoncoreontologies.org/ont00002022
-# 
-# https://www.commoncoreontologies.org/ont00002023
-# 
-# https://www.commoncoreontologies.org/ont00002024
-# 
-# https://www.commoncoreontologies.org/ont00002025
-# 
-# https://www.commoncoreontologies.org/ont00002026
-# 
-# https://www.commoncoreontologies.org/ont00002027
-# 
-# https://www.commoncoreontologies.org/ont00002028
-# 
-# https://www.commoncoreontologies.org/ont00002029
-# 
-# https://www.commoncoreontologies.org/ont00002030
-# 
-# https://www.commoncoreontologies.org/ont00002031
-# 
-# https://www.commoncoreontologies.org/ont00002032
-# 
-# https://www.commoncoreontologies.org/ont00002033
-# 
-# https://www.commoncoreontologies.org/ont00002034
-# 
-# https://www.commoncoreontologies.org/ont00002035
-# 
-# https://www.commoncoreontologies.org/ont00002036
-# 
-# https://www.commoncoreontologies.org/ont00002037
-# 
-# https://www.commoncoreontologies.org/ont00002038
-# 
-# https://www.commoncoreontologies.org/ont00002039
-# 
-# https://www.commoncoreontologies.org/ont00002040
-# 
-# https://www.commoncoreontologies.org/ont00002041
-# 
-# https://www.commoncoreontologies.org/ont00002042
-# 
-# https://www.commoncoreontologies.org/ont00002043
-# 
-# https://www.commoncoreontologies.org/ont00002044
-# 
-# https://www.commoncoreontologies.org/ont00002045
-# 
-# 
-# 
-# #################################################################
-# #
-# #    Individuals
-# #
-# #################################################################
-# 
-# 
-# https://www.commoncoreontologies.org/ont00001392
-# 
-# https://www.commoncoreontologies.org/ont00001395
-# 
-# https://www.commoncoreontologies.org/ont00001398
-# 
-# https://www.commoncoreontologies.org/ont00001403
-# 
-# https://www.commoncoreontologies.org/ont00001405
-# 
-# https://www.commoncoreontologies.org/ont00001406
-# 
-# https://www.commoncoreontologies.org/ont00001408
-# 
-# https://www.commoncoreontologies.org/ont00001412
-# 
-# https://www.commoncoreontologies.org/ont00001414
-# 
-# https://www.commoncoreontologies.org/ont00001417
-# 
-# https://www.commoncoreontologies.org/ont00001419
-# 
-# https://www.commoncoreontologies.org/ont00001421
-# 
-# https://www.commoncoreontologies.org/ont00001424
-# 
-# https://www.commoncoreontologies.org/ont00001430
-# 
-# https://www.commoncoreontologies.org/ont00001431
-# 
-# https://www.commoncoreontologies.org/ont00001434
-# 
-# https://www.commoncoreontologies.org/ont00001436
-# 
-# https://www.commoncoreontologies.org/ont00001439
-# 
-# https://www.commoncoreontologies.org/ont00001440
-# 
-# https://www.commoncoreontologies.org/ont00001446
-# 
-# https://www.commoncoreontologies.org/ont00001454
-# 
-# https://www.commoncoreontologies.org/ont00001457
-# 
-# https://www.commoncoreontologies.org/ont00001461
-# 
-# https://www.commoncoreontologies.org/ont00001467
-# 
-# https://www.commoncoreontologies.org/ont00001468
-# 
-# https://www.commoncoreontologies.org/ont00001476
-# 
-# https://www.commoncoreontologies.org/ont00001480
-# 
-# https://www.commoncoreontologies.org/ont00001488
-# 
-# https://www.commoncoreontologies.org/ont00001491
-# 
-# https://www.commoncoreontologies.org/ont00001500
-# 
-# https://www.commoncoreontologies.org/ont00001506
-# 
-# https://www.commoncoreontologies.org/ont00001516
-# 
-# https://www.commoncoreontologies.org/ont00001524
-# 
-# https://www.commoncoreontologies.org/ont00001527
-# 
-# https://www.commoncoreontologies.org/ont00001529
-# 
-# https://www.commoncoreontologies.org/ont00001534
-# 
-# https://www.commoncoreontologies.org/ont00001537
-# 
-# https://www.commoncoreontologies.org/ont00001541
-# 
-# https://www.commoncoreontologies.org/ont00001548
-# 
-# https://www.commoncoreontologies.org/ont00001550
-# 
-# https://www.commoncoreontologies.org/ont00001553
-# 
-# https://www.commoncoreontologies.org/ont00001554
-# 
-# https://www.commoncoreontologies.org/ont00001565
-# 
-# https://www.commoncoreontologies.org/ont00001570
-# 
-# https://www.commoncoreontologies.org/ont00001580
-# 
-# https://www.commoncoreontologies.org/ont00001581
-# 
-# https://www.commoncoreontologies.org/ont00001582
-# 
-# https://www.commoncoreontologies.org/ont00001584
-# 
-# https://www.commoncoreontologies.org/ont00001588
-# 
-# https://www.commoncoreontologies.org/ont00001590
-# 
-# https://www.commoncoreontologies.org/ont00001591
-# 
-# https://www.commoncoreontologies.org/ont00001597
-# 
-# https://www.commoncoreontologies.org/ont00001599
-# 
-# https://www.commoncoreontologies.org/ont00001603
-# 
-# https://www.commoncoreontologies.org/ont00001607
-# 
-# https://www.commoncoreontologies.org/ont00001615
-# 
-# https://www.commoncoreontologies.org/ont00001624
-# 
-# https://www.commoncoreontologies.org/ont00001625
-# 
-# https://www.commoncoreontologies.org/ont00001626
-# 
-# https://www.commoncoreontologies.org/ont00001628
-# 
-# https://www.commoncoreontologies.org/ont00001630
-# 
-# https://www.commoncoreontologies.org/ont00001634
-# 
-# https://www.commoncoreontologies.org/ont00001648
-# 
-# https://www.commoncoreontologies.org/ont00001658
-# 
-# https://www.commoncoreontologies.org/ont00001660
-# 
-# https://www.commoncoreontologies.org/ont00001661
-# 
-# https://www.commoncoreontologies.org/ont00001666
-# 
-# https://www.commoncoreontologies.org/ont00001674
-# 
-# https://www.commoncoreontologies.org/ont00001691
-# 
-# https://www.commoncoreontologies.org/ont00001692
-# 
-# https://www.commoncoreontologies.org/ont00001693
-# 
-# https://www.commoncoreontologies.org/ont00001695
-# 
-# https://www.commoncoreontologies.org/ont00001700
-# 
-# https://www.commoncoreontologies.org/ont00001701
-# 
-# https://www.commoncoreontologies.org/ont00001702
-# 
-# https://www.commoncoreontologies.org/ont00001704
-# 
-# https://www.commoncoreontologies.org/ont00001712
-# 
-# https://www.commoncoreontologies.org/ont00001716
-# 
-# https://www.commoncoreontologies.org/ont00001723
-# 
-# https://www.commoncoreontologies.org/ont00001727
-# 
-# https://www.commoncoreontologies.org/ont00001732
-# 
-# Generated by the OWL API (version 4.5.26.2023-07-17T20:34:13Z) https://github.com/owlcs/owlapi
-
-cco:ont00001022 rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en;
-  rdfs:label "Ratio Measurement Information Content Entity"@en;
-  skos:definition "A Measurement Information Content Entity that consists of a symbol that places a Quality of an Entity onto an interval scale having a true zero value."@en;
-  skos:example "The sentence \"The temperature reached 240.372 degrees Kelvin on January 20, 1985 in Chicago, IL.\" is the carrier of a ratio measurement as 0 degrees on the Kelvin scale does describe absolute zero."@en,
-    "a measurement of the barometric pressure at 1,000 feet above sea level", "a measurement of the measure of air temperature on the Kelvin scale",
-    "a measurement of the number of members in an Organization";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001041 a owl:Class;
-  rdfs:subClassOf cco:ont00001010;
-  rdfs:label "Sequence Position Ordinality"@en;
-  skos:definition "An Ordinal Measurement Information Content Entity that is about the position of some entity in some ordered sequence."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001046 a owl:Class .
-
-cco:ont00001069 a owl:Class;
-  owl:equivalentClass _:genid67;
-  rdfs:subClassOf cco:ont00000958;
-  owl:disjointWith cco:ont00001163;
-  rdfs:label "Representational Information Content Entity"@en;
-  skos:definition "An Information Content Entity that represents some Entity."@en;
-  skos:example "the content of a court transcript represents a courtroom proceeding",
-    "the content of a photograph of the Statue of Liberty represents the Statue of Liberty",
-    "the content of a video of a sporting event represents that sporting event";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid67 a owl:Class;
-  owl:intersectionOf _:genid70 .
-
-_:genid70 a rdf:List;
-  rdf:first cco:ont00000958;
-  rdf:rest _:genid68 .
-
-_:genid68 a rdf:List;
-  rdf:first _:genid69;
-  rdf:rest rdf:nil .
-
-_:genid69 a owl:Restriction;
-  owl:someValuesFrom obo:BFO_0000001;
-  owl:onProperty cco:ont00001938 .
-
-cco:ont00001101 a owl:Class;
-  rdfs:subClassOf cco:ont00001176;
-  rdfs:label "Interval Estimate Information Content Entity"@en;
-  skos:altLabel "Interval Estimate"@en, "Interval Estimate Measurement Information Content Entity"@en;
-  skos:definition "An Estimate Information Content Entity that consists of an interval of possible (or probable) values for the measured entity."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001146 a owl:Class;
-  rdfs:subClassOf cco:ont00001328;
-  rdfs:comment "Sidereal Time is the angle measured from an observer's meridian along the celestial equator to the Great Circle that passes through the March equinox and both poles. This angle is usually expressed in Hours, Minutes, and Seconds."@en;
-  rdfs:label "Sidereal Time Reference System"@en;
-  skos:definition "A Temporal Reference System that is based on Earth's rate of rotation measured relative to one or more fixed Stars (rather than the Sun)."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001149 a owl:Class;
-  rdfs:subClassOf cco:ont00001101;
-  rdfs:label "Data Range Interval Estimate Information Content Entity"@en;
-  skos:definition "A Ratio Measurement Information Content Entity that is a measurement of a set of values and is equal to the absolute difference between the largest value and the smallest value in the set."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001163 a owl:Class;
-  owl:equivalentClass _:genid71;
-  rdfs:subClassOf cco:ont00000853;
-  rdfs:label "Measurement Information Content Entity"@en;
-  skos:altLabel "Measurement ICE"@en;
-  skos:definition "A Descriptive Information Content Entity that describes the extent, dimensions, quantity, or quality of an Entity relative to some standard."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid71 a owl:Class;
-  owl:intersectionOf _:genid74 .
-
-_:genid74 a rdf:List;
-  rdf:first cco:ont00000853;
-  rdf:rest _:genid72 .
-
-_:genid72 a rdf:List;
-  rdf:first _:genid73;
-  rdf:rest rdf:nil .
-
-_:genid73 a owl:Restriction;
-  owl:someValuesFrom obo:BFO_0000001;
-  owl:onProperty cco:ont00001966 .
-
-cco:ont00001175 a owl:Class;
-  rdfs:subClassOf cco:ont00000965;
-  rdfs:label "Language"@en;
-  skos:definition "A Directive Information Content Entity that prescribes a canonical format for communication."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001176 a owl:Class;
-  rdfs:subClassOf cco:ont00001163;
-  rdfs:label "Estimate Information Content Entity"@en;
-  skos:altLabel "Estimate"@en, "Estimate Measurement Information Content Entity"@en,
-    "Estimated Value"@en;
-  skos:definition "A Measurement Information Content Entity that is a measurement of an entity based on partial information about that entity or an appropriately similar entity."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001205 a owl:Class;
-  rdfs:subClassOf cco:ont00000398;
-  rdfs:label "Priority Scale"@en;
-  skos:definition "A Reference System that is designed to be used to rank or identify the importance of entities of the specified type."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001235 a owl:Class;
-  rdfs:subClassOf cco:ont00000829;
-  rdfs:label "Military Time Zone Identifier"@en;
-  skos:definition "A Time Zone Identifier that designates a spatial region where the local time is calculated according to the specified offset from Zulu time, which has no offset from Coordinated Universal Time."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001238 a owl:Class;
-  rdfs:subClassOf cco:ont00000605;
-  rdfs:label "Initialism"@en;
-  skos:definition "An Abbreviated Name that consists of the initial letters of some words (or syllables) in a Designative Name, and in which each letter is pronounced separately."@en;
-  skos:example "USA, CPU, BBC";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001256 a owl:Class;
-  rdfs:subClassOf cco:ont00001163;
-  rdfs:comment "Note, the term 'accuracy' is avoided due to its ambiguity between: correctness-of-performance ('Reliability Measurement Information Content Entity'), correctness-of-information (see: 'Veracity Measurement Information Content Entity'), and adherance-to-expectations (see: 'Deviation Measurement Information Content Entity')."@en;
-  rdfs:label "Reliability Measurement Information Content Entity"@en;
-  skos:altLabel "Accuracy of Process"@en, "Reliability Measurement"@en;
-  skos:definition "A Measurement Information Content Entity that is a measurement of the extent to which an entity can consistently produce an outcome."@en;
-  skos:scopeNote "Reliability concerns both a measure of past performance and the expectation that future performance will conform to the range of past performances."@en;
-  cco:ont00001754 "https://en.wikipedia.org/wiki/Reliability_(statistics)";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001309 a owl:Class;
-  rdfs:subClassOf cco:ont00000077;
-  rdfs:label "Lot Number"@en;
-  skos:definition "A Code Identifier that designates a particular quantity or lot of material from a single manufacturer."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Lot_number&oldid=1061846325"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001328 a owl:Class;
-  rdfs:subClassOf cco:ont00000398;
-  rdfs:label "Temporal Reference System"@en;
-  skos:altLabel "Temporal Reference Frame"@en, "Time Scale"@en;
-  skos:definition "A Reference System that describes a set of standards for measuring time as well as understanding the context of and organizing temporal data."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001331 a owl:Class;
-  rdfs:subClassOf cco:ont00001014;
-  rdfs:label "Legal Name"@en;
-  skos:definition "A Proper Name that is an official name for the designated entity as determined by a Government or court of law."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001340 a owl:Class;
-  rdfs:subClassOf cco:ont00000529;
-  rdfs:label "Calendar Date Identifier"@en;
-  skos:definition "A Date Identifier that designates some Day by using a combination of Day, Week, Month, or Year Identifiers formatted according to an implementation of a Calendar System."@en;
-  skos:example "January 1, 2018; 1 January 2018; 01/01/18; 01Jan18";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001351 a owl:Class;
-  rdfs:subClassOf cco:ont00000275;
-  rdfs:label "Cartesian Coordinate System"@en;
-  skos:altLabel "Rectangular Coordinate System"@en;
-  skos:definition "A Spatial Reference System that identifies each point in a spatial region of n-dimensions using an ordered n-tuple of numerical coordinates that are the signed (i.e. positive or negative) distances measured in the same unit of length from the zero point where the fixed perpendicular Coordinate System Axes meet."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Cartesian_coordinate_system&oldid=1058613323"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001352 a owl:Class;
-  rdfs:subClassOf cco:ont00000829;
-  rdfs:comment "Greenwich Mean Time (GMT) is the mean solar time at the Royal Observatory in Greenwich, London and has been superseded by Coordinated Universal Time (UTC)."@en;
-  rdfs:label "Greenwich Mean Time Zone Identifier"@en;
-  skos:definition "A Time Zone Identifier that designates a spatial region where the local time is calculated according to the specified offset from Greenwich Mean Time."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001364 a owl:Class;
-  owl:equivalentClass _:genid75;
-  rdfs:subClassOf cco:ont00001163;
-  rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en;
-  rdfs:label "Interval Measurement Information Content Entity"@en;
-  skos:definition "A Measurement Information Content Entity that places a Quality of an Entity onto some interval scale having no true zero value."@en;
-  skos:example "The sentence \"The temperature reached -27 degrees Fahrenheit on January 20, 1985 in Chicago, IL.\" is the carrier of an interval measurement as 0 degrees on the Fahrenheit scale does not describe absolute zero."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-_:genid75 a owl:Class;
-  owl:intersectionOf _:genid78 .
-
-_:genid78 a rdf:List;
-  rdf:first cco:ont00001163;
-  rdf:rest _:genid76 .
-
-_:genid76 a rdf:List;
-  rdf:first _:genid77;
-  rdf:rest rdf:nil .
-
-_:genid77 a owl:Restriction;
-  owl:someValuesFrom obo:BFO_0000001;
-  owl:onProperty cco:ont00001877 .
-
-cco:ont00002001 a owl:Class;
-  rdfs:subClassOf cco:ont00000958;
-  rdfs:label "Media Content Entity";
-  skos:definition "An information content entity presented in a canonical media format."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002002 a owl:Class;
-  rdfs:subClassOf cco:ont00002001;
-  rdfs:label "Certificate"@en;
-  skos:definition "A Media Content Entity that attests to certain demonstrated characteristics of an Object, Person, or Organization."@en;
-  cco:ont00001754 "http://www.dictionary.com/browse/degree";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002003 a owl:Class;
-  rdfs:subClassOf cco:ont00002002;
-  rdfs:label "Academic Degree"@en;
-  skos:definition "A Certificate issued by an Educational Organization to a Person to indicate that the Person has satisfactorily completed a course of study, or as an honorary recognition of the Person's achievement."@en;
-  cco:ont00001754 "http://www.dictionary.com/browse/degree";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002004 a owl:Class;
-  rdfs:subClassOf cco:ont00002001;
-  rdfs:label "Image"@en;
-  skos:definition "A Media Content Entity represents some entity owing to a visual isomorphism between the carrying artifact and the entity."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Image&oldid=1062709732"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002005 a owl:Class;
-  rdfs:subClassOf cco:ont00002004;
-  rdfs:label "Chart"@en;
-  skos:definition "An Image that is prescribed by some canonical visual format."@en;
-  cco:ont00001754 "Adapted from “Chart.” Merriam-Webster.com Dictionary, Merriam-Webster, https://www.merriam-webster.com/dictionary/chart. Accessed 4 Aug. 2024.";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002006 a owl:Class;
-  rdfs:subClassOf cco:ont00002001;
-  rdfs:label "Database"@en;
-  skos:definition "A Media Content Entity that is designed to be rapidly searchable and retrievable."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Database&oldid=1057024641"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002007 a owl:Class;
-  rdfs:subClassOf cco:ont00002001;
-  rdfs:label "List"@en;
-  skos:definition "A Media Content Entity whose parts are the subject of some Sequence Position Ordinality."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=List_(abstract_data_type)&oldid=1041588680"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002008 a owl:Class;
-  rdfs:subClassOf cco:ont00002007;
-  rdfs:label "Code List"@en;
-  skos:definition "A List whose parts are Code Identifiers."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002009 a owl:Class;
-  rdfs:subClassOf cco:ont00002001;
-  rdfs:label "Video"@en;
-  skos:definition "A Media Content Entity that contains a sequence of representations that are presented sufficiently rapidly to create the appearance of motion and continuity."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Video&oldid=1049376249"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002010 a owl:Class;
-  rdfs:subClassOf cco:ont00002001;
-  rdfs:label "Message"@en;
-  skos:definition "A Media Content Entity that is relatively brief and designed to be transmitted from a sender to a recipient."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Message&oldid=1060098631"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002011 a owl:Class;
-  rdfs:subClassOf cco:ont00002010;
-  rdfs:label "Warning Message"@en;
-  skos:definition "A Message that describes a possible or impending threat."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002012 a owl:Class;
-  rdfs:subClassOf cco:ont00002010;
-  rdfs:label "Email Message"@en;
-  skos:definition "A Message that is transmitted to the recipient's Email Box."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Email&oldid=1063646749"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002013 a owl:Class;
-  rdfs:subClassOf cco:ont00002010;
-  rdfs:label "Notification Message"@en;
-  skos:definition "A Message that describes a scenario that has been determined to merit attention by the recipient."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002014 a owl:Class;
-  rdfs:subClassOf cco:ont00002001;
-  rdfs:comment "For information on types of barcodes, see: https://www.scandit.com/types-barcodes-choosing-right-barcode/"@en;
-  rdfs:label "Barcode"@en;
-  skos:definition "A Media Content Entity that represents one or more geometric shapes that have, as part, some Directive Information Content Entity."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Barcode&oldid=1059844765"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002015 a owl:Class;
-  rdfs:subClassOf cco:ont00002014;
-  rdfs:label "Two-Dimensional Barcode"@en;
-  skos:definition "A Barcode that represents lines of varying widths, spacing, height, and color that has, as part, some Directive Information Content Entity."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002016 a owl:Class;
-  rdfs:subClassOf cco:ont00002015;
-  rdfs:label "Aztec Code"@en;
-  skos:definition "A Two-Dimensional Barcode that is used by the transportation industry to scan tickets."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002017 a owl:Class;
-  rdfs:subClassOf cco:ont00002015;
-  rdfs:label "Data Matrix Code"@en;
-  skos:definition "A Two-Dimensional Barcode that represents cells arranged in rectangular patterns and is used for marking small items in logistics and operations."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002018 a owl:Class;
-  rdfs:subClassOf cco:ont00002015;
-  rdfs:label "QR Code"@en;
-  skos:definition "A Two-Dimensional Barcode that represents numeric, alphanumeric, binary, or kanji information and is used primarily for tracking and marketing."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002019 a owl:Class;
-  rdfs:subClassOf cco:ont00002015;
-  rdfs:label "PDF417 Code"@en;
-  skos:definition "A Two-Dimensional Barcode that is used in applications that require the storage of huge amounts of data."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002020 a owl:Class;
-  rdfs:subClassOf cco:ont00002014;
-  rdfs:label "One-Dimensional Barcode"@en;
-  skos:definition "A Barcode that represents parallel lines of varying widths and spacing that concretize some Directive Information Content Entity."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002021 a owl:Class;
-  rdfs:subClassOf cco:ont00002020;
-  rdfs:label "Codabar Barcode"@en;
-  skos:definition "A One-Dimensional Barcode that represents numbers 0-9 and the characters -$:/.+ and is intended for use by logistics and healthcare professionals."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002022 a owl:Class;
-  rdfs:subClassOf cco:ont00002020;
-  rdfs:label "Code 93 Barcode"@en;
-  skos:definition "A One-Dimensional Barcode that represents 93 ASCII characters and is used in logistics to identify packages in retail inventory, lable electornic components, and provide supplementary delivery information."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002023 a owl:Class;
-  rdfs:subClassOf cco:ont00002020;
-  rdfs:label "ITF Barcode"@en;
-  skos:definition "A One-Dimensional Barcode that represents an even number of numerical characters and is used primarily in packaging and distribution."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002024 a owl:Class;
-  rdfs:subClassOf cco:ont00002020;
-  rdfs:label "MSI Plessey Barcode"@en;
-  skos:definition "A One-Dimensional Barcode that represents an indefinite number of numerical characters and is used for inventory control and marking storage containers and shelves in warehouse environments."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002025 a owl:Class;
-  rdfs:subClassOf cco:ont00002020;
-  rdfs:label "EAN Barcode"@en;
-  skos:definition "A One-Dimensional Barcode that represents 8 or 13 numerical digits and is used to scan consumer goods."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002026 a owl:Class;
-  rdfs:subClassOf cco:ont00002025;
-  rdfs:label "ISSN Barcode"@en;
-  skos:definition "An EAN Barcode that is designed to designate a periodical."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002027 a owl:Class;
-  rdfs:subClassOf cco:ont00002025;
-  rdfs:label "JAN-13 Barcode"@en;
-  skos:definition "An EAN Barcode that is designed to designate 13 numerical digits and is used primarily in Japan to designate products at the point of sale."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002028 a owl:Class;
-  rdfs:subClassOf cco:ont00002025;
-  rdfs:label "EAN-13 Barcode"@en;
-  skos:definition "An EAN Barcode that represents 13 numerical digits and is used to designate products at the point of sale."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002029 a owl:Class;
-  rdfs:subClassOf cco:ont00002025;
-  rdfs:label "EAN-8 Barcode"@en;
-  skos:definition "An EAN Barcode that represents 8 numerical digits and is used to designate products at the point of sale."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002030 a owl:Class;
-  rdfs:subClassOf cco:ont00002025;
-  rdfs:label "ISBN Barcode"@en;
-  skos:definition "An EAN Barcode that is designed to designate a book."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002031 a owl:Class;
-  rdfs:subClassOf cco:ont00002020;
-  rdfs:comment "Further variants of GS1 DataBar have not been defined here."@en;
-  rdfs:label "GS1 DataBar Barcode"@en;
-  skos:definition "A One-Dimensional Barcode that represents 12-14 numerical digits and is used in retail and healthcare."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002032 a owl:Class;
-  rdfs:subClassOf cco:ont00002020;
-  rdfs:label "Code 39 Barcode"@en;
-  skos:definition "A One-Dimensional Barcode that represents 39 characters that are numbers 0-9, capital letters A-Z, or the symbols -.$/+% and space and is used primarily in automotive and defense industries."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002033 a owl:Class;
-  rdfs:subClassOf cco:ont00002020;
-  rdfs:label "Code 128 Barcode"@en;
-  skos:definition "A One-Dimensional Barcode that represents to 128 ASCII characters and is used primarily in supply chains."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002034 a owl:Class;
-  rdfs:subClassOf cco:ont00002020;
-  rdfs:label "UPC Barcode"@en;
-  skos:definition "A One-Dimensional Barcode that represents 6 or 12 numerical digits and is used to scan consumer goods."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002035 a owl:Class;
-  rdfs:subClassOf cco:ont00002034;
-  rdfs:label "UPC-A Barcode"@en;
-  skos:definition "A UPC Barcode that represents 12 numerical digits."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002036 a owl:Class;
-  rdfs:subClassOf cco:ont00002034;
-  rdfs:label "UPC-E Barcode"@en;
-  skos:definition "A UPC Barcode that represents 6 numerical digits."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002037 a owl:Class;
-  rdfs:subClassOf cco:ont00002001;
-  rdfs:label "Information Line"@en;
-  skos:definition "A Media Content entity consisting of a single line or row in some Document Content entity of which it is a part."@en;
-  skos:example "a line in a computer file that bears a portion of code for some computer program",
-    "a line of data in a database", "a line of text in a book";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002038 a owl:Class;
-  rdfs:subClassOf cco:ont00000958;
-  rdfs:label "Document Field Content"@en;
-  skos:altLabel "Document Field"@en;
-  skos:definition "A Media Content Entity that is a part of some document content entity, and which  prescribes the eliciation of information to be written or selected within the document content entity."@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002039 a owl:Class;
-  rdfs:subClassOf cco:ont00002001;
-  rdfs:label "Document Content Entity"@en;
-  skos:altLabel "Document"@en;
-  skos:definition "A Media Information Content that consists of a series of paragraphs of text or diagrams that are intended to be carried by physical pieces of paper or an electronic word processor file."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Document&oldid=1057829688"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002040 a owl:Class;
-  rdfs:subClassOf cco:ont00002039;
-  rdfs:label "Book"@en;
-  skos:definition "A Document Content Entity that canonically appears as ink on paper or parchment, or other materials fastened together to hinge at one side."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Book&oldid=1063132471"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002041 a owl:Class;
-  rdfs:subClassOf cco:ont00002039;
-  rdfs:label "Transcript"@en;
-  skos:definition "A Document Content Entity that was originally recorded in a different medium."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Transcript&oldid=1038510063"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002042 a owl:Class;
-  rdfs:subClassOf cco:ont00002039;
-  rdfs:label "Spreadsheet"@en;
-  skos:definition "A Document Content Entity that canonically appears as a interactive, tabular form."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Spreadsheet&oldid=1064060503"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002043 a owl:Class;
-  rdfs:subClassOf cco:ont00002039;
-  rdfs:label "Report"@en;
-  skos:definition "A Document Content entity that conveys an account of some event, situation, or the result of some observation or inquiry."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Report&oldid=1063765657"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002044 a owl:Class;
-  rdfs:subClassOf cco:ont00002039;
-  rdfs:label "Form Document"@en;
-  skos:definition "A Document Content Entity that has Document Field Contents as parts."@en;
-  cco:ont00001754 "https://en.wikipedia.org/wiki/Form_(document)";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00002045 a owl:Class;
-  rdfs:subClassOf cco:ont00002039;
-  rdfs:label "Journal Article"@en;
-  skos:definition "A Document Content Entity that is part of a Journal Issue."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Academic_journal&oldid=1059723283"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001392 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT-8"@en;
-  skos:altLabel "PST"@en, "Pacific Standard Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001395 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT-3:30"@en;
-  skos:altLabel "Newfoundland Standard Time"@en;
-  cco:ont00001753 "NST";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001398 a owl:NamedIndividual, cco:ont00000469;
-  rdfs:label "Global Area Reference System"@en;
-  cco:ont00001753 "GARS";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001403 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC+2"@en;
-  rdfs:label "Bravo Time Zone"@en;
-  cco:ont00001753 "B";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001405 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT-2"@en;
-  skos:altLabel "BET"@en, "Brazil Eastern Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001406 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT+9:30"@en;
-  skos:altLabel "Australian Central Standard Time"@en;
-  cco:ont00001753 "ACST";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001408 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC-11"@en;
-  rdfs:label "X-ray Time Zone"@en;
-  cco:ont00001753 "X";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001412 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC+0"@en;
-  rdfs:label "GMT"@en;
-  skos:altLabel "Greenwich Mean Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001414 a owl:NamedIndividual, cco:ont00001328;
-  rdfs:comment "TT is an astronomical time standard that is a theoretical ideal designed to be free of the irregularities in Earth's rotation and is primarily used for time measurements of astronomical observations made from the surface of Earth. It was formerly called Terrestrial Dynamical Time (TDT), which was formulated to replace Ephemeris Time (ET)."@en;
-  rdfs:label "Terrestrial Time"@en;
-  cco:ont00001753 "TT";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001417 a owl:NamedIndividual, cco:ont00001328;
-  rdfs:comment "ET is an astronomical time scale that was adopted as a standard in 1952 by the IAU but has since been superseded and is no longer actively used. ET is based on the ephemeris second, which was defined as a fraction of the tropical year for 1900 January 01 as calculated using Newcomb's 1895 tables of the Sun. ET was designed to avoid problems caused by variations in Earth's rotational period and was used for Solar System ephemeris calculations until being replaced by Terrestrial Dynamical Time (TDT) in 1979."@en;
-  rdfs:label "Ephemeris Time"@en;
-  cco:ont00001753 "ET";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001419 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT+5"@en;
-  skos:altLabel "PLT"@en, "Pakistan Lahore Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001421 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC-6"@en;
-  rdfs:label "Sierra Time Zone"@en;
-  cco:ont00001753 "S";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001424 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC+1"@en;
-  rdfs:label "Alpha Time Zone"@en;
-  cco:ont00001753 "A";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001430 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC+6"@en;
-  rdfs:label "Foxtrot Time Zone"@en;
-  cco:ont00001753 "F";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001431 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC-10"@en;
-  rdfs:label "Whiskey Time Zone"@en;
-  cco:ont00001753 "W";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001434 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT+1"@en;
-  skos:altLabel "ECT"@en, "European Central Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001436 a owl:NamedIndividual, cco:ont00000630;
-  rdfs:label "Universal Time 1 D"@en;
-  cco:ont00001753 "UT1D";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001439 a owl:NamedIndividual, cco:ont00000263;
-  rdfs:label "Twenty-Four-Hour Clock Time System"@en;
-  skos:altLabel "24-Hour Clock"@en, "24-Hour Clock Time System"@en, "Military Time"@en,
-    "Military Time System"@en, "Twenty-Four Hour Clock Time System"@en, "Twenty-Four-Hour Clock"@en;
-  skos:definition "A Clock Time System for time keeping in which the Day runs from midnight to midnight and is divided into 24 Hours, indicated by the Hours passed since midnight, from 0 to 23."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=24-hour_clock&oldid=1063744105"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001440 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT-9"@en;
-  skos:altLabel "AST"@en, "Alaska Standard Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001446 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Mike Time Zone is the same local time as Yankee Time Zone, but is 1 Day (i.e. 24 Hours) ahead of Yankee Time Zone as they are on opposite sides of the International Date Line."@en,
-    "Offset from Universal Coordinated Time = UTC+12"@en;
-  rdfs:label "Mike Time Zone"@en;
-  cco:ont00001753 "M";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001454 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC+11"@en;
-  rdfs:label "Lima Time Zone"@en;
-  cco:ont00001753 "L";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001457 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC-4"@en;
-  rdfs:label "Quebec Time Zone"@en;
-  cco:ont00001753 "Q";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001461 a owl:NamedIndividual, cco:ont00001328;
-  rdfs:comment "TDB is a linear scaling of Barycentric Coordinate Time (TCB) and is a relativistic coordinate time scale used in astronomy as a time standard that accounts for time dilation when calculating Orbits and Ephemerides of Astronomical Bodies and interplanetary Spacecraft in the Solar System. TDB is a successor of Ephemeris Time (ET) and is nearly equivalent to the time scale Teph used for DE405 planetary and lunar ephemerides generated by the Jet Propulsion Laboratory."@en;
-  rdfs:label "Barycentric Dynamical Time"@en;
-  cco:ont00001753 "TDB";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001467 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT-4"@en;
-  skos:altLabel "PRT"@en, "Puerto Rico and US Virgin Islands Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001468 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT+10"@en;
-  skos:altLabel "AET"@en, "Australia Eastern Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001476 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT+4"@en;
-  skos:altLabel "NET"@en, "Near East Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001480 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC+9"@en;
-  rdfs:label "India Time Zone"@en;
-  cco:ont00001753 "I";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001488 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC-7"@en;
-  rdfs:label "Tango Time Zone"@en;
-  cco:ont00001753 "T";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001491 a owl:NamedIndividual, cco:ont00000630;
-  rdfs:label "Universal Time 1 A"@en;
-  cco:ont00001753 "UT1A";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001500 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC+5"@en;
-  rdfs:label "Echo Time Zone"@en;
-  cco:ont00001753 "E";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001506 a owl:NamedIndividual, cco:ont00000630;
-  rdfs:label "Universal Time 1 F"@en;
-  cco:ont00001753 "UT1F";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001516 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC-2"@en;
-  rdfs:label "Oscar Time Zone"@en;
-  cco:ont00001753 "O";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001524 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT-11"@en;
-  skos:altLabel "MIT"@en, "Midway Islands Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001527 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC+8"@en;
-  rdfs:label "Hotel Time Zone"@en;
-  cco:ont00001753 "H";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001529 a owl:NamedIndividual, cco:ont00001328;
-  rdfs:comment """\"TCG is a coordinate time standard intended to be used as the independent variable of time for all calculations pertaining to precession, nutation, the Moon, and artificial satellites of the Earth. It is equivalent to the proper time experienced by a clock at rest in a coordinate frame co-moving with the center of the Earth: that is, a clock that performs exactly the same movements as the Earth but is outside the Earth's gravity well. It is therefore not influenced by the gravitational time dilation caused by the Earth.\"
-From: (https://en.wikipedia.org/wiki/Geocentric_Coordinate_Time)"""@en;
-  rdfs:label "Geocentric Coordinate Time"@en;
-  cco:ont00001753 "TCG";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001534 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT+7"@en;
-  skos:altLabel "VST"@en, "Vietnam Standard Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001537 a owl:NamedIndividual, cco:ont00000067, cco:ont00000630;
-  rdfs:comment "UTC is a variant of Universal Time that is calculated by combining Universal Time 1 with International Atomic Time by occasionally adding leap seconds to TAI in order to maintain UTC within 0.9 seconds of UT1. The difference between UTC and UT1 is called DUT1 and always has a value between -0.9 seconds and +0.9 seconds. Coordinated Universal Time is the current basis for civil time and is the reference time for time zones, whose local times are defined based on an offset from UTC."@en;
-  rdfs:label "Coordinated Universal Time"@en;
-  cco:ont00001753 "UTC";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001541 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT+12"@en;
-  skos:altLabel "NST"@en, "New Zealand Standard Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001548 a owl:NamedIndividual, cco:ont00000630;
-  rdfs:comment "UT1R is a variant of Universal Time that is a smoothed version of UT1 by filtering out periodic variations due to tidal waves."@en;
-  rdfs:label "Universal Time 1 R"@en;
-  cco:ont00001753 "UT1R";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001550 a owl:NamedIndividual, cco:ont00000276;
-  rdfs:comment "The Julian Calendar was proposed by Julius Caesar as a reform of the Roman Calendar, took effect on 1 January 46 BC, and was the predominant Calendar System in Europe until being largely replaced by the Gregorian Calendar."@en;
-  rdfs:label "Julian Calendar"@en;
-  skos:definition "A Solar Calendar System that has a regular Year of 365 24-Hour Days divided into 12 Months with a leap day added at the end of February every 4 Years such that the average length of a Julian Year is 365.25 Days."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Julian_calendar&oldid=1063127575"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001553 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT+6"@en;
-  skos:altLabel "BST"@en, "Bangladesh Standard Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001554 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT-10"@en;
-  skos:altLabel "HST"@en, "Hawaii Standard Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001565 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT-5"@en;
-  skos:altLabel "EST"@en, "Eastern Standard Time"@en, "IET"@en, "Indiana Eastern Standard Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001570 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT+2"@en;
-  skos:altLabel "EET"@en, "Eastern European Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001580 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC-3"@en;
-  rdfs:label "Papa Time Zone"@en;
-  cco:ont00001753 "P";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-cco:ont00001581 a owl:NamedIndividual, cco:ont00000469;
-  rdfs:comment """The ITRS definition fulfills the following conditions:
+W3C (https://www.w3.org/TR/NOTE-datetime)"""@en ,
+                             "There is no class 'Time Zone' (the region), only 'Time Zone Identifier' (the designator for some region). Instances of 'Time Zone Identifier' should be related to instances of 'Information Bearing Entity' by means of the object properites 'uses time zone identifier' and 'time zone identifier used by' as appropriate. This is supposed to be analogous to the way we represent the relationship between measurement values and measurement units, where the relevant instance of Information Bearing Entity 'uses measurement unit' some instance of Measurement Unit (i.e., an instance of Information Content Entity)."@en ;
+                rdfs:label "Time Zone Identifier"@en ;
+                skos:definition "A Spatial Region Identifier that designates the region associated with some uniform standard time for legal, commercial, or social purposes."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000833
+cco:ont00000833 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000973 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000178 ;
+                                  owl:someValuesFrom cco:ont00000589
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000178 ;
+                                  owl:someValuesFrom cco:ont00000749
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty cco:ont00001916 ;
+                                  owl:someValuesFrom cco:ont00000359
+                                ] ;
+                rdfs:label "Julian Date Identifier"@en ;
+                skos:definition "A Decimal Time of Day Identifier that designates a Julian Date and is composed of both a Julian Day Number and a Julian Date Fraction."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000845
+cco:ont00000845 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001022 ;
+                rdfs:comment "A percentage is one way to express a proportional measure where the decimal expression of the proportion is multiplied by 100, thus giving the proportional value with respect to a whole of 100. E.g., the ratio of pigs to cows on a farm is 44 to 79 (44:79 or 44/79). The proportion of pigs to total animals is 44 to 123 or 44/123. The percentage of pigs is the decimal equivalent of the proportion (0.36) multiplied by a 100 (36%). The percentage can be expressed as a proportion where the numerator value is transformed for a denominator of 100, i.e., 36 of a 100 animals are pigs (36/100)."@en ,
+                             "We may want to add either a subclass for Percentage or a data property (has percentage value) that links the percentage expression for a proportion to the relevant IBE."@en ;
+                rdfs:label "Proportional Ratio Measurement Information Content Entity"@en ;
+                skos:definition "A Ratio Measurement Information Content Entity that is a measurement of a portion of a whole (described by the numerator) compared against that whole (described by the denominator) where the whole is a nominally described set of like entities."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000853
+cco:ont00000853 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000958
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001982 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000958 ;
+                owl:disjointWith cco:ont00000965 ;
+                rdfs:label "Descriptive Information Content Entity"@en ;
+                skos:altLabel "Descriptive ICE"@en ;
+                skos:definition "An Information Content Entity that consists of a set of propositions that describe some Entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000891
+cco:ont00000891 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001328 ;
+                rdfs:label "Calendar System"@en ;
+                skos:definition "A Temporal Reference System that is designed to organize and identify dates."@en ;
+                skos:scopeNote "Calendars typically organize dates through the use of naming and temporal conventions based on Days, Weeks, Months, and Years."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000894
+cco:ont00000894 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000529 ;
+                rdfs:label "Decimal Date Identifier"@en ;
+                skos:definition "A Date Identifier that designates some Day by using a number to indicate the sequential ordering of the Day since a specified Reference Time."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000896
+cco:ont00000896 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000745 ;
+                rdfs:label "Mean Point Estimate Information Content Entity"@en ;
+                skos:altLabel "Arithmetic Mean"@en ,
+                              "Average"@en ,
+                              "Mean"@en ;
+                skos:definition "A Point Estimate Information Content Entity that is a measurement of a set of values and is equal to the sum of all the values in the set divided by the total number of values in the set."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000915
+cco:ont00000915 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000605 ;
+                rdfs:label "Acronym"@en ;
+                skos:definition "An Abbreviated Name that combines the initial letters of a Designative Name and which is pronounced as a word."@en ;
+                skos:example "Wi-Fi, ASCII, OPSEC" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000916
+cco:ont00000916 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000891 ;
+                rdfs:label "Lunar Calendar System"@en ;
+                skos:definition "A Calendar System that is designed to organize and identify dates based on the cycles of the Moon's phases."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Lunar_calendar&oldid=1055396837"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000923
+cco:ont00000923 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000649 ;
+                rdfs:label "Arbitrary Identifier"@en ;
+                skos:altLabel "Arbitrary ID"@en ;
+                skos:definition "A Non-Name Identifier that consists of a string of characters that does not follow an encoding system."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000958
+cco:ont00000958 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000031
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001808 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:BFO_0000031 ;
+                rdfs:label "Information Content Entity"@en ;
+                skos:altLabel "ICE"@en ;
+                skos:definition "A Generically Dependent Continuant that generically depends on some Information Bearing Entity and stands in relation of aboutness to some Entity."@en ;
+                skos:scopeNote "Information Content Entity is here intended to be a class of Entities whose instances are the informational content of Information Bearing Entities. For example, three instances of information bearers -- such as a bar chart, color-coded map, and a written report -- each of which lists the GDP of Countries for the year 2010 are each different carriers of the same information content. It is this content that is generically dependent upon its carrier. This treatment of Informational Content Entity (cf. the Information Artifact Ontology) leads to a principle of subtyping based upon the relationship that ICE's have with the Entity they are about rather than characteristics such as format, language, measurement scale, or media. The latter are treated here as being Qualities of bearers."@en ;
+                cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000030" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000965
+cco:ont00000965 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000958
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001942 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000958 ;
+                rdfs:label "Prescriptive Information Content Entity"@en ;
+                skos:altLabel "Directive ICE"@en ;
+                skos:definition "An Information Content Entity that consists of a set of propositions or images (as in the case of a blueprint) that prescribe some Entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000973
+cco:ont00000973 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000827 ;
+                rdfs:label "Decimal Time of Day Identifier"@en ;
+                skos:altLabel "Fractional Time of Day Identifier"@en ;
+                skos:definition "A Time of Day Identifier that designates an approximate Temporal Instant that is part of some Day and is specified using a decimal value for the portion of the Day that preceded the Temporal Instant."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00000990
+cco:ont00000990 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000003 ;
+                rdfs:label "Nickname"@en ;
+                skos:definition "A Designative Name that is a familiar or humorous substitute for an entity's Proper Name."@en ;
+                skos:example "Ike, Chief, P-Fox" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001010
+cco:ont00001010 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00001163
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001811 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00001163 ;
+                owl:disjointWith cco:ont00001022 ,
+                                 cco:ont00001364 ;
+                rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en ;
+                rdfs:label "Ordinal Measurement Information Content Entity"@en ;
+                skos:definition "A Measurement Information Content Entity that consists of a symbol that places an Entity into some rank order."@en ;
+                skos:example "The sentence \"The coldest day in history in Chicago, IL. is January 20, 1985.\" is the carrier of an ordinal measurment."@en ,
+                             "a measurement that places Geospatial Regions into a rank order of small, medium, large" ,
+                             "a measurement that places military units onto a readiness rank order of red, yellow, green" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001014
+cco:ont00001014 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000003 ;
+                rdfs:label "Proper Name"@en ;
+                skos:definition "A Designative Name that is an official name for a particular entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001022
+cco:ont00001022 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00001163
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001983 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00001163 ;
+                owl:disjointWith cco:ont00001364 ;
+                rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en ;
+                rdfs:label "Ratio Measurement Information Content Entity"@en ;
+                skos:definition "A Measurement Information Content Entity that consists of a symbol that places a Quality of an Entity onto an interval scale having a true zero value."@en ;
+                skos:example "The sentence \"The temperature reached 240.372 degrees Kelvin on January 20, 1985 in Chicago, IL.\" is the carrier of a ratio measurement as 0 degrees on the Kelvin scale does describe absolute zero."@en ,
+                             "a measurement of the barometric pressure at 1,000 feet above sea level" ,
+                             "a measurement of the measure of air temperature on the Kelvin scale" ,
+                             "a measurement of the number of members in an Organization" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001041
+cco:ont00001041 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001010 ;
+                rdfs:label "Sequence Position Ordinality"@en ;
+                skos:definition "An Ordinal Measurement Information Content Entity that is about the position of some entity in some ordered sequence."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001046
+cco:ont00001046 rdf:type owl:Class .
+
+
+###  https://www.commoncoreontologies.org/ont00001069
+cco:ont00001069 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000958
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001938 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000958 ;
+                owl:disjointWith cco:ont00001163 ;
+                rdfs:label "Representational Information Content Entity"@en ;
+                skos:definition "An Information Content Entity that represents some Entity."@en ;
+                skos:example "the content of a court transcript represents a courtroom proceeding" ,
+                             "the content of a photograph of the Statue of Liberty represents the Statue of Liberty" ,
+                             "the content of a video of a sporting event represents that sporting event" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001101
+cco:ont00001101 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001176 ;
+                rdfs:label "Interval Estimate Information Content Entity"@en ;
+                skos:altLabel "Interval Estimate"@en ,
+                              "Interval Estimate Measurement Information Content Entity"@en ;
+                skos:definition "An Estimate Information Content Entity that consists of an interval of possible (or probable) values for the measured entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001146
+cco:ont00001146 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001328 ;
+                rdfs:comment "Sidereal Time is the angle measured from an observer's meridian along the celestial equator to the Great Circle that passes through the March equinox and both poles. This angle is usually expressed in Hours, Minutes, and Seconds."@en ;
+                rdfs:label "Sidereal Time Reference System"@en ;
+                skos:definition "A Temporal Reference System that is based on Earth's rate of rotation measured relative to one or more fixed Stars (rather than the Sun)."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001149
+cco:ont00001149 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001101 ;
+                rdfs:label "Data Range Interval Estimate Information Content Entity"@en ;
+                skos:definition "A Ratio Measurement Information Content Entity that is a measurement of a set of values and is equal to the absolute difference between the largest value and the smallest value in the set."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001163
+cco:ont00001163 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000853
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001966 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00000853 ;
+                rdfs:label "Measurement Information Content Entity"@en ;
+                skos:altLabel "Measurement ICE"@en ;
+                skos:definition "A Descriptive Information Content Entity that describes the extent, dimensions, quantity, or quality of an Entity relative to some standard."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001175
+cco:ont00001175 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000965 ;
+                rdfs:label "Language"@en ;
+                skos:definition "A Directive Information Content Entity that prescribes a canonical format for communication."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001176
+cco:ont00001176 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001163 ;
+                rdfs:label "Estimate Information Content Entity"@en ;
+                skos:altLabel "Estimate"@en ,
+                              "Estimate Measurement Information Content Entity"@en ,
+                              "Estimated Value"@en ;
+                skos:definition "A Measurement Information Content Entity that is a measurement of an entity based on partial information about that entity or an appropriately similar entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001205
+cco:ont00001205 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000398 ;
+                rdfs:label "Priority Scale"@en ;
+                skos:definition "A Reference System that is designed to be used to rank or identify the importance of entities of the specified type."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001235
+cco:ont00001235 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000829 ;
+                rdfs:label "Military Time Zone Identifier"@en ;
+                skos:definition "A Time Zone Identifier that designates a spatial region where the local time is calculated according to the specified offset from Zulu time, which has no offset from Coordinated Universal Time."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001238
+cco:ont00001238 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000605 ;
+                rdfs:label "Initialism"@en ;
+                skos:definition "An Abbreviated Name that consists of the initial letters of some words (or syllables) in a Designative Name, and in which each letter is pronounced separately."@en ;
+                skos:example "USA, CPU, BBC" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001256
+cco:ont00001256 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001163 ;
+                rdfs:comment "Note, the term 'accuracy' is avoided due to its ambiguity between: correctness-of-performance ('Reliability Measurement Information Content Entity'), correctness-of-information (see: 'Veracity Measurement Information Content Entity'), and adherance-to-expectations (see: 'Deviation Measurement Information Content Entity')."@en ;
+                rdfs:label "Reliability Measurement Information Content Entity"@en ;
+                skos:altLabel "Accuracy of Process"@en ,
+                              "Reliability Measurement"@en ;
+                skos:definition "A Measurement Information Content Entity that is a measurement of the extent to which an entity can consistently produce an outcome."@en ;
+                skos:scopeNote "Reliability concerns both a measure of past performance and the expectation that future performance will conform to the range of past performances."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Reliability_(statistics)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001309
+cco:ont00001309 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000077 ;
+                rdfs:label "Lot Number"@en ;
+                skos:definition "A Code Identifier that designates a particular quantity or lot of material from a single manufacturer."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Lot_number&oldid=1061846325"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001328
+cco:ont00001328 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000398 ;
+                rdfs:label "Temporal Reference System"@en ;
+                skos:altLabel "Temporal Reference Frame"@en ,
+                              "Time Scale"@en ;
+                skos:definition "A Reference System that describes a set of standards for measuring time as well as understanding the context of and organizing temporal data."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001331
+cco:ont00001331 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00001014 ;
+                rdfs:label "Legal Name"@en ;
+                skos:definition "A Proper Name that is an official name for the designated entity as determined by a Government or court of law."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001340
+cco:ont00001340 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000529 ;
+                rdfs:label "Calendar Date Identifier"@en ;
+                skos:definition "A Date Identifier that designates some Day by using a combination of Day, Week, Month, or Year Identifiers formatted according to an implementation of a Calendar System."@en ;
+                skos:example "January 1, 2018; 1 January 2018; 01/01/18; 01Jan18" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001351
+cco:ont00001351 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000275 ;
+                rdfs:label "Cartesian Coordinate System"@en ;
+                skos:altLabel "Rectangular Coordinate System"@en ;
+                skos:definition "A Spatial Reference System that identifies each point in a spatial region of n-dimensions using an ordered n-tuple of numerical coordinates that are the signed (i.e. positive or negative) distances measured in the same unit of length from the zero point where the fixed perpendicular Coordinate System Axes meet."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Cartesian_coordinate_system&oldid=1058613323"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001352
+cco:ont00001352 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000829 ;
+                rdfs:comment "Greenwich Mean Time (GMT) is the mean solar time at the Royal Observatory in Greenwich, London and has been superseded by Coordinated Universal Time (UTC)."@en ;
+                rdfs:label "Greenwich Mean Time Zone Identifier"@en ;
+                skos:definition "A Time Zone Identifier that designates a spatial region where the local time is calculated according to the specified offset from Greenwich Mean Time."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001364
+cco:ont00001364 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( cco:ont00001163
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty cco:ont00001877 ;
+                                                             owl:someValuesFrom obo:BFO_0000001
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf cco:ont00001163 ;
+                rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en ;
+                rdfs:label "Interval Measurement Information Content Entity"@en ;
+                skos:definition "A Measurement Information Content Entity that places a Quality of an Entity onto some interval scale having no true zero value."@en ;
+                skos:example "The sentence \"The temperature reached -27 degrees Fahrenheit on January 20, 1985 in Chicago, IL.\" is the carrier of an interval measurement as 0 degrees on the Fahrenheit scale does not describe absolute zero."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002001
+cco:ont00002001 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000958 ;
+                rdfs:label "Media Content Entity" ;
+                skos:definition "An information content entity presented in a canonical media format."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002002
+cco:ont00002002 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002001 ;
+                rdfs:label "Certificate"@en ;
+                skos:definition "A Media Content Entity that attests to certain demonstrated characteristics of an Object, Person, or Organization."@en ;
+                cco:ont00001754 "http://www.dictionary.com/browse/degree" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002003
+cco:ont00002003 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002002 ;
+                rdfs:label "Academic Degree"@en ;
+                skos:definition "A Certificate issued by an Educational Organization to a Person to indicate that the Person has satisfactorily completed a course of study, or as an honorary recognition of the Person's achievement."@en ;
+                cco:ont00001754 "http://www.dictionary.com/browse/degree" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002004
+cco:ont00002004 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002001 ;
+                rdfs:label "Image"@en ;
+                skos:definition "A Media Content Entity represents some entity owing to a visual isomorphism between the carrying artifact and the entity."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Image&oldid=1062709732"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002005
+cco:ont00002005 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002004 ;
+                rdfs:label "Chart"@en ;
+                skos:definition "An Image that is prescribed by some canonical visual format."@en ;
+                cco:ont00001754 "Adapted from “Chart.” Merriam-Webster.com Dictionary, Merriam-Webster, https://www.merriam-webster.com/dictionary/chart. Accessed 4 Aug. 2024." ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002006
+cco:ont00002006 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002001 ;
+                rdfs:label "Database"@en ;
+                skos:definition "A Media Content Entity that is designed to be rapidly searchable and retrievable."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Database&oldid=1057024641"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002007
+cco:ont00002007 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002001 ;
+                rdfs:label "List"@en ;
+                skos:definition "A Media Content Entity whose parts are the subject of some Sequence Position Ordinality."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=List_(abstract_data_type)&oldid=1041588680"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002008
+cco:ont00002008 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002007 ;
+                rdfs:label "Code List"@en ;
+                skos:definition "A List whose parts are Code Identifiers."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002009
+cco:ont00002009 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002001 ;
+                rdfs:label "Video"@en ;
+                skos:definition "A Media Content Entity that contains a sequence of representations that are presented sufficiently rapidly to create the appearance of motion and continuity."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Video&oldid=1049376249"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002010
+cco:ont00002010 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002001 ;
+                rdfs:label "Message"@en ;
+                skos:definition "A Media Content Entity that is relatively brief and designed to be transmitted from a sender to a recipient."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Message&oldid=1060098631"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002011
+cco:ont00002011 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002010 ;
+                rdfs:label "Warning Message"@en ;
+                skos:definition "A Message that describes a possible or impending threat."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002012
+cco:ont00002012 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002010 ;
+                rdfs:label "Email Message"@en ;
+                skos:definition "A Message that is transmitted to the recipient's Email Box."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Email&oldid=1063646749"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002013
+cco:ont00002013 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002010 ;
+                rdfs:label "Notification Message"@en ;
+                skos:definition "A Message that describes a scenario that has been determined to merit attention by the recipient."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002014
+cco:ont00002014 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002001 ;
+                rdfs:comment "For information on types of barcodes, see: https://www.scandit.com/types-barcodes-choosing-right-barcode/"@en ;
+                rdfs:label "Barcode"@en ;
+                skos:definition "A Media Content Entity that represents one or more geometric shapes that have, as part, some Directive Information Content Entity."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Barcode&oldid=1059844765"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002015
+cco:ont00002015 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002014 ;
+                rdfs:label "Two-Dimensional Barcode"@en ;
+                skos:definition "A Barcode that represents lines of varying widths, spacing, height, and color that has, as part, some Directive Information Content Entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002016
+cco:ont00002016 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002015 ;
+                rdfs:label "Aztec Code"@en ;
+                skos:definition "A Two-Dimensional Barcode that is used by the transportation industry to scan tickets."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002017
+cco:ont00002017 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002015 ;
+                rdfs:label "Data Matrix Code"@en ;
+                skos:definition "A Two-Dimensional Barcode that represents cells arranged in rectangular patterns and is used for marking small items in logistics and operations."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002018
+cco:ont00002018 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002015 ;
+                rdfs:label "QR Code"@en ;
+                skos:definition "A Two-Dimensional Barcode that represents numeric, alphanumeric, binary, or kanji information and is used primarily for tracking and marketing."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002019
+cco:ont00002019 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002015 ;
+                rdfs:label "PDF417 Code"@en ;
+                skos:definition "A Two-Dimensional Barcode that is used in applications that require the storage of huge amounts of data."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002020
+cco:ont00002020 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002014 ;
+                rdfs:label "One-Dimensional Barcode"@en ;
+                skos:definition "A Barcode that represents parallel lines of varying widths and spacing that concretize some Directive Information Content Entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002021
+cco:ont00002021 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002020 ;
+                rdfs:label "Codabar Barcode"@en ;
+                skos:definition "A One-Dimensional Barcode that represents numbers 0-9 and the characters -$:/.+ and is intended for use by logistics and healthcare professionals."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002022
+cco:ont00002022 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002020 ;
+                rdfs:label "Code 93 Barcode"@en ;
+                skos:definition "A One-Dimensional Barcode that represents 93 ASCII characters and is used in logistics to identify packages in retail inventory, lable electornic components, and provide supplementary delivery information."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002023
+cco:ont00002023 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002020 ;
+                rdfs:label "ITF Barcode"@en ;
+                skos:definition "A One-Dimensional Barcode that represents an even number of numerical characters and is used primarily in packaging and distribution."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002024
+cco:ont00002024 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002020 ;
+                rdfs:label "MSI Plessey Barcode"@en ;
+                skos:definition "A One-Dimensional Barcode that represents an indefinite number of numerical characters and is used for inventory control and marking storage containers and shelves in warehouse environments."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002025
+cco:ont00002025 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002020 ;
+                rdfs:label "EAN Barcode"@en ;
+                skos:definition "A One-Dimensional Barcode that represents 8 or 13 numerical digits and is used to scan consumer goods."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002026
+cco:ont00002026 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002025 ;
+                rdfs:label "ISSN Barcode"@en ;
+                skos:definition "An EAN Barcode that is designed to designate a periodical."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002027
+cco:ont00002027 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002025 ;
+                rdfs:label "JAN-13 Barcode"@en ;
+                skos:definition "An EAN Barcode that is designed to designate 13 numerical digits and is used primarily in Japan to designate products at the point of sale."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002028
+cco:ont00002028 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002025 ;
+                rdfs:label "EAN-13 Barcode"@en ;
+                skos:definition "An EAN Barcode that represents 13 numerical digits and is used to designate products at the point of sale."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002029
+cco:ont00002029 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002025 ;
+                rdfs:label "EAN-8 Barcode"@en ;
+                skos:definition "An EAN Barcode that represents 8 numerical digits and is used to designate products at the point of sale."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002030
+cco:ont00002030 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002025 ;
+                rdfs:label "ISBN Barcode"@en ;
+                skos:definition "An EAN Barcode that is designed to designate a book."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002031
+cco:ont00002031 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002020 ;
+                rdfs:comment "Further variants of GS1 DataBar have not been defined here."@en ;
+                rdfs:label "GS1 DataBar Barcode"@en ;
+                skos:definition "A One-Dimensional Barcode that represents 12-14 numerical digits and is used in retail and healthcare."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002032
+cco:ont00002032 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002020 ;
+                rdfs:label "Code 39 Barcode"@en ;
+                skos:definition "A One-Dimensional Barcode that represents 39 characters that are numbers 0-9, capital letters A-Z, or the symbols -.$/+% and space and is used primarily in automotive and defense industries."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002033
+cco:ont00002033 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002020 ;
+                rdfs:label "Code 128 Barcode"@en ;
+                skos:definition "A One-Dimensional Barcode that represents to 128 ASCII characters and is used primarily in supply chains."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002034
+cco:ont00002034 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002020 ;
+                rdfs:label "UPC Barcode"@en ;
+                skos:definition "A One-Dimensional Barcode that represents 6 or 12 numerical digits and is used to scan consumer goods."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002035
+cco:ont00002035 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002034 ;
+                rdfs:label "UPC-A Barcode"@en ;
+                skos:definition "A UPC Barcode that represents 12 numerical digits."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002036
+cco:ont00002036 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002034 ;
+                rdfs:label "UPC-E Barcode"@en ;
+                skos:definition "A UPC Barcode that represents 6 numerical digits."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002037
+cco:ont00002037 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002001 ;
+                rdfs:label "Information Line"@en ;
+                skos:definition "A Media Content entity consisting of a single line or row in some Document Content entity of which it is a part."@en ;
+                skos:example "a line in a computer file that bears a portion of code for some computer program" ,
+                             "a line of data in a database" ,
+                             "a line of text in a book" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002038
+cco:ont00002038 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00000958 ;
+                rdfs:label "Document Field Content"@en ;
+                skos:altLabel "Document Field"@en ;
+                skos:definition "A Media Content Entity that is a part of some document content entity, and which  prescribes the eliciation of information to be written or selected within the document content entity."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002039
+cco:ont00002039 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002001 ;
+                rdfs:label "Document Content Entity"@en ;
+                skos:altLabel "Document"@en ;
+                skos:definition "A Media Information Content that consists of a series of paragraphs of text or diagrams that are intended to be carried by physical pieces of paper or an electronic word processor file."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Document&oldid=1057829688"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002040
+cco:ont00002040 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002039 ;
+                rdfs:label "Book"@en ;
+                skos:definition "A Document Content Entity that canonically appears as ink on paper or parchment, or other materials fastened together to hinge at one side."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Book&oldid=1063132471"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002041
+cco:ont00002041 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002039 ;
+                rdfs:label "Transcript"@en ;
+                skos:definition "A Document Content Entity that was originally recorded in a different medium."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Transcript&oldid=1038510063"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002042
+cco:ont00002042 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002039 ;
+                rdfs:label "Spreadsheet"@en ;
+                skos:definition "A Document Content Entity that canonically appears as a interactive, tabular form."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Spreadsheet&oldid=1064060503"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002043
+cco:ont00002043 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002039 ;
+                rdfs:label "Report"@en ;
+                skos:definition "A Document Content entity that conveys an account of some event, situation, or the result of some observation or inquiry."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Report&oldid=1063765657"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002044
+cco:ont00002044 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002039 ;
+                rdfs:label "Form Document"@en ;
+                skos:definition "A Document Content Entity that has Document Field Contents as parts."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/wiki/Form_(document)" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00002045
+cco:ont00002045 rdf:type owl:Class ;
+                rdfs:subClassOf cco:ont00002039 ;
+                rdfs:label "Journal Article"@en ;
+                skos:definition "A Document Content Entity that is part of a Journal Issue."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Academic_journal&oldid=1059723283"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  https://www.commoncoreontologies.org/ont00001392
+cco:ont00001392 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT-8"@en ;
+                skos:altLabel "PST"@en ,
+                              "Pacific Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001395
+cco:ont00001395 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT-3:30"@en ;
+                skos:altLabel "Newfoundland Standard Time"@en ;
+                cco:ont00001753 "NST" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001398
+cco:ont00001398 rdf:type owl:NamedIndividual ,
+                         cco:ont00000469 ;
+                rdfs:label "Global Area Reference System"@en ;
+                cco:ont00001753 "GARS" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001403
+cco:ont00001403 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+2"@en ;
+                rdfs:label "Bravo Time Zone"@en ;
+                cco:ont00001753 "B" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001405
+cco:ont00001405 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT-2"@en ;
+                skos:altLabel "BET"@en ,
+                              "Brazil Eastern Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001406
+cco:ont00001406 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT+9:30"@en ;
+                skos:altLabel "Australian Central Standard Time"@en ;
+                cco:ont00001753 "ACST" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001408
+cco:ont00001408 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-11"@en ;
+                rdfs:label "X-ray Time Zone"@en ;
+                cco:ont00001753 "X" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001412
+cco:ont00001412 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+0"@en ;
+                rdfs:label "GMT"@en ;
+                skos:altLabel "Greenwich Mean Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001414
+cco:ont00001414 rdf:type owl:NamedIndividual ,
+                         cco:ont00001328 ;
+                rdfs:comment "TT is an astronomical time standard that is a theoretical ideal designed to be free of the irregularities in Earth's rotation and is primarily used for time measurements of astronomical observations made from the surface of Earth. It was formerly called Terrestrial Dynamical Time (TDT), which was formulated to replace Ephemeris Time (ET)."@en ;
+                rdfs:label "Terrestrial Time"@en ;
+                cco:ont00001753 "TT" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001417
+cco:ont00001417 rdf:type owl:NamedIndividual ,
+                         cco:ont00001328 ;
+                rdfs:comment "ET is an astronomical time scale that was adopted as a standard in 1952 by the IAU but has since been superseded and is no longer actively used. ET is based on the ephemeris second, which was defined as a fraction of the tropical year for 1900 January 01 as calculated using Newcomb's 1895 tables of the Sun. ET was designed to avoid problems caused by variations in Earth's rotational period and was used for Solar System ephemeris calculations until being replaced by Terrestrial Dynamical Time (TDT) in 1979."@en ;
+                rdfs:label "Ephemeris Time"@en ;
+                cco:ont00001753 "ET" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001419
+cco:ont00001419 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT+5"@en ;
+                skos:altLabel "PLT"@en ,
+                              "Pakistan Lahore Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001421
+cco:ont00001421 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-6"@en ;
+                rdfs:label "Sierra Time Zone"@en ;
+                cco:ont00001753 "S" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001424
+cco:ont00001424 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+1"@en ;
+                rdfs:label "Alpha Time Zone"@en ;
+                cco:ont00001753 "A" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001430
+cco:ont00001430 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+6"@en ;
+                rdfs:label "Foxtrot Time Zone"@en ;
+                cco:ont00001753 "F" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001431
+cco:ont00001431 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-10"@en ;
+                rdfs:label "Whiskey Time Zone"@en ;
+                cco:ont00001753 "W" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001434
+cco:ont00001434 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT+1"@en ;
+                skos:altLabel "ECT"@en ,
+                              "European Central Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001436
+cco:ont00001436 rdf:type owl:NamedIndividual ,
+                         cco:ont00000630 ;
+                rdfs:label "Universal Time 1 D"@en ;
+                cco:ont00001753 "UT1D" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001439
+cco:ont00001439 rdf:type owl:NamedIndividual ,
+                         cco:ont00000263 ;
+                rdfs:label "Twenty-Four-Hour Clock Time System"@en ;
+                skos:altLabel "24-Hour Clock"@en ,
+                              "24-Hour Clock Time System"@en ,
+                              "Military Time"@en ,
+                              "Military Time System"@en ,
+                              "Twenty-Four Hour Clock Time System"@en ,
+                              "Twenty-Four-Hour Clock"@en ;
+                skos:definition "A Clock Time System for time keeping in which the Day runs from midnight to midnight and is divided into 24 Hours, indicated by the Hours passed since midnight, from 0 to 23."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=24-hour_clock&oldid=1063744105"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001440
+cco:ont00001440 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT-9"@en ;
+                skos:altLabel "AST"@en ,
+                              "Alaska Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001446
+cco:ont00001446 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Mike Time Zone is the same local time as Yankee Time Zone, but is 1 Day (i.e. 24 Hours) ahead of Yankee Time Zone as they are on opposite sides of the International Date Line."@en ,
+                             "Offset from Universal Coordinated Time = UTC+12"@en ;
+                rdfs:label "Mike Time Zone"@en ;
+                cco:ont00001753 "M" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001454
+cco:ont00001454 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+11"@en ;
+                rdfs:label "Lima Time Zone"@en ;
+                cco:ont00001753 "L" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001457
+cco:ont00001457 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-4"@en ;
+                rdfs:label "Quebec Time Zone"@en ;
+                cco:ont00001753 "Q" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001461
+cco:ont00001461 rdf:type owl:NamedIndividual ,
+                         cco:ont00001328 ;
+                rdfs:comment "TDB is a linear scaling of Barycentric Coordinate Time (TCB) and is a relativistic coordinate time scale used in astronomy as a time standard that accounts for time dilation when calculating Orbits and Ephemerides of Astronomical Bodies and interplanetary Spacecraft in the Solar System. TDB is a successor of Ephemeris Time (ET) and is nearly equivalent to the time scale Teph used for DE405 planetary and lunar ephemerides generated by the Jet Propulsion Laboratory."@en ;
+                rdfs:label "Barycentric Dynamical Time"@en ;
+                cco:ont00001753 "TDB" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001467
+cco:ont00001467 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT-4"@en ;
+                skos:altLabel "PRT"@en ,
+                              "Puerto Rico and US Virgin Islands Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001468
+cco:ont00001468 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT+10"@en ;
+                skos:altLabel "AET"@en ,
+                              "Australia Eastern Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001476
+cco:ont00001476 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT+4"@en ;
+                skos:altLabel "NET"@en ,
+                              "Near East Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001480
+cco:ont00001480 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+9"@en ;
+                rdfs:label "India Time Zone"@en ;
+                cco:ont00001753 "I" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001488
+cco:ont00001488 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-7"@en ;
+                rdfs:label "Tango Time Zone"@en ;
+                cco:ont00001753 "T" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001491
+cco:ont00001491 rdf:type owl:NamedIndividual ,
+                         cco:ont00000630 ;
+                rdfs:label "Universal Time 1 A"@en ;
+                cco:ont00001753 "UT1A" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001500
+cco:ont00001500 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+5"@en ;
+                rdfs:label "Echo Time Zone"@en ;
+                cco:ont00001753 "E" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001506
+cco:ont00001506 rdf:type owl:NamedIndividual ,
+                         cco:ont00000630 ;
+                rdfs:label "Universal Time 1 F"@en ;
+                cco:ont00001753 "UT1F" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001516
+cco:ont00001516 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-2"@en ;
+                rdfs:label "Oscar Time Zone"@en ;
+                cco:ont00001753 "O" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001524
+cco:ont00001524 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT-11"@en ;
+                skos:altLabel "MIT"@en ,
+                              "Midway Islands Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001527
+cco:ont00001527 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+8"@en ;
+                rdfs:label "Hotel Time Zone"@en ;
+                cco:ont00001753 "H" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001529
+cco:ont00001529 rdf:type owl:NamedIndividual ,
+                         cco:ont00001328 ;
+                rdfs:comment """\"TCG is a coordinate time standard intended to be used as the independent variable of time for all calculations pertaining to precession, nutation, the Moon, and artificial satellites of the Earth. It is equivalent to the proper time experienced by a clock at rest in a coordinate frame co-moving with the center of the Earth: that is, a clock that performs exactly the same movements as the Earth but is outside the Earth's gravity well. It is therefore not influenced by the gravitational time dilation caused by the Earth.\"
+From: (https://en.wikipedia.org/wiki/Geocentric_Coordinate_Time)"""@en ;
+                rdfs:label "Geocentric Coordinate Time"@en ;
+                cco:ont00001753 "TCG" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001534
+cco:ont00001534 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT+7"@en ;
+                skos:altLabel "VST"@en ,
+                              "Vietnam Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001537
+cco:ont00001537 rdf:type owl:NamedIndividual ,
+                         cco:ont00000067 ,
+                         cco:ont00000630 ;
+                rdfs:comment "UTC is a variant of Universal Time that is calculated by combining Universal Time 1 with International Atomic Time by occasionally adding leap seconds to TAI in order to maintain UTC within 0.9 seconds of UT1. The difference between UTC and UT1 is called DUT1 and always has a value between -0.9 seconds and +0.9 seconds. Coordinated Universal Time is the current basis for civil time and is the reference time for time zones, whose local times are defined based on an offset from UTC."@en ;
+                rdfs:label "Coordinated Universal Time"@en ;
+                cco:ont00001753 "UTC" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001541
+cco:ont00001541 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT+12"@en ;
+                skos:altLabel "NST"@en ,
+                              "New Zealand Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001548
+cco:ont00001548 rdf:type owl:NamedIndividual ,
+                         cco:ont00000630 ;
+                rdfs:comment "UT1R is a variant of Universal Time that is a smoothed version of UT1 by filtering out periodic variations due to tidal waves."@en ;
+                rdfs:label "Universal Time 1 R"@en ;
+                cco:ont00001753 "UT1R" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001550
+cco:ont00001550 rdf:type owl:NamedIndividual ,
+                         cco:ont00000276 ;
+                rdfs:comment "The Julian Calendar was proposed by Julius Caesar as a reform of the Roman Calendar, took effect on 1 January 46 BC, and was the predominant Calendar System in Europe until being largely replaced by the Gregorian Calendar."@en ;
+                rdfs:label "Julian Calendar"@en ;
+                skos:definition "A Solar Calendar System that has a regular Year of 365 24-Hour Days divided into 12 Months with a leap day added at the end of February every 4 Years such that the average length of a Julian Year is 365.25 Days."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Julian_calendar&oldid=1063127575"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001553
+cco:ont00001553 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT+6"@en ;
+                skos:altLabel "BST"@en ,
+                              "Bangladesh Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001554
+cco:ont00001554 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT-10"@en ;
+                skos:altLabel "HST"@en ,
+                              "Hawaii Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001565
+cco:ont00001565 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT-5"@en ;
+                skos:altLabel "EST"@en ,
+                              "Eastern Standard Time"@en ,
+                              "IET"@en ,
+                              "Indiana Eastern Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001570
+cco:ont00001570 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT+2"@en ;
+                skos:altLabel "EET"@en ,
+                              "Eastern European Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001580
+cco:ont00001580 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-3"@en ;
+                rdfs:label "Papa Time Zone"@en ;
+                cco:ont00001753 "P" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001581
+cco:ont00001581 rdf:type owl:NamedIndividual ,
+                         cco:ont00000469 ;
+                rdfs:comment """The ITRS definition fulfills the following conditions:
 1. It is geocentric, the center of mass being defined for the whole earth, including oceans and atmosphere.
 2. The unit of length is the metre (SI). This scale is consistent with the TCG time coordinate for a geocentric local frame, in agreement with IAU and IUGG (1991) resolutions. This is obtained by appropriate relativistic modelling.
 3. Its orientation was initially given by the BIH orientation at 1984.0.
 4. The time evolution of the orientation is ensured by using a no-net-rotation condition with regards to horizontal tectonic motions over the whole earth.
-From: (https://www.iers.org/IERS/EN/Science/ITRS/ITRS.html)"""@en;
-  rdfs:label "International Terrestrial Reference System"@en;
-  cco:ont00001753 "ITRS";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+From: (https://www.iers.org/IERS/EN/Science/ITRS/ITRS.html)"""@en ;
+                rdfs:label "International Terrestrial Reference System"@en ;
+                cco:ont00001753 "ITRS" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001582 a owl:NamedIndividual, cco:ont00000469;
-  rdfs:label "Universal Transverse Mercator Reference System"@en;
-  cco:ont00001753 "UTM";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001584 a owl:NamedIndividual, cco:ont00000469;
-  rdfs:label "World Geographic Reference System"@en;
-  cco:ont00001753 "WGRS";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+###  https://www.commoncoreontologies.org/ont00001582
+cco:ont00001582 rdf:type owl:NamedIndividual ,
+                         cco:ont00000469 ;
+                rdfs:label "Universal Transverse Mercator Reference System"@en ;
+                cco:ont00001753 "UTM" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001588 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT+9"@en;
-  skos:altLabel "JST"@en, "Japan Standard Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001590 a owl:NamedIndividual, cco:ont00001328;
-  rdfs:comment "TAI is a time standard the values of which are generated by calculating the weighted average of the measurements of more than 400 atomic clocks and is based on the International System of Units (SI) definition of one second equals the time it takes a Cesium-133 atom at the ground state to oscillate exactly 9,192,631,770 times. TAI is extremely precise, but does not perfectly synchronize with Earth times, which is why TAI and UT1 are both used to determine UTC. TAI serves as the main realization of TT."@en;
-  rdfs:label "International Atomic Time"@en;
-  cco:ont00001753 "TAI";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+###  https://www.commoncoreontologies.org/ont00001584
+cco:ont00001584 rdf:type owl:NamedIndividual ,
+                         cco:ont00000469 ;
+                rdfs:label "World Geographic Reference System"@en ;
+                cco:ont00001753 "WGRS" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001591 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC-8"@en;
-  rdfs:label "Uniform Time Zone"@en;
-  cco:ont00001753 "U";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001597 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT+11"@en;
-  skos:altLabel "SST"@en, "Solomon Standard Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+###  https://www.commoncoreontologies.org/ont00001588
+cco:ont00001588 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT+9"@en ;
+                skos:altLabel "JST"@en ,
+                              "Japan Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001599 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT+3:30"@en;
-  skos:altLabel "Iran Standard Time"@en, "Iran Time"@en;
-  cco:ont00001753 "IRST", "IT";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001603 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC-1"@en;
-  rdfs:label "November Time Zone"@en;
-  cco:ont00001753 "N";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+###  https://www.commoncoreontologies.org/ont00001590
+cco:ont00001590 rdf:type owl:NamedIndividual ,
+                         cco:ont00001328 ;
+                rdfs:comment "TAI is a time standard the values of which are generated by calculating the weighted average of the measurements of more than 400 atomic clocks and is based on the International System of Units (SI) definition of one second equals the time it takes a Cesium-133 atom at the ground state to oscillate exactly 9,192,631,770 times. TAI is extremely precise, but does not perfectly synchronize with Earth times, which is why TAI and UT1 are both used to determine UTC. TAI serves as the main realization of TT."@en ;
+                rdfs:label "International Atomic Time"@en ;
+                cco:ont00001753 "TAI" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001607 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC-9"@en;
-  rdfs:label "Victor Time Zone"@en;
-  cco:ont00001753 "V";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001615 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT-7"@en;
-  skos:altLabel "MST"@en, "Mountain Standard Time"@en, "PNT"@en, "Phoenix Standard Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+###  https://www.commoncoreontologies.org/ont00001591
+cco:ont00001591 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-8"@en ;
+                rdfs:label "Uniform Time Zone"@en ;
+                cco:ont00001753 "U" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001624 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC+7"@en;
-  rdfs:label "Golf Time Zone"@en;
-  cco:ont00001753 "G";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001625 a owl:NamedIndividual, cco:ont00000630;
-  rdfs:comment "UT0 is a variant of Universal Time that is measured by observing the diurnal motion of stars or extragalactic radio sources at a specific location on Earth. It does not take into consideration distorting factors, in particular polar motion, such that its value will differ based on the location it is measured at."@en;
-  rdfs:label "Universal Time 0"@en;
-  cco:ont00001753 "UT0";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+###  https://www.commoncoreontologies.org/ont00001597
+cco:ont00001597 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT+11"@en ;
+                skos:altLabel "SST"@en ,
+                              "Solomon Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001626 a owl:NamedIndividual, cco:ont00000263;
-  rdfs:label "Twelve-Hour Clock Time System"@en;
-  skos:altLabel "12-Hour Clock"@en, "12-Hour Clock Time System"@en, "Twelve Hour Clock"@en,
-    "Twelve Hour Clock Time System"@en, "Twelve-Hour Clock"@en;
-  skos:definition "A Clock Time System for keeping the Time of Day in which the Day runs from midnight to midnight and is divided into two intervals of 12 Hours each, where: the first interval begins at midnight, ends at noon, and is indicated by the suffix 'a.m.'; the second interval begins at noon, ends at midnight, and is indicated by the suffix 'p.m.'; and the midnight and noon Hours are numbered 12 with subsequent Hours numbered 1-11."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=12-hour_clock&oldid=1057602523"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001628 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC-12"@en, "Yankee Time Zone is the same local time as Mike Time Zone, but is 1 Day (i.e. 24 Hours) behind Mike Time Zone as they are on opposite sides of the International Date Line."@en;
-  rdfs:label "Yankee Time Zone"@en;
-  cco:ont00001753 "Y";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+###  https://www.commoncoreontologies.org/ont00001599
+cco:ont00001599 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT+3:30"@en ;
+                skos:altLabel "Iran Standard Time"@en ,
+                              "Iran Time"@en ;
+                cco:ont00001753 "IRST" ,
+                                "IT" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001630 a owl:NamedIndividual, cco:ont00000469;
-  rdfs:comment """\"WGS 84 is an Earth-centered, Earth-fixed terrestrial reference system and geodetic datum. WGS 84 is based on a consistent set of constants and model parameters that describe the Earth's size, shape, and gravity and geomagnetic fields. WGS 84 is the standard U.S. Department of Defense definition of a global reference system for geospatial information and is the reference system for the Global Positioning System (GPS). It is compatible with the International Terrestrial Reference System (ITRS).\"
-From: (http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf)"""@en;
-  rdfs:label "World Geodetic System 1984"@en;
-  cco:ont00001753 "WGS 84";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001634 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT-1"@en;
-  skos:altLabel "CAT"@en, "Central African Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+###  https://www.commoncoreontologies.org/ont00001603
+cco:ont00001603 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-1"@en ;
+                rdfs:label "November Time Zone"@en ;
+                cco:ont00001753 "N" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001648 a owl:NamedIndividual, cco:ont00000469, cco:ont00001351;
-  rdfs:label "Earth-Centered Earth-Fixed Coordinate System"@en;
-  skos:altLabel "Conventional Terrestrial Coordinate System"@en, "ECEF"@en, "ECR"@en,
-    "Earth Centered Earth Fixed"@en, "Earth Centered Rotational Coordinate System"@en,
-    "Earth-Centered Earth-Fixed"@en, "Earth-Centered, Earth-Fixed"@en;
-  skos:definition "A Geospatial and Cartesian Coordinate System that identifies positions using an x-axis, y-axis, and z-axis coordinate where the zero point is the center of the Earth, the z-Axis extends toward the North Pole but does not always coincide exactly with the Earth's Axis of Rotation, the x-Axis extends through the intersection of the Prime Meridian and the Equator, the y-Axis completes the right-handed system, and all three axes are fixed to the Earth such that they rotate along with the Earth."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Earth-centered,_Earth-fixed_coordinate_system&oldid=1062678600"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001658 a owl:NamedIndividual, cco:ont00001328;
-  rdfs:comment "Teph (the 'eph' is written as subscript) is an ephemeris time argument developed and calculated at the Jet Propulsion Laboratory (JPL) and implemented in a series of numerically integrated Development Ephemerides (DE), including the currently used DE405. Teph is characterized as a relativistic coordinate time that is nearly equivalent to the IAU's definition of TCB, though Teph is not currently an IAU time standard. Teph is used by the JPL to generate the ephemerides it publishes to support spacecraft navigation and astronomy."@en;
-  rdfs:label "Jet Propulsion Laboratory Ephemeris Time Argument"@en;
-  skos:altLabel "JPL Ephemeris Time"@en;
-  cco:ont00001753 "Teph";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+###  https://www.commoncoreontologies.org/ont00001607
+cco:ont00001607 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-9"@en ;
+                rdfs:label "Victor Time Zone"@en ;
+                cco:ont00001753 "V" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001660 a owl:NamedIndividual, cco:ont00000469;
-  rdfs:comment "This global main field model provides magnetic field values for any location on Earth, e.g. for  navigational purposes (declination) or as a standard for core field subtraction for aeromagnetic surveys. An updated version is adopted by International Association of Geomagnetism and Aeronomy (IAGA) every 5 years)."@en;
-  rdfs:label "International Geomagnetic Reference Field"@en;
-  cco:ont00001754 "Alken, P., Thébault, E., Beggan, C.D. et al. International Geomagnetic Reference Field: the thirteenth generation. Earth Planets Space 73, 49 (2021). https://doi.org/10.1186/s40623-020-01288-x , https://www.iaga-aiga.org/" .
 
-cco:ont00001661 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT+8"@en;
-  skos:altLabel "CTT"@en, "China Taiwan Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+###  https://www.commoncoreontologies.org/ont00001615
+cco:ont00001615 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT-7"@en ;
+                skos:altLabel "MST"@en ,
+                              "Mountain Standard Time"@en ,
+                              "PNT"@en ,
+                              "Phoenix Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001666 a owl:NamedIndividual, cco:ont00001328;
-  rdfs:comment """\"Barycentric Coordinate Time (TCB, from the French Temps-coordonnée barycentrique) is a coordinate time standard intended to be used as the independent variable of time for all calculations pertaining to orbits of planets, asteroids, comets, and interplanetary spacecraft in the Solar system. It is equivalent to the proper time experienced by a clock at rest in a coordinate frame co-moving with the barycenter of the Solar system: that is, a clock that performs exactly the same movements as the Solar system but is outside the system's gravity well. It is therefore not influenced by the gravitational time dilation caused by the Sun and the rest of the system.\"
-From: (https://en.wikipedia.org/wiki/Barycentric_Coordinate_Time)"""@en;
-  rdfs:label "Barycentric Coordinate Time"@en;
-  cco:ont00001753 "TCB";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001674 a owl:NamedIndividual, cco:ont00000276;
-  rdfs:comment "The Gregorian Calendar was instituted by Pope Gregory XIII via papal bull on 24 February 1582 as a reform of the Julian Calendar to stop the drift of the calendar with respect to the equinoxes and solstices. The Gregorian Calendar is currently the most widely used civil Calendar System in the world and is 13 days ahead of the Julian Calendar Date."@en;
-  rdfs:label "Gregorian Calendar"@en;
-  skos:definition "A Solar Calendar System that has a regular Year of 365 24-Hour Days divided into 12 Months with a leap day added at the end of February every 4 Years except Years that are evenly divisible by 100 but not 400 such that there are 97 leap Years every 400 Years and the average length of a Gregorian Year is 365.2425 Days (365 Days 5 Hours 49 Minutes 12 Seconds)."@en;
-  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Gregorian_calendar&oldid=1062360692"^^xsd:anyURI;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+###  https://www.commoncoreontologies.org/ont00001624
+cco:ont00001624 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+7"@en ;
+                rdfs:label "Golf Time Zone"@en ;
+                cco:ont00001753 "G" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001691 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT-6"@en;
-  skos:altLabel "CST"@en, "Central Standard Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001692 a owl:NamedIndividual, cco:ont00001328;
-  rdfs:comment """Unix Time is a Temporal Reference System for describing a point in time, defined as the number of seconds that have elapsed since 00:00:00 Coordinated Universal Time (UTC) Thursday, 1 January 1970 minus the number of leap seconds that have taken place since then.
-(See: https://en.wikipedia.org/wiki/Unix_time)"""@en;
-  rdfs:label "Unix Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+###  https://www.commoncoreontologies.org/ont00001625
+cco:ont00001625 rdf:type owl:NamedIndividual ,
+                         cco:ont00000630 ;
+                rdfs:comment "UT0 is a variant of Universal Time that is measured by observing the diurnal motion of stars or extragalactic radio sources at a specific location on Earth. It does not take into consideration distorting factors, in particular polar motion, such that its value will differ based on the location it is measured at."@en ;
+                rdfs:label "Universal Time 0"@en ;
+                cco:ont00001753 "UT0" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001693 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC+0"@en;
-  rdfs:label "Zulu Time Zone"@en;
-  cco:ont00001753 "Z";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001695 a owl:NamedIndividual, cco:ont00000630;
-  rdfs:comment "UT2 is a variant of Universal Time that smooths UT1 by accounting for both polar motion and variations in Earth's rotation due to seasonal factors, such as changes in vegetation and water or snow distribution."@en;
-  rdfs:label "Universal Time 2"@en;
-  cco:ont00001753 "UT2";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+###  https://www.commoncoreontologies.org/ont00001626
+cco:ont00001626 rdf:type owl:NamedIndividual ,
+                         cco:ont00000263 ;
+                rdfs:label "Twelve-Hour Clock Time System"@en ;
+                skos:altLabel "12-Hour Clock"@en ,
+                              "12-Hour Clock Time System"@en ,
+                              "Twelve Hour Clock"@en ,
+                              "Twelve Hour Clock Time System"@en ,
+                              "Twelve-Hour Clock"@en ;
+                skos:definition "A Clock Time System for keeping the Time of Day in which the Day runs from midnight to midnight and is divided into two intervals of 12 Hours each, where: the first interval begins at midnight, ends at noon, and is indicated by the suffix 'a.m.'; the second interval begins at noon, ends at midnight, and is indicated by the suffix 'p.m.'; and the midnight and noon Hours are numbered 12 with subsequent Hours numbered 1-11."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=12-hour_clock&oldid=1057602523"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001700 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Juliet time is used as an indexical to refer to local time without otherwise specifying the time zone."@en;
-  rdfs:label "Juliet Time Zone"@en;
-  cco:ont00001753 "J";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001701 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT-3"@en;
-  skos:altLabel "AGT"@en, "Argentina Standard Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+###  https://www.commoncoreontologies.org/ont00001628
+cco:ont00001628 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-12"@en ,
+                             "Yankee Time Zone is the same local time as Mike Time Zone, but is 1 Day (i.e. 24 Hours) behind Mike Time Zone as they are on opposite sides of the International Date Line."@en ;
+                rdfs:label "Yankee Time Zone"@en ;
+                cco:ont00001753 "Y" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001702 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT+5:30"@en;
-  skos:altLabel "Indian Standard Time"@en, "Sri Lanka Standard Time"@en;
-  cco:ont00001753 "IST", "SLST";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001704 a owl:NamedIndividual, cco:ont00001352;
-  rdfs:label "GMT+3"@en;
-  skos:altLabel "EAT"@en, "Eastern African Time"@en;
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+###  https://www.commoncoreontologies.org/ont00001630
+cco:ont00001630 rdf:type owl:NamedIndividual ,
+                         cco:ont00000469 ;
+                rdfs:comment """\"WGS 84 is an Earth-centered, Earth-fixed terrestrial reference system and geodetic datum. WGS 84 is based on a consistent set of constants and model parameters that describe the Earth's size, shape, and gravity and geomagnetic fields. WGS 84 is the standard U.S. Department of Defense definition of a global reference system for geospatial information and is the reference system for the Global Positioning System (GPS). It is compatible with the International Terrestrial Reference System (ITRS).\"
+From: (http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf)"""@en ;
+                rdfs:label "World Geodetic System 1984"@en ;
+                cco:ont00001753 "WGS 84" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001712 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC-5"@en;
-  rdfs:label "Romeo Time Zone"@en;
-  cco:ont00001753 "R";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001716 a owl:NamedIndividual, cco:ont00000630;
-  rdfs:comment "UT1 is a derivation of UT0 that takes into account distortions caused by polar motion and is proportional to the rotation angle of the Earth with respect to distant quasars, specifically, the International Celestial Reference Frame (ICRF). UT1 is currently the most widely used variant of Universal Time and has the same value everywhere on Earth."@en;
-  rdfs:label "Universal Time 1"@en;
-  skos:altLabel "Astronomical Time"@en;
-  cco:ont00001753 "UT1";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+###  https://www.commoncoreontologies.org/ont00001634
+cco:ont00001634 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT-1"@en ;
+                skos:altLabel "CAT"@en ,
+                              "Central African Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001723 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC+4"@en;
-  rdfs:label "Delta Time Zone"@en;
-  cco:ont00001753 "D";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001727 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC+10"@en;
-  rdfs:label "Kilo Time Zone"@en;
-  cco:ont00001753 "K";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+###  https://www.commoncoreontologies.org/ont00001648
+cco:ont00001648 rdf:type owl:NamedIndividual ,
+                         cco:ont00000469 ,
+                         cco:ont00001351 ;
+                rdfs:label "Earth-Centered Earth-Fixed Coordinate System"@en ;
+                skos:altLabel "Conventional Terrestrial Coordinate System"@en ,
+                              "ECEF"@en ,
+                              "ECR"@en ,
+                              "Earth Centered Earth Fixed"@en ,
+                              "Earth Centered Rotational Coordinate System"@en ,
+                              "Earth-Centered Earth-Fixed"@en ,
+                              "Earth-Centered, Earth-Fixed"@en ;
+                skos:definition "A Geospatial and Cartesian Coordinate System that identifies positions using an x-axis, y-axis, and z-axis coordinate where the zero point is the center of the Earth, the z-Axis extends toward the North Pole but does not always coincide exactly with the Earth's Axis of Rotation, the x-Axis extends through the intersection of the Prime Meridian and the Equator, the y-Axis completes the right-handed system, and all three axes are fixed to the Earth such that they rotate along with the Earth."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Earth-centered,_Earth-fixed_coordinate_system&oldid=1062678600"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
-cco:ont00001732 a owl:NamedIndividual, cco:ont00001235;
-  rdfs:comment "Offset from Universal Coordinated Time = UTC+3"@en;
-  rdfs:label "Charlie Time Zone"@en;
-  cco:ont00001753 "C";
-  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+###  https://www.commoncoreontologies.org/ont00001658
+cco:ont00001658 rdf:type owl:NamedIndividual ,
+                         cco:ont00001328 ;
+                rdfs:comment "Teph (the 'eph' is written as subscript) is an ephemeris time argument developed and calculated at the Jet Propulsion Laboratory (JPL) and implemented in a series of numerically integrated Development Ephemerides (DE), including the currently used DE405. Teph is characterized as a relativistic coordinate time that is nearly equivalent to the IAU's definition of TCB, though Teph is not currently an IAU time standard. Teph is used by the JPL to generate the ephemerides it publishes to support spacecraft navigation and astronomy."@en ;
+                rdfs:label "Jet Propulsion Laboratory Ephemeris Time Argument"@en ;
+                skos:altLabel "JPL Ephemeris Time"@en ;
+                cco:ont00001753 "Teph" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001660
+cco:ont00001660 rdf:type owl:NamedIndividual ,
+                         cco:ont00000469 ;
+                rdfs:comment "This global main field model provides magnetic field values for any location on Earth, e.g. for  navigational purposes (declination) or as a standard for core field subtraction for aeromagnetic surveys. An updated version is adopted by International Association of Geomagnetism and Aeronomy (IAGA) every 5 years)."@en ;
+                rdfs:label "International Geomagnetic Reference Field"@en ;
+                cco:ont00001754 "Alken, P., Thébault, E., Beggan, C.D. et al. International Geomagnetic Reference Field: the thirteenth generation. Earth Planets Space 73, 49 (2021). https://doi.org/10.1186/s40623-020-01288-x , https://www.iaga-aiga.org/" .
+
+
+###  https://www.commoncoreontologies.org/ont00001661
+cco:ont00001661 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT+8"@en ;
+                skos:altLabel "CTT"@en ,
+                              "China Taiwan Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001666
+cco:ont00001666 rdf:type owl:NamedIndividual ,
+                         cco:ont00001328 ;
+                rdfs:comment """\"Barycentric Coordinate Time (TCB, from the French Temps-coordonnée barycentrique) is a coordinate time standard intended to be used as the independent variable of time for all calculations pertaining to orbits of planets, asteroids, comets, and interplanetary spacecraft in the Solar system. It is equivalent to the proper time experienced by a clock at rest in a coordinate frame co-moving with the barycenter of the Solar system: that is, a clock that performs exactly the same movements as the Solar system but is outside the system's gravity well. It is therefore not influenced by the gravitational time dilation caused by the Sun and the rest of the system.\"
+From: (https://en.wikipedia.org/wiki/Barycentric_Coordinate_Time)"""@en ;
+                rdfs:label "Barycentric Coordinate Time"@en ;
+                cco:ont00001753 "TCB" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001674
+cco:ont00001674 rdf:type owl:NamedIndividual ,
+                         cco:ont00000276 ;
+                rdfs:comment "The Gregorian Calendar was instituted by Pope Gregory XIII via papal bull on 24 February 1582 as a reform of the Julian Calendar to stop the drift of the calendar with respect to the equinoxes and solstices. The Gregorian Calendar is currently the most widely used civil Calendar System in the world and is 13 days ahead of the Julian Calendar Date."@en ;
+                rdfs:label "Gregorian Calendar"@en ;
+                skos:definition "A Solar Calendar System that has a regular Year of 365 24-Hour Days divided into 12 Months with a leap day added at the end of February every 4 Years except Years that are evenly divisible by 100 but not 400 such that there are 97 leap Years every 400 Years and the average length of a Gregorian Year is 365.2425 Days (365 Days 5 Hours 49 Minutes 12 Seconds)."@en ;
+                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Gregorian_calendar&oldid=1062360692"^^xsd:anyURI ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001691
+cco:ont00001691 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT-6"@en ;
+                skos:altLabel "CST"@en ,
+                              "Central Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001692
+cco:ont00001692 rdf:type owl:NamedIndividual ,
+                         cco:ont00001328 ;
+                rdfs:comment """Unix Time is a Temporal Reference System for describing a point in time, defined as the number of seconds that have elapsed since 00:00:00 Coordinated Universal Time (UTC) Thursday, 1 January 1970 minus the number of leap seconds that have taken place since then.
+(See: https://en.wikipedia.org/wiki/Unix_time)"""@en ;
+                rdfs:label "Unix Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001693
+cco:ont00001693 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+0"@en ;
+                rdfs:label "Zulu Time Zone"@en ;
+                cco:ont00001753 "Z" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001695
+cco:ont00001695 rdf:type owl:NamedIndividual ,
+                         cco:ont00000630 ;
+                rdfs:comment "UT2 is a variant of Universal Time that smooths UT1 by accounting for both polar motion and variations in Earth's rotation due to seasonal factors, such as changes in vegetation and water or snow distribution."@en ;
+                rdfs:label "Universal Time 2"@en ;
+                cco:ont00001753 "UT2" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001700
+cco:ont00001700 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Juliet time is used as an indexical to refer to local time without otherwise specifying the time zone."@en ;
+                rdfs:label "Juliet Time Zone"@en ;
+                cco:ont00001753 "J" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001701
+cco:ont00001701 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT-3"@en ;
+                skos:altLabel "AGT"@en ,
+                              "Argentina Standard Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001702
+cco:ont00001702 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT+5:30"@en ;
+                skos:altLabel "Indian Standard Time"@en ,
+                              "Sri Lanka Standard Time"@en ;
+                cco:ont00001753 "IST" ,
+                                "SLST" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001704
+cco:ont00001704 rdf:type owl:NamedIndividual ,
+                         cco:ont00001352 ;
+                rdfs:label "GMT+3"@en ;
+                skos:altLabel "EAT"@en ,
+                              "Eastern African Time"@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001712
+cco:ont00001712 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC-5"@en ;
+                rdfs:label "Romeo Time Zone"@en ;
+                cco:ont00001753 "R" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001716
+cco:ont00001716 rdf:type owl:NamedIndividual ,
+                         cco:ont00000630 ;
+                rdfs:comment "UT1 is a derivation of UT0 that takes into account distortions caused by polar motion and is proportional to the rotation angle of the Earth with respect to distant quasars, specifically, the International Celestial Reference Frame (ICRF). UT1 is currently the most widely used variant of Universal Time and has the same value everywhere on Earth."@en ;
+                rdfs:label "Universal Time 1"@en ;
+                skos:altLabel "Astronomical Time"@en ;
+                cco:ont00001753 "UT1" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001723
+cco:ont00001723 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+4"@en ;
+                rdfs:label "Delta Time Zone"@en ;
+                cco:ont00001753 "D" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001727
+cco:ont00001727 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+10"@en ;
+                rdfs:label "Kilo Time Zone"@en ;
+                cco:ont00001753 "K" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001732
+cco:ont00001732 rdf:type owl:NamedIndividual ,
+                         cco:ont00001235 ;
+                rdfs:comment "Offset from Universal Coordinated Time = UTC+3"@en ;
+                rdfs:label "Charlie Time Zone"@en ;
+                cco:ont00001753 "C" ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+
+###  Generated by the OWL API (version 4.5.26.2023-07-17T20:34:13Z) https://github.com/owlcs/owlapi

--- a/src/cco-modules/InformationEntityOntology.ttl
+++ b/src/cco-modules/InformationEntityOntology.ttl
@@ -1,3 +1,4 @@
+@base <https://www.commoncoreontologies.org/InformationEntityOntology/> .
 @prefix : <https://www.commoncoreontologies.org/InformationEntityOntology/> .
 @prefix cco: <https://www.commoncoreontologies.org/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
@@ -8,2290 +9,2699 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@base <https://www.commoncoreontologies.org/InformationEntityOntology/> .
-
-<https://www.commoncoreontologies.org/InformationEntityOntology> rdf:type owl:Ontology ;
-                                                                  owl:versionIRI <https://www.commoncoreontologies.org/2024-11-06/InformationEntityOntology> ;
-                                                                  owl:imports cco:GeospatialOntology ,
-                                                                              cco:TimeOntology ;
-                                                                  dcterms:license "BSD 3-Clause: https://github.com/CommonCoreOntology/CommonCoreOntologies/blob/master/LICENSE"@en ;
-                                                                  dcterms:rights "CUBRC Inc., see full license."@en ;
-                                                                  rdfs:comment "This ontology is designed to represent generic types of information as well as the relationships between information and other entities."@en ;
-                                                                  rdfs:label "Information Entity Ontology"@en ;
-                                                                  owl:versionInfo "Version 2.0"@en .
-
-#################################################################
-#    Annotation properties
-#################################################################
-
-###  http://purl.org/dc/terms/rights
-dcterms:rights rdf:type owl:AnnotationProperty .
-
-
-###  https://www.commoncoreontologies.org/ont00001753
-cco:ont00001753 rdf:type owl:AnnotationProperty .
-
-
-###  https://www.commoncoreontologies.org/ont00001754
-cco:ont00001754 rdf:type owl:AnnotationProperty .
-
-
-###  https://www.commoncoreontologies.org/ont00001760
-cco:ont00001760 rdf:type owl:AnnotationProperty .
-
-
-#################################################################
-#    Object Properties
-#################################################################
-
-###  https://www.commoncoreontologies.org/ont00001801
-cco:ont00001801 rdf:type owl:ObjectProperty ;
-                 owl:inverseOf cco:ont00001808 ;
-                 rdfs:domain obo:BFO_0000001 ;
-                 rdfs:range cco:ont00000958 ;
-                 rdfs:label "is subject of"@en ;
-                 skos:definition "x is_subject_of y iff x is an instance of Entity and y is an instance of Information Content Entity and y is_about x."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001808
-cco:ont00001808 rdf:type owl:ObjectProperty ;
-                 rdfs:domain cco:ont00000958 ;
-                 rdfs:range obo:BFO_0000001 ;
-                 rdfs:label "is about"@en ;
-                 skos:definition "x is_about y is a primitive relationship between an instance of Information Content Entity x and an instance of Entity y."@en ;
-                 cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000136" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-
-###  https://www.commoncoreontologies.org/ont00001811
-cco:ont00001811 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001966 ;
-                 owl:inverseOf cco:ont00001963 ;
-                 rdfs:domain cco:ont00001010 ;
-                 rdfs:range obo:BFO_0000001 ;
-                 rdfs:label "is an ordinal measurement of"@en ;
-                 skos:definition "x is_an_ordinal_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity and y is_measured_by_ordinal x."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-
-###  https://www.commoncoreontologies.org/ont00001824
-cco:ont00001824 rdf:type owl:ObjectProperty ;
-                rdfs:domain cco:ont00000253 ;
-                rdfs:range cco:ont00000253 ;
-                rdfs:label "is excerpted from"@en ;
-                skos:definition "An Information Bearing Entity b1 is excerpted from another Information Bearing Entity B2 iff b1 is part of some Information Bearing Entity B1 that is carrier of some Information Content Entity C1, B2 is carrier of some Information Content Entity C2, C1 is not identical with C2, b1 is carrier of some Information Content Entity c1, b2 is an Information Bearing Entity that is part of B2 and b2 is carrier of c1 (i.e. the same Information Content Entity as borne by b1)."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001837
-cco:ont00001837 rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf obo:BFO_0000084 ;
-                owl:inverseOf cco:ont00001908 ;
-                rdfs:domain cco:ont00000829 ;
-                rdfs:range cco:ont00000253 ;
-                rdfs:label "time zone identifier used by"@en ;
-                skos:definition "x time_zone_identifier_used_by y iff y is an instance of Information Bearing Entity and x is an instance of Time Zone Identifier, such that x designates the spatial region associated with the time zone mentioned in y."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001863
-cco:ont00001863 rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf obo:BFO_0000101 ;
-                owl:inverseOf cco:ont00001961 ;
-                rdfs:domain cco:ont00000253 ;
-                rdfs:range cco:ont00000120 ;
-                rdfs:label "uses measurement unit"@en ;
-                skos:definition "y uses_measurement_unit x iff y is an instance of Information Bearing Entity and x is an instance of Measurement Unit, such that x describes the magnitude of measured physical quantity mentioned in y."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001868
-cco:ont00001868 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001966 ;
-                 owl:inverseOf cco:ont00001914 ;
-                 rdfs:domain cco:ont00000293 ;
-                 rdfs:range obo:BFO_0000001 ;
-                 rdfs:label "is a nominal measurement of"@en ;
-                 skos:definition "x is_a_nominal_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x classifies y relative to some set of shared, possibly arbitrary, characteristics."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001873
-cco:ont00001873 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001801 ;
-                 owl:inverseOf cco:ont00001938 ;
-                 rdfs:range cco:ont00001069 ;
-                 rdfs:comment "See notes for inverse property." ;
-                 rdfs:label "represented by"@en ;
-                 skos:definition "y represented_by x iff x is an instance of Representational Information Content Entity, and y is an instance of Entity, and z is carrier of x, such that x is about y in virtue of there existing an isomorphism between characteristics of z and y."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001877
-cco:ont00001877 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001966 ;
-                 owl:inverseOf cco:ont00001964 ;
-                 rdfs:domain cco:ont00001364 ;
-                 rdfs:range obo:BFO_0000001 ;
-                 rdfs:label "is an interval measurement of"@en ;
-                 skos:definition "x is_an_interval_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity and y is_measured_by_interval x."@en ;
-                 skos:example "a measurement of air temperature on the Celsius scale." ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001878
-cco:ont00001878 rdf:type owl:ObjectProperty ;
-                 owl:inverseOf cco:ont00001919 ; 
-                 rdfs:domain cco:ont00000253 ;
-                 rdfs:range obo:BFO_0000001 ;
-                 rdfs:label "is mention of"@en ;
-                 skos:definition "x is_mention_of y iff x is an instance Information Bearing Entity and y is an instance of Entity, such that x is used as a reference to y."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001879
-cco:ont00001879 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001801 ;
-                 owl:inverseOf cco:ont00001916 ;
-                 rdfs:domain obo:BFO_0000001 ;
-                 rdfs:range cco:ont00000686 ;
-                 rdfs:label "designated by"@en ;
-                 skos:definition "x designated_by y iff y is an instance of Designative Information Content Entity and x is an instance of Entity and y designates x."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001884
-cco:ont00001884 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001801 ;
-                 owl:inverseOf cco:ont00001980 ;
-                 rdfs:domain obo:BFO_0000001 ;
-                 rdfs:range cco:ont00000127 ;
-                 owl:propertyChainAxiom ( cco:ont00001917
-                                          obo:BFO_0000176
-                                        ) ;
-                 rdfs:label "condition described by"@en ;
-                 skos:definition "x condition_described_by y iff y is an instance of Performance Specification and x is an instance of Entity and y describes_condition x."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001899
-cco:ont00001899 rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf cco:ont00001942 ;
-                owl:inverseOf cco:ont00001976 ;
-                rdfs:domain cco:ont00001175 ;
-                rdfs:range cco:ont00000253 ;
-                rdfs:label "language used in"@en ;
-                skos:definition "x language_used_by y iff y is an instance of Information Bearing Entity and x is an instance of Language, such that the literal value of y is a string that is encoded according to the syntax of x."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001900
-cco:ont00001900 rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf cco:ont00001997 ;
-                owl:inverseOf cco:ont00001913 ;
-                rdfs:domain cco:ont00000469 ;
-                rdfs:range cco:ont00000253 ;
-                rdfs:label "is geospatial coordinate reference system of"@en ;
-                skos:definition "x is_geospatial_coordinate_reference_system_of y iff y is an instance of Information Bearing Entity and x is an instance of Geospatial Coordinate Reference System, such that x describes the set of standards mentioned in y."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001904
-cco:ont00001904 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001917 ;
-                 owl:inverseOf cco:ont00001966 ;
-                 rdfs:domain obo:BFO_0000001 ;
-                 rdfs:range cco:ont00001163 ;
-                 rdfs:label "is measured by"@en ;
-                 skos:definition "y is_measured_by x iff x is an instance of Measurement Information Content Entity and y is an instance of Entity and y is_a_measurement_of x."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001908
-cco:ont00001908 rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf obo:BFO_0000101 ;
-                rdfs:domain cco:ont00000253 ;
-                rdfs:range cco:ont00000829 ;
-                rdfs:label "uses time zone identifier"@en ;
-                skos:definition "x uses_time_zone_identifier y iff x is an instance of Information Bearing Entity and y is an instance of Time Zone Identifier, such that y designates the spatial region associated with the time zone mentioned in x."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001912
-cco:ont00001912 rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf obo:BFO_0000101 ;
-                owl:inverseOf cco:ont00001997 ;
-                rdfs:domain cco:ont00000253 ;
-                rdfs:range cco:ont00000398 ;
-                rdfs:label "uses reference system"@en ;
-                skos:definition "y uses_reference_system x iff y is an instance of Information Bearing Entity and x is an instance of Reference System, such that x describes the set of standards mentioned in y."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001913
-cco:ont00001913 rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf cco:ont00001912 ;
-                rdfs:domain cco:ont00000253 ;
-                rdfs:range cco:ont00000469 ;
-                rdfs:label "uses geospatial coordinate reference system"@en ;
-                skos:definition "y uses_geospatial_coordinate_reference_system x iff y is an instance of Information Bearing Entity and x is an instance of Geospatial Coordinate Reference System, such that x describes the set of standards mentioned in y."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001914
-cco:ont00001914 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001904 ;
-                 rdfs:domain obo:BFO_0000001 ;
-                 rdfs:range cco:ont00000293 ;
-                 rdfs:label "is measured by nominal"@en ;
-                 skos:definition "x is_measured_by_nominal y iff y is an instance of Nominal Measurement Information Content Entity and x is an instance of Entity, such that y classifies x relative to some set of shared, possibly arbitrary, characteristics."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001916
-cco:ont00001916 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001808 ;
-                 rdfs:domain cco:ont00000686 ;
-                 rdfs:range obo:BFO_0000001 ;
-                 rdfs:label "designates"@en ;
-                 skos:definition "x designates y iff x is an instance of a Designative Information Content Entity, and y is an instance of an Entity, such that given some context, x uniquely distinguishes y from other entities."@en ;
-                 skos:example "a URL designates the location of a Web Page on the internet" ,
-                              "a person's name designates that person" ,
-                              "a vehicle identification number designates some vehicle" ;
-                 skos:scopeNote "Given a stronger temporal interpretation, this property may be functional. For more info please refer to https://github.com/BFO-ontology/BFO-2020/tree/master/src/owl/temporal%20extensions."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001917
-cco:ont00001917 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001801 ;
-                 owl:inverseOf cco:ont00001982 ;
-                 rdfs:domain obo:BFO_0000001 ;
-                 rdfs:range cco:ont00000853 ;
-                 rdfs:label "described by"@en ;
-                 skos:definition "x described_by y iff y is an instance of Descriptive Information Content Entity and x is an instance of Entity and y describes x."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001919
-cco:ont00001919 rdf:type owl:ObjectProperty ;
-                 rdfs:domain obo:BFO_0000001 ;
-                 rdfs:range cco:ont00000253 ;
-                 rdfs:label "is mentioned by"@en ;
-                 skos:definition "x is_mentioned_by y iff y is an instance of Information Bearing Entity and x is an instance of Entity, such that y is used as a reference to x."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001920
-cco:ont00001920 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001801 ;
-                 owl:inverseOf cco:ont00001942 ;
-                 rdfs:domain obo:BFO_0000001 ;
-                 rdfs:range cco:ont00000965 ;
-                 rdfs:label "prescribed by"@en ;
-                 skos:definition "x prescribed_by y iff y is an instance of Directive Information Content Entity and x is an instance of Entity and y prescribes x."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001938
-cco:ont00001938 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001808 ;
-                 rdfs:domain cco:ont00000958 ;
-                 rdfs:range obo:BFO_0000001 ;
-                 rdfs:comment "Isomorphism between the carrier of x and the represented entity can be via a direct similarity relation, e.g., grooves in a vinyl record corresponding to sound waves, or linguistic convention, e.g., a court stenographer's transcription of spoken words, as well as others, such as encoding processes for images."@en ;
-                 rdfs:label "represents"@en ;
-                 skos:definition "x represents y iff x is an instance of Information Content Entity, y is an instance of Entity, and z is carrier of x, such that x is about y in virtue of there existing an isomorphism between characteristics of z and y."@en ;
-                 skos:scopeNote "Given a stronger temporal interpretation, this property may be functional. For more info please refer to https://github.com/BFO-ontology/BFO-2020/tree/master/src/owl/temporal%20extensions."@en ,
-                                "The relationship that is being defined here is that between the content of a photographic image and its object, between the content of a video and its objects and events, between the content of an audio recording and the sounds or events generating those sounds, or between the content of a written transcript and the verbal event that it transcribes."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001942
-cco:ont00001942 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001808 ;
-                 rdfs:domain cco:ont00000965 ;
-                 rdfs:range obo:BFO_0000001 ;
-                 rdfs:label "prescribes"@en ;
-                 skos:definition "x prescribes y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x serves as a rule or guide for y if y an Occurrent, or x serves as a model for y if y is a Continuant."@en ;
-                 skos:example "A blueprint prescribes some artifact or facility by being a model for it." ,
-                              "A professional code of conduct prescribes some realizations of a profession (role) by giving rules for how the bearer should act in those realizations." ,
-                              "An operations plan prescribes an operation by enumerating the tasks that need to be performed in order to achieve the objectives of the operation." ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001961
-cco:ont00001961 rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf obo:BFO_0000084 ;
-                rdfs:domain cco:ont00000120 ;
-                rdfs:range cco:ont00000253 ;
-                rdfs:label "is measurement unit of"@en ;
-                skos:definition "x is_measurement_unit_of y iff y is an instance of Information Bearing Entity and x is an instance of Measurement Unit, such that x describes the magnitude of measured physical quantity mentioned in y."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001963
-cco:ont00001963 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001904 ;
-                 rdfs:domain obo:BFO_0000001 ;
-                 rdfs:range cco:ont00001010 ;
-                 rdfs:label "is measured by ordinal"@en ;
-                 skos:definition "x is_measured_by_ordinal y iff y is an instance of Ordinal Measurement Information Content Entity and x is an instance of Entity, such that y describes some attribute of x relative to a scale ordered by rank."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001964
-cco:ont00001964 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001904 ;
-                 rdfs:domain obo:BFO_0000001 ;
-                 rdfs:range cco:ont00001364 ;
-                 rdfs:label "is measured by interval"@en ;
-                 skos:definition "y is_measured_by_interval x iff x is an instance of Interval Measurement Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale which has uniform intervals but has a zero value that does not correspond to an absence of the attribute being measured."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001965
-cco:ont00001965 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001904 ;
-                 owl:inverseOf cco:ont00001983 ;
-                 rdfs:domain obo:BFO_0000001 ;
-                 rdfs:range cco:ont00001022 ;
-                 rdfs:label "is measured by ratio"@en ;
-                 skos:definition "y is_measured_by_ratio x iff x is an instance of Ratio Measurement Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale having equal unit values and a zero value that corresponds to the absence of the attribute being measured."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001966
-cco:ont00001966 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001982 ;
-                 rdfs:domain cco:ont00001163 ;
-                 rdfs:range obo:BFO_0000001 ;
-                 rdfs:comment "This object property, as well as all of its children are typified as functional properties. This means that for instances x, y, and z if x is a measurement of y and x is a measurement of z, then y = z."@en ;
-                 rdfs:label "is a measurement of"@en ;
-                 skos:definition "x is_a_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to some scale or classification scheme."@en ;
-                 skos:scopeNote "Given a stronger temporal interpretation, this property may be functional. For more info please refer to https://github.com/BFO-ontology/BFO-2020/tree/master/src/owl/temporal%20extensions."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001976
-cco:ont00001976 rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf cco:ont00001920 ;
-                rdfs:domain cco:ont00000253 ;
-                rdfs:range cco:ont00001175 ;
-                rdfs:label "uses language"@en ;
-                skos:definition "x uses_language y iff x is an instance of an Information Bearing Entity and y is an instance of a Language such that the literal value of x is a string that is encoded according to the syntax of y."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001980
-cco:ont00001980 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001808 ;
-                 owl:propertyChainAxiom ( obo:BFO_0000178
-                                          cco:ont00001982
-                                        ) ;
-                 rdfs:domain cco:ont00000127 ;
-                 rdfs:range obo:BFO_0000001 ;
-                 rdfs:label "describes condition"@en ;
-                 skos:definition "p describes_condition c iff p is an instance of a Performance Specification and c is an instance of Entity and p has part d, and d is an instance of a Descriptive Information Content Entity, and p prescribes an entity s, and d describes c, and c is an entity that is causally relevant to s existing as prescribed by p."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001982
-cco:ont00001982 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001808 ;
-                 rdfs:domain cco:ont00000853 ;
-                 rdfs:range obo:BFO_0000001 ;
-                 rdfs:comment "It is possible that this relation should be a functional property, that is for all x, y, z if x describes y and x describes z then y = z. For example, if a financial report x describes the quarterly results of a company y and that same financial report describes the quarterly results of a company z, then it should be inferred that companies y and z are the same. We refrained from classifying the relation as a functional property on the concern that descriptions are multifaceted and so consequently it may be that the same report would contain descriptions of multiple entities."@en ;
-                 rdfs:label "describes"@en ;
-                 skos:definition "x describes y iff x is an instance of Descriptive Information Content Entity, and y is an instance of Entity, such that x is_about the characteristics that identify y."@en ;
-                 skos:example "the content of a newspaper article describes some current event" ,
-                              "the content of a visitor's log describes some facility visit" ,
-                              "the content of an accident report describes some accident" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001983
-cco:ont00001983 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf cco:ont00001966 ;
-                 rdfs:domain cco:ont00001022 ;
-                 rdfs:range obo:BFO_0000001 ;
-                 rdfs:label "is a ratio measurement of"@en ;
-                 skos:definition "x is_a_ratio_measurement_of y iff x is an instance of Ratio Measurement Information Content Entity and y is an instance of Entity and x describes some attribute of y relative to a scale having equal unit values and a zero value that corresponds to the absence of the attribute being measured."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001997
-cco:ont00001997 rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf obo:BFO_0000084 ;
-                rdfs:domain cco:ont00000398 ;
-                rdfs:range cco:ont00000253 ;
-                rdfs:label "is reference system of"@en ;
-                skos:definition "x is_reference_system_of y iff y is an instance of Information Bearing Entity and x is an instance of Reference System, such that x describes the set of standards mentioned in y."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-#################################################################
-#    Data properties
-#################################################################
-
-###  https://www.commoncoreontologies.org/ont00001765
-cco:ont00001765 rdf:type owl:DatatypeProperty ;
-                rdfs:domain cco:ont00000253 ;
-                rdfs:label "has text value"@en ;
-                skos:definition "A data property that has as its range a string value."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001767
-cco:ont00001767 rdf:type owl:DatatypeProperty ;
-                rdfs:domain cco:ont00000253 ;
-                rdfs:range xsd:dateTime ;
-                rdfs:label "has datetime value"@en ;
-                skos:definition "A data property that has as its value a datetime value."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001768
-cco:ont00001768 rdf:type owl:DatatypeProperty ;
-                rdfs:domain cco:ont00000253 ;
-                rdfs:range xsd:anyURI ;
-                rdfs:label "has URI value"@en ;
-                skos:definition "A data property that has as its range a URI value."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001769
-cco:ont00001769 rdf:type owl:DatatypeProperty ;
-                rdfs:domain cco:ont00000253 ;
-                rdfs:range xsd:decimal ;
-                rdfs:label "has decimal value"@en ;
-                skos:definition "A data property that has as its range a decimal value."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001770
-cco:ont00001770 rdf:type owl:DatatypeProperty ;
-                rdfs:domain cco:ont00000253 ;
-                rdfs:range xsd:double ;
-                rdfs:label "has double value"@en ;
-                skos:definition "A data property that has as its range a double value."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001771
-cco:ont00001771 rdf:type owl:DatatypeProperty ;
-                rdfs:domain cco:ont00000253 ;
-                rdfs:label "has date value"@en ;
-                skos:definition "A data property that has as its range a date value."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001772
-cco:ont00001772 rdf:type owl:DatatypeProperty ;
-                rdfs:domain cco:ont00000253 ;
-                rdfs:range xsd:boolean ;
-                rdfs:label "has boolean value"@en ;
-                skos:definition "A data property that has as its range a boolean value."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001773
-cco:ont00001773 rdf:type owl:DatatypeProperty ;
-                rdfs:domain cco:ont00000253 ;
-                rdfs:range xsd:integer ;
-                rdfs:label "has integer value"@en ;
-                skos:definition "A data property that has as its range an integer value."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-#################################################################
-#    Classes
-#################################################################
-
-###  https://www.commoncoreontologies.org/ont00000003
-cco:ont00000003 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000686 ;
-                owl:disjointWith cco:ont00000649 ;
-                rdfs:label "Designative Name"@en ;
-                skos:altLabel "Name"@en ;
-                skos:definition "A Designative Information Content Entity that consists of a string of characters that designates an entity within a specified cultural or social namespace and which is typically a word or phrase in a natural language that has an accepted cultural or social significance."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000029
-cco:ont00000029 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000745 ;
-                rdfs:label "Median Point Estimate Information Content Entity"@en ;
-                skos:altLabel "Median"@en ;
-                skos:definition "A Point Estimate Information Content Entity that is a measurement of a set of values and is equal to either the middle value or the average of the two values which separate the set into two equally populated upper and lower sets."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000067
-cco:ont00000067 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001328 ;
-                rdfs:comment "In traditional astronomical usage, civil time is mean solar time as calculated from midnight as the beginning of the Civil Day."@en ,
-                             "Note that Civil Time Reference System is more accurately represented as a Temporal Reference System that participates in an act of usage that is sanctioned by an appropriate civil authority. As such, it should be represented as a defined class."@en ;
-                rdfs:label "Civil Time Reference System"@en ;
-                skos:definition "A Temporal Reference System that is a statutory time scale as designated by civilian authorities to determine local time(s)."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000073
-cco:ont00000073 rdf:type owl:Class ;
-                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000399
-                                                           [ rdf:type owl:Restriction ;
-                                                             owl:onProperty cco:ont00001916 ;
-                                                             owl:someValuesFrom obo:BFO_0000038
-                                                           ]
-                                                         ) ;
-                                      rdf:type owl:Class
-                                    ] ;
-                rdfs:subClassOf cco:ont00000399 ;
-                rdfs:label "Temporal Interval Identifier"@en ;
-                skos:altLabel "One-Dimensional Temporal Region Identifier"@en ;
-                skos:definition "A Temporal Region Identifier that designates some Temporal Interval."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000077
-cco:ont00000077 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000649 ;
-                owl:disjointWith cco:ont00000923 ;
-                rdfs:label "Code Identifier"@en ;
-                skos:altLabel "Code ID"@en ,
-                              "ID Code"@en ,
-                              "Identifier Code"@en ;
-                skos:definition "A Non-Name Identifier that consists of a string of characters that was created and assigned according to an encoding system such that metadata can be derived from the identifier."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000080
-cco:ont00000080 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000827 ;
-                rdfs:label "Standard Time of Day Identifier"@en ;
-                skos:definition "A Time of Day Identifier that designates an approximate Temporal Instant that is part of some Day and is specified using the Hours, Minutes, and Seconds of the Day that preceded the Temporal Instant."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000087
-cco:ont00000087 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000894 ;
-                rdfs:comment "An Ordinal Date Identifier may or may not also contain a number indicating a specific Year. If both numbers are included, the ISO 8601 ordinal date format stipulates that the two numbers be formatted as YYYY-DDD or YYYYDDD where [YYYY] indicates a year and [DDD] is the day of that year, from 001 through 365 (or 366 in leap years)."@en ;
-                rdfs:label "Ordinal Date Identifier"@en ;
-                skos:altLabel "Ordinal Date"@en ;
-                skos:definition "A Decimal Date Identifier that designates some Day by using a number to indicate the sequential ordering of the Day since the beginning of the Year."@en ;
-                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ordinal_date&oldid=1061989434"^^xsd:anyURI ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000120
-cco:ont00000120 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000853 ;
-                rdfs:label "Measurement Unit"@en ;
-                skos:definition "A Descriptive Information Content Entity that describes a definite magnitude of a physical quantity, defined and adopted by convention and/or by law, that is used as a standard for measurement of the same physical quantity."@en ;
-                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Unit_of_measurement&oldid=1061038125"^^xsd:anyURI ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000124
-cco:ont00000124 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001328 ;
-                rdfs:label "Solar Time Reference System"@en ;
-                skos:definition "A Temporal Reference System that is based on the position of the Sun in the sky."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000127
-cco:ont00000127 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000965 ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty cco:ont00001980 ;
-                                  owl:someValuesFrom obo:BFO_0000001
-                                ] ;
-                rdfs:label "Performance Specification"@en ;
-                skos:definition "A Directive Information Content Entity that prescribes some aspect of the behavior of a participant in a Process given one or more operating conditions."@en ;
-                skos:example "Maximum Speed at high altitude; Rate of Ascent at 10 degrees celsius with nominal payload." ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000146
-cco:ont00000146 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001175 ;
-                owl:disjointWith cco:ont00000496 ;
-                rdfs:label "Artificial Language"@en ;
-                skos:definition "A Language that is developed through conscious planning and premeditation, rather than one that was developed through use and repetition."@en ;
-                skos:example "Esperanto" ,
-                             "Python Programming Language" ;
-                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Constructed_language&oldid=1062733589"^^xsd:anyURI ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000154
-cco:ont00000154 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000745 ;
-                rdfs:comment "While there is always at least one Mode for every set of data, it is possible for any given set of data to have multiple Modes. The Mode is typically most useful when the members of the set are all Nominal Measurement Information Content Entities."@en ;
-                rdfs:label "Mode Point Estimate Information Content Entity"@en ;
-                skos:altLabel "Mode"@en ,
-                              "Statistical Mode"@en ;
-                skos:definition "A Point Estimate Information Content Entity that is a measurement of a set of values and is equal to the value or values that occur most often in the set."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000164
-cco:ont00000164 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001010 ;
-                rdfs:label "Minimum Ordinal Measurement Information Content Entity"@en ;
-                skos:definition "An Ordinal Measurement Information Content Entity that is a measurement of some entity in virtue of it being the smallest or having the least amount relative to a nominally described set of like entities."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000186
-cco:ont00000186 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001010 ;
-                rdfs:label "Artifact Version Ordinality"@en ;
-                skos:definition "An Ordinal Measurement Information Content Entity that is about the form of an Artifact which differs in some respects from previous or future forms of that Artifact."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000203
-cco:ont00000203 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000293 ;
-                rdfs:label "Event Status Nominal Information Content Entity"@en ;
-                skos:definition "A Nominal Measurement Information Content Entity that is a measurement of the current state of a process."@en ;
-                skos:example "proposed, approved, planned, in progress, completed, failed, or successful" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000223
-cco:ont00000223 rdf:type owl:Class .
-
-
-###  https://www.commoncoreontologies.org/ont00000253
-cco:ont00000253 rdf:type owl:Class ;
-                owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000030
-                                                           [ rdf:type owl:Restriction ;
-                                                             owl:onProperty obo:BFO_0000101 ;
-                                                             owl:someValuesFrom cco:ont00000958
-                                                           ]
-                                                         ) ;
-                                      rdf:type owl:Class
-                                    ] ;
-                rdfs:subClassOf obo:BFO_0000030 ;
-                rdfs:label "Information Bearing Entity"@en ;
-                skos:altLabel "IBE"@en ;
-                skos:definition "An Object upon which an Information Content Entity generically depends."@en ;
-                cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000178"^^xsd:anyURI ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000263
-cco:ont00000263 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001328 ;
-                rdfs:comment "A single Clock Time System does not provide a complete means for identifying or measuring times. Depending on the particular Clock Time System, it may be compatible for use with one or more other Temporal Reference Systems."@en ;
-                rdfs:label "Clock Time System"@en ;
-                skos:definition "A Temporal Reference System that is a convention for keeping and displaying the Time of Day."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000275
-cco:ont00000275 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000398 ;
-                rdfs:comment "Note that, while reference systems and reference frames are treated as synonyms here, some people treat them as related but separate entities. See: http://www.ggos-portal.org/lang_en/GGOS-Portal/EN/Topics/GeodeticApplications/GeodeticReferenceSystemsAndFrames/GeodeticReferenceSystemsAndFrames.html"@en ;
-                rdfs:label "Spatial Reference System"@en ;
-                skos:altLabel "Coordinate System"@en ,
-                              "Spatial Coordinate System"@en ,
-                              "Spatial Reference Frame"@en ;
-                skos:definition "A Reference System that describes a set of standards for uniquely identifying the position of an entity or the direction of a vector within a defined spatial region by means of measurements along one or more Coordinate System Axes."@en ;
-                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Coordinate_system&oldid=1060461397"^^xsd:anyURI ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000276
-cco:ont00000276 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000891 ;
-                rdfs:label "Solar Calendar System"@en ;
-                skos:definition "A Calendar System that is designed to organize and identify dates based on the cycles of an Astronomical Body's Orbit around the Sun."@en ;
-                skos:scopeNote "Unless otherwise specified, a Solar Calendar System is assumed to be relative to the Orbit of the Earth around the Sun."@en ;
-                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Solar_calendar&oldid=1058016588"^^xsd:anyURI ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000293
-cco:ont00000293 rdf:type owl:Class ;
-                owl:equivalentClass [ owl:intersectionOf ( cco:ont00001163
-                                                           [ rdf:type owl:Restriction ;
-                                                             owl:onProperty cco:ont00001868 ;
-                                                             owl:someValuesFrom obo:BFO_0000001
-                                                           ]
-                                                         ) ;
-                                      rdf:type owl:Class
-                                    ] ;
-                rdfs:subClassOf cco:ont00001163 ;
-                owl:disjointWith cco:ont00001010 ,
-                                 cco:ont00001022 ,
-                                 cco:ont00001364 ;
-                rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en ;
-                rdfs:label "Nominal Measurement Information Content Entity"@en ;
-                skos:definition "A Measurement Information Content Entity that consists of a symbol that classifies Entities according to some shared, possibly arbitrary, characteristic."@en ;
-                skos:example "The sentence \"January 20, 1985 was a cold day in Chicago, IL\" is the carrier of a nominal measurement."@en ,
-                             "a measurement that classifies automobiles as sedans, coupes, hatchbacks, or convertibles" ,
-                             "a measurement that classifies military intelligence as strategic, operational, or tactical" ,
-                             "a measurement that classifies rocks as igneous, sedimentary, or metamorphic" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000314
-cco:ont00000314 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000019 ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty obo:BFO_0000197 ;
-                                  owl:someValuesFrom cco:ont00000253
-                                ] ;
-                rdfs:comment "Typically, an IQE will be a complex pattern made up of multiple qualities joined together spatially."@en ;
-                rdfs:label "Information Quality Entity"@en ;
-                skos:altLabel "IQE"@en ;
-                skos:definition "A Quality that concretizes some Information Content Entity."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000359
-cco:ont00000359 rdf:type owl:Class .
-
-
-###  https://www.commoncoreontologies.org/ont00000369
-cco:ont00000369 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001010 ;
-                rdfs:label "Priority Measurement Information Content Entity"@en ;
-                skos:altLabel "Criticality Measurement"@en ,
-                              "Importance Measurement"@en ,
-                              "Priority Measurement"@en ;
-                skos:definition "An Ordinal Measurement Information Content Entity that is a measurement of the relative importance of an entity."@en ;
-                skos:example "low, normal, high, urgent, or immediate priority" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000390
-cco:ont00000390 rdf:type owl:Class ;
-                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000686
-                                                           [ rdf:type owl:Restriction ;
-                                                             owl:onProperty cco:ont00001916 ;
-                                                             owl:someValuesFrom obo:BFO_0000006
-                                                           ]
-                                                         ) ;
-                                      rdf:type owl:Class
-                                    ] ;
-                rdfs:subClassOf cco:ont00000686 ;
-                rdfs:label "Spatial Region Identifier"@en ;
-                skos:definition "A Designative Information Content Entity that designates some Spatial Region."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000398
-cco:ont00000398 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000853 ;
-                rdfs:label "Reference System"@en ;
-                skos:definition "A Descriptive Information Content Entity that describes a set of standards for organizing and understanding data of the specified type or domain."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000399
-cco:ont00000399 rdf:type owl:Class ;
-                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000686
-                                                           [ rdf:type owl:Restriction ;
-                                                             owl:onProperty cco:ont00001916 ;
-                                                             owl:someValuesFrom obo:BFO_0000008
-                                                           ]
-                                                         ) ;
-                                      rdf:type owl:Class
-                                    ] ;
-                rdfs:subClassOf cco:ont00000686 ;
-                rdfs:label "Temporal Region Identifier"@en ;
-                skos:definition "A Designative Information Content Entity that designates some Temporal Region."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000406
-cco:ont00000406 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000120 ;
-                rdfs:label "Measurement Unit of Geocoordinate"@en ;
-                skos:definition "A Measurement Unit specifying the geospatial coordinates of a location."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000419
-cco:ont00000419 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000077 ;
-                rdfs:label "Part Number"@en ;
-                skos:definition "A Code Identifier that designates a type of part whose instances are designed to be part of some Artifact."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000469
-cco:ont00000469 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000275 ;
-                rdfs:label "Geospatial Coordinate Reference System"@en ;
-                skos:altLabel "Geographic Coordinate System"@en ;
-                skos:definition "A Spatial Reference System that is used to determine and identify the location of a point or object at or near the surface of the Earth."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000496
-cco:ont00000496 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001175 ;
-                rdfs:label "Natural Language"@en ;
-                skos:definition "A Language that is developed and evolves through use and repetition, rather than through conscious planning or premeditation."@en ;
-                skos:example "English" ,
-                             "Mandarin (Chinese)" ,
-                             "Spanish" ;
-                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Natural_language&oldid=1060890461"^^xsd:anyURI ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000498
-cco:ont00000498 rdf:type owl:Class .
-
-
-###  https://www.commoncoreontologies.org/ont00000529
-cco:ont00000529 rdf:type owl:Class ;
-                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000073
-                                                           [ rdf:type owl:Restriction ;
-                                                             owl:onProperty cco:ont00001916 ;
-                                                             owl:someValuesFrom cco:ont00000800
-                                                           ]
-                                                         ) ;
-                                      rdf:type owl:Class
-                                    ] ;
-                rdfs:subClassOf cco:ont00000073 ;
-                rdfs:label "Date Identifier"@en ;
-                skos:altLabel "Day Identifier"@en ;
-                skos:definition "A Temporal Interval Identifier that designates some Day."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000539
-cco:ont00000539 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001022 ;
-                rdfs:label "Count Measurement Information Content Entity"@en ;
-                skos:definition "A Ratio Measurement Information Content Entity that is a measurement of the number of members of some aggregate."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000540
-cco:ont00000540 rdf:type owl:Class ;
-                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000399
-                                                           [ rdf:type owl:Restriction ;
-                                                             owl:onProperty cco:ont00001916 ;
-                                                             owl:someValuesFrom obo:BFO_0000203
-                                                           ]
-                                                         ) ;
-                                      rdf:type owl:Class
-                                    ] ;
-                rdfs:subClassOf cco:ont00000399 ;
-                rdfs:label "Temporal Instant Identifier"@en ;
-                skos:altLabel "Zero-Dimensional Temporal Region Identifier"@en ;
-                skos:definition "A Temporal Region Identifier that designates some Temporal Instant."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000589
-cco:ont00000589 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000973 ;
-                rdfs:label "Julian Date Fraction"@en ;
-                skos:altLabel "Julian Date Time Identifier"@en ,
-                              "Julian Day Fraction"@en ;
-                skos:definition "A Decimal Time of Day Identifier that designates an approximate Temporal Instant that is part of some Julian Day."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000592
-cco:ont00000592 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001163 ;
-                rdfs:comment "'Deviation Measurement Information Content Entity' and 'Veracity Measurement Information Content Entity' are complementary notions. Deviation is a measure of whether reality conforms to an ICE (e.g., a plan or prediction), whereas Veracity is a measure of whether a Descriptive ICE conforms to reality."@en ,
-                             "Note, the term 'accuracy' is avoided due to its ambiguity between: correctness-of-performance (see: 'Reliability Measurement Information Content Entity'), correctness-of-information ('Veracity Measurement Information Content Entity'), and adherance-to-expectations (see: 'Deviation Measurement Information Content Entity')."@en ;
-                rdfs:label "Veracity Measurement Information Content Entity"@en ;
-                skos:altLabel "Accuracy of Information"@en ,
-                              "Trueness Measurement"@en ,
-                              "Veracity Measurement"@en ;
-                skos:definition "A Measurement Information Content Entity that is a measurement of the extent to which a description conforms to the reality it describes."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000604
-cco:ont00000604 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001010 ;
-                rdfs:label "Maximum Ordinal Measurement Information Content Entity"@en ;
-                skos:definition "An Ordinal Measurement Information Content Entity that is a measurement of some entity in virtue of it being the largest or having the greatest amount relative to a nominally described set of like entities."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000605
-cco:ont00000605 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000003 ;
-                rdfs:label "Abbreviated Name"@en ;
-                skos:definition "A Designative Name that is a shortened form of a Proper Name."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000626
-cco:ont00000626 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000853 ;
-                rdfs:comment "Since predictions are inherently about not-yet-existant things, the Modal Relation Ontology term 'describes' (i.e. mro:describes) should be used (instead of the standard cco:describes) to relate instances of Predictive Information Content Entity to the entities they are about."@en ;
-                rdfs:label "Predictive Information Content Entity"@en ;
-                skos:altLabel "Prediction"@en ,
-                              "Prediction Information Content Entity"@en ;
-                skos:definition "A Descriptive Information Content Entity that describes an uncertain future event."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000630
-cco:ont00000630 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000124 ;
-                rdfs:label "Universal Time Reference System"@en ;
-                skos:definition "A Solar Time Reference System that is based on the average speed of the Earth's rotation and which uses the prime meridian at 0° longitude as a reference point."@en ;
-                cco:ont00001753 "UT" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000649
-cco:ont00000649 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000686 ;
-                rdfs:label "Non-Name Identifier"@en ;
-                skos:altLabel "ID"@en ,
-                              "Identifier"@en ;
-                skos:definition "A Designative Information Content Entity that consists of a string of characters that designates an entity within a specified namespace or context, is not a Designative Name, may be automatically or randomly generated, and typically has no preexisting cultural or social significance."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000653
-cco:ont00000653 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000965 ;
-                rdfs:label "Algorithm"@en ;
-                skos:definition "A Directive Information Content Entity that prescribes some Process and contains a finite sequence of unambiguous instructions in order to achieve some Objective."@en ;
-                cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000064"^^xsd:anyURI ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000669
-cco:ont00000669 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001022 ;
-                rdfs:label "Distance Measurement Information Content Entity"@en ;
-                skos:definition "A Ratio Measurement Information Content Entity that is a measurement of a One-Dimensional Extent inhering in some Site that is externally connected to two Independent Continuants."@en ;
-                skos:scopeNote "Displacement (vector) is the shortest possible distance (scalar) between two points. Further thought is needed to adequately handle measurements of distance traveled along a path, e.g., a circuitous path or an arc (such as the surface of a planet), versus the simple case of a direct, straight line between two points."@en ,
-                               "Distance is a measure between two reference points, which are located on or in, or in some manner part of, the two obejcts for which the length of the extent between is sought. For exmple, the center point of the indentation of a ball in the sand and the edge of the foul line, the forwardmost point on a car's bumper and the closest point on the 2-dimensional plane that serves as the fiat boundary of a crosswalk, the center of an antenna array and closest point on ground."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000683
-cco:ont00000683 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000605 ;
-                rdfs:label "Diminutive Name"@en ;
-                skos:definition "An Abbreviated Name that is a familiar form of a Proper Name."@en ;
-                skos:example "Alex, Bob, Cathy" ;
-                skos:scopeNote "\"Familiar form of a Proper Name\" means: that the name is (originally) a short, affectionate version of the fuller name, used (originally) by family or friends."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000686
-cco:ont00000686 rdf:type owl:Class ;
-                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000958
-                                                           [ rdf:type owl:Restriction ;
-                                                             owl:onProperty cco:ont00001916 ;
-                                                             owl:someValuesFrom obo:BFO_0000001
-                                                           ]
-                                                         ) ;
-                                      rdf:type owl:Class
-                                    ] ;
-                rdfs:subClassOf cco:ont00000958 ;
-                owl:disjointWith cco:ont00000853 ,
-                                 cco:ont00000965 ;
-                rdfs:label "Designative Information Content Entity"@en ;
-                skos:altLabel "Designative ICE"@en ;
-                skos:definition "An Information Content Entity that consists of a set of symbols that designate some Entity."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000692
-cco:ont00000692 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001163 ;
-                rdfs:comment "Every probability measurement is made within a particular context given certain background assumptions."@en ;
-                rdfs:label "Probability Measurement Information Content Entity"@en ;
-                skos:altLabel "Likelihood Measurement"@en ,
-                              "Probability Measurement"@en ;
-                skos:definition "A Measurement Information Content Entity that is a measurement of the likelihood that a Process or Process Aggregate occurs."@en ;
-                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Probability&oldid=1059657543"^^xsd:anyURI ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000729
-cco:ont00000729 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000275 ;
-                rdfs:label "Spherical Coordinate System"@en ;
-                skos:definition "A Spatial Reference System for three-dimensional spatial regions that identifies each point using an ordered triple of numerical coordinates that consist of the radial distance of the point of interest from a fixed origin, its polar angle measured from a fixed zenith direction, and the azimuth angle of its orthogonal projection measured from a fixed direction on a reference plane that passes through the origin and is orthogonal to the zenith."@en ;
-                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Spherical_coordinate_system&oldid=1061029174"^^xsd:anyURI ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000731
-cco:ont00000731 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001163 ;
-                rdfs:comment "'Deviation Measurement Information Content Entity' and 'Veracity Measurement Information Content Entity' are complementary notions. Deviation is a measure of whether reality conforms to an ICE (e.g., a plan or prediction), whereas Veracity is a measure of whether a Descriptive ICE conforms to reality."@en ,
-                             "Note, the term 'accuracy' is avoided due to its ambiguity between: correctness-of-performance (see: 'Reliability Measurement Information Content Entity'), correctness-of-information (see: 'Veracity Measurement Information Content Entity'), and adherance-to-expectations ('Deviation Measurement Information Content Entity')."@en ;
-                rdfs:label "Deviation Measurement Information Content Entity"@en ;
-                skos:altLabel "Conformance Measurement"@en ,
-                              "Degree of Conformance"@en ,
-                              "Degree of Deviation"@en ,
-                              "Deviation Measurement"@en ;
-                skos:definition "A Measurement Information Content Entity that is a measurement of the extent to which an entity conforms to how it is expected or supposed to be."@en ;
-                skos:example "a missile impact deviates from its target location by 100 feet" ,
-                             "a satellite deviaties from its predicted orbital path by 5 kilometers" ,
-                             "an overweight piece of luggage deviates from an airline's maximum allowed weight by +10 pounds" ;
-                skos:scopeNote "In order for a Deviation to exist, an entity must first be expected, represented, prescribed, or predicted as being a certain way. Then, at a future time, this value can be compared to its actual, reported, or measured value to determine the Deviation between these values."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000735
-cco:ont00000735 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000406 ;
-                rdfs:label "Geospatial Region Bounding Box Identifier List"@en ;
-                skos:definition "A Measurement Unit of Geocoordinate that is comprised of 4 pairs of coordinates, one for each of the 4 defining points (North, West, South, East) of a Geospatial Region Bounding Box."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000745
-cco:ont00000745 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001176 ;
-                rdfs:label "Point Estimate Information Content Entity"@en ;
-                skos:altLabel "Best Estimate"@en ,
-                              "Point Estimate"@en ,
-                              "Point Estimate Measurement Information Content Entity"@en ;
-                skos:definition "An Estimate Information Content Entity that consists of a single value for the measured entity."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000749
-cco:ont00000749 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000894 ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty cco:ont00001916 ;
-                                  owl:someValuesFrom cco:ont00000498
-                                ] ;
-                rdfs:label "Julian Day Number"@en ;
-                skos:definition "A Decimal Date Identifier that designates some Julian Day by using a number to indicate the sequential ordering of the Day since the Julian Date epoch."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000800
-cco:ont00000800 rdf:type owl:Class .
-
-
-###  https://www.commoncoreontologies.org/ont00000827
-cco:ont00000827 rdf:type owl:Class ;
-                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000540
-                                                           [ rdf:type owl:Restriction ;
-                                                             owl:onProperty cco:ont00001916 ;
-                                                             owl:someValuesFrom cco:ont00000223
-                                                           ]
-                                                         ) ;
-                                      rdf:type owl:Class
-                                    ] ;
-                rdfs:subClassOf cco:ont00000540 ;
-                rdfs:label "Time of Day Identifier"@en ;
-                skos:definition "A Temporal Instant Identifier that designates some Time of Day."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000829
-cco:ont00000829 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000390 ;
-                rdfs:comment """Standards of date, time, and time zone data formats:
+# 
+# 
+# #################################################################
+# #
+# #    Annotation properties
+# #
+# #################################################################
+# 
+# 
+# http://purl.org/dc/terms/rights
+# 
+# https://www.commoncoreontologies.org/ont00001753
+# 
+# https://www.commoncoreontologies.org/ont00001754
+# 
+# https://www.commoncoreontologies.org/ont00001760
+# 
+# 
+# 
+# #################################################################
+# #
+# #    Object Properties
+# #
+# #################################################################
+# 
+# 
+# https://www.commoncoreontologies.org/ont00001801
+# 
+# https://www.commoncoreontologies.org/ont00001808
+# 
+# https://www.commoncoreontologies.org/ont00001811
+# 
+# https://www.commoncoreontologies.org/ont00001824
+# 
+# https://www.commoncoreontologies.org/ont00001837
+# 
+# https://www.commoncoreontologies.org/ont00001863
+# 
+# https://www.commoncoreontologies.org/ont00001868
+# 
+# https://www.commoncoreontologies.org/ont00001873
+# 
+# https://www.commoncoreontologies.org/ont00001877
+# 
+# https://www.commoncoreontologies.org/ont00001878
+# 
+# https://www.commoncoreontologies.org/ont00001879
+# 
+# https://www.commoncoreontologies.org/ont00001884
+# 
+# https://www.commoncoreontologies.org/ont00001899
+# 
+# https://www.commoncoreontologies.org/ont00001900
+# 
+# https://www.commoncoreontologies.org/ont00001904
+# 
+# https://www.commoncoreontologies.org/ont00001908
+# 
+# https://www.commoncoreontologies.org/ont00001912
+# 
+# https://www.commoncoreontologies.org/ont00001913
+# 
+# https://www.commoncoreontologies.org/ont00001914
+# 
+# https://www.commoncoreontologies.org/ont00001916
+# 
+# https://www.commoncoreontologies.org/ont00001917
+# 
+# https://www.commoncoreontologies.org/ont00001919
+# 
+# https://www.commoncoreontologies.org/ont00001920
+# 
+# https://www.commoncoreontologies.org/ont00001938
+# 
+# https://www.commoncoreontologies.org/ont00001942
+# 
+# https://www.commoncoreontologies.org/ont00001961
+# 
+# https://www.commoncoreontologies.org/ont00001963
+# 
+# https://www.commoncoreontologies.org/ont00001964
+# 
+# https://www.commoncoreontologies.org/ont00001965
+# 
+# https://www.commoncoreontologies.org/ont00001966
+# 
+# https://www.commoncoreontologies.org/ont00001976
+# 
+# https://www.commoncoreontologies.org/ont00001980
+# 
+# https://www.commoncoreontologies.org/ont00001982
+# 
+# https://www.commoncoreontologies.org/ont00001983
+# 
+# https://www.commoncoreontologies.org/ont00001997
+# 
+# 
+# 
+# #################################################################
+# #
+# #    Data properties
+# #
+# #################################################################
+# 
+# 
+# https://www.commoncoreontologies.org/ont00001765
+# 
+# https://www.commoncoreontologies.org/ont00001767
+# 
+# https://www.commoncoreontologies.org/ont00001768
+# 
+# https://www.commoncoreontologies.org/ont00001769
+# 
+# https://www.commoncoreontologies.org/ont00001770
+# 
+# https://www.commoncoreontologies.org/ont00001771
+# 
+# https://www.commoncoreontologies.org/ont00001772
+# 
+# https://www.commoncoreontologies.org/ont00001773
+# 
+# 
+# 
+# #################################################################
+# #
+# #    Classes
+# #
+# #################################################################
+# 
+# 
+# https://www.commoncoreontologies.org/ont00000003
+# 
+# https://www.commoncoreontologies.org/ont00000029
+# 
+# https://www.commoncoreontologies.org/ont00000067
+# 
+# https://www.commoncoreontologies.org/ont00000073
+# 
+# https://www.commoncoreontologies.org/ont00000077
+# 
+# https://www.commoncoreontologies.org/ont00000080
+# 
+# https://www.commoncoreontologies.org/ont00000087
+# 
+# https://www.commoncoreontologies.org/ont00000120
+# 
+# https://www.commoncoreontologies.org/ont00000124
+# 
+# https://www.commoncoreontologies.org/ont00000127
+# 
+# https://www.commoncoreontologies.org/ont00000146
+# 
+# https://www.commoncoreontologies.org/ont00000154
+# 
+# https://www.commoncoreontologies.org/ont00000164
+# 
+# https://www.commoncoreontologies.org/ont00000186
+# 
+# https://www.commoncoreontologies.org/ont00000203
+# 
+# https://www.commoncoreontologies.org/ont00000223
+# 
+# https://www.commoncoreontologies.org/ont00000253
+# 
+# https://www.commoncoreontologies.org/ont00000263
+# 
+# https://www.commoncoreontologies.org/ont00000275
+# 
+# https://www.commoncoreontologies.org/ont00000276
+# 
+# https://www.commoncoreontologies.org/ont00000293
+# 
+# https://www.commoncoreontologies.org/ont00000314
+# 
+# https://www.commoncoreontologies.org/ont00000326
+# 
+# https://www.commoncoreontologies.org/ont00000359
+# 
+# https://www.commoncoreontologies.org/ont00000369
+# 
+# https://www.commoncoreontologies.org/ont00000390
+# 
+# https://www.commoncoreontologies.org/ont00000398
+# 
+# https://www.commoncoreontologies.org/ont00000399
+# 
+# https://www.commoncoreontologies.org/ont00000406
+# 
+# https://www.commoncoreontologies.org/ont00000419
+# 
+# https://www.commoncoreontologies.org/ont00000469
+# 
+# https://www.commoncoreontologies.org/ont00000496
+# 
+# https://www.commoncoreontologies.org/ont00000498
+# 
+# https://www.commoncoreontologies.org/ont00000529
+# 
+# https://www.commoncoreontologies.org/ont00000539
+# 
+# https://www.commoncoreontologies.org/ont00000540
+# 
+# https://www.commoncoreontologies.org/ont00000589
+# 
+# https://www.commoncoreontologies.org/ont00000592
+# 
+# https://www.commoncoreontologies.org/ont00000604
+# 
+# https://www.commoncoreontologies.org/ont00000605
+# 
+# https://www.commoncoreontologies.org/ont00000626
+# 
+# https://www.commoncoreontologies.org/ont00000630
+# 
+# https://www.commoncoreontologies.org/ont00000649
+# 
+# https://www.commoncoreontologies.org/ont00000653
+# 
+# https://www.commoncoreontologies.org/ont00000669
+# 
+# https://www.commoncoreontologies.org/ont00000683
+# 
+# https://www.commoncoreontologies.org/ont00000686
+# 
+# https://www.commoncoreontologies.org/ont00000692
+# 
+# https://www.commoncoreontologies.org/ont00000702
+# 
+# https://www.commoncoreontologies.org/ont00000729
+# 
+# https://www.commoncoreontologies.org/ont00000731
+# 
+# https://www.commoncoreontologies.org/ont00000735
+# 
+# https://www.commoncoreontologies.org/ont00000745
+# 
+# https://www.commoncoreontologies.org/ont00000749
+# 
+# https://www.commoncoreontologies.org/ont00000798
+# 
+# https://www.commoncoreontologies.org/ont00000800
+# 
+# https://www.commoncoreontologies.org/ont00000827
+# 
+# https://www.commoncoreontologies.org/ont00000829
+# 
+# https://www.commoncoreontologies.org/ont00000833
+# 
+# https://www.commoncoreontologies.org/ont00000845
+# 
+# https://www.commoncoreontologies.org/ont00000853
+# 
+# https://www.commoncoreontologies.org/ont00000891
+# 
+# https://www.commoncoreontologies.org/ont00000894
+# 
+# https://www.commoncoreontologies.org/ont00000896
+# 
+# https://www.commoncoreontologies.org/ont00000915
+# 
+# https://www.commoncoreontologies.org/ont00000916
+# 
+# https://www.commoncoreontologies.org/ont00000923
+# 
+# https://www.commoncoreontologies.org/ont00000958
+# 
+# https://www.commoncoreontologies.org/ont00000965
+# 
+# https://www.commoncoreontologies.org/ont00000973
+# 
+# https://www.commoncoreontologies.org/ont00000990
+# 
+# https://www.commoncoreontologies.org/ont00001010
+# 
+# https://www.commoncoreontologies.org/ont00001014
+# 
+# https://www.commoncoreontologies.org/ont00001022
+
+cco:InformationEntityOntology a owl:Ontology;
+  owl:versionIRI </2024-11-06/InformationEntityOntology>;
+  owl:imports cco:GeospatialOntology, cco:TimeOntology;
+  dcterms:license "BSD 3-Clause: https://github.com/CommonCoreOntology/CommonCoreOntologies/blob/master/LICENSE"@en;
+  dcterms:rights "CUBRC Inc., see full license."@en;
+  rdfs:comment "This ontology is designed to represent generic types of information as well as the relationships between information and other entities."@en;
+  rdfs:label "Information Entity Ontology"@en;
+  owl:versionInfo "Version 2.0"@en .
+
+dcterms:rights a owl:AnnotationProperty .
+
+cco:ont00001753 a owl:AnnotationProperty .
+
+cco:ont00001754 a owl:AnnotationProperty .
+
+cco:ont00001760 a owl:AnnotationProperty .
+
+cco:ont00001801 a owl:ObjectProperty;
+  owl:inverseOf cco:ont00001808;
+  rdfs:domain obo:BFO_0000001;
+  rdfs:range cco:ont00000958;
+  rdfs:label "is subject of"@en;
+  skos:definition "x is_subject_of y iff x is an instance of Entity and y is an instance of Information Content Entity and y is_about x."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001808 a owl:ObjectProperty;
+  rdfs:domain cco:ont00000958;
+  rdfs:range obo:BFO_0000001;
+  rdfs:label "is about"@en;
+  skos:definition "x is_about y is a primitive relationship between an instance of Information Content Entity x and an instance of Entity y."@en;
+  cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000136";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001811 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001966;
+  owl:inverseOf cco:ont00001963;
+  rdfs:domain cco:ont00001010;
+  rdfs:range obo:BFO_0000001;
+  rdfs:label "is an ordinal measurement of"@en;
+  skos:definition "x is_an_ordinal_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity and y is_measured_by_ordinal x."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001824 a owl:ObjectProperty;
+  rdfs:domain cco:ont00000253;
+  rdfs:range cco:ont00000253;
+  rdfs:label "is excerpted from"@en;
+  skos:definition "An Information Bearing Entity b1 is excerpted from another Information Bearing Entity B2 iff b1 is part of some Information Bearing Entity B1 that is carrier of some Information Content Entity C1, B2 is carrier of some Information Content Entity C2, C1 is not identical with C2, b1 is carrier of some Information Content Entity c1, b2 is an Information Bearing Entity that is part of B2 and b2 is carrier of c1 (i.e. the same Information Content Entity as borne by b1)."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001837 a owl:ObjectProperty;
+  rdfs:subPropertyOf obo:BFO_0000084;
+  owl:inverseOf cco:ont00001908;
+  rdfs:domain cco:ont00000829;
+  rdfs:range cco:ont00000253;
+  rdfs:label "time zone identifier used by"@en;
+  skos:definition "x time_zone_identifier_used_by y iff y is an instance of Information Bearing Entity and x is an instance of Time Zone Identifier, such that x designates the spatial region associated with the time zone mentioned in y."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001863 a owl:ObjectProperty;
+  rdfs:subPropertyOf obo:BFO_0000101;
+  owl:inverseOf cco:ont00001961;
+  rdfs:domain cco:ont00000253;
+  rdfs:range cco:ont00000120;
+  rdfs:label "uses measurement unit"@en;
+  skos:definition "y uses_measurement_unit x iff y is an instance of Information Bearing Entity and x is an instance of Measurement Unit, such that x describes the magnitude of measured physical quantity mentioned in y."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001868 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001966;
+  owl:inverseOf cco:ont00001914;
+  rdfs:domain cco:ont00000293;
+  rdfs:range obo:BFO_0000001;
+  rdfs:label "is a nominal measurement of"@en;
+  skos:definition "x is_a_nominal_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x classifies y relative to some set of shared, possibly arbitrary, characteristics."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001873 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001801;
+  owl:inverseOf cco:ont00001938;
+  rdfs:range cco:ont00001069;
+  rdfs:comment "See notes for inverse property.";
+  rdfs:label "represented by"@en;
+  skos:definition "y represented_by x iff x is an instance of Representational Information Content Entity, and y is an instance of Entity, and z is carrier of x, such that x is about y in virtue of there existing an isomorphism between characteristics of z and y."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001877 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001966;
+  owl:inverseOf cco:ont00001964;
+  rdfs:domain cco:ont00001364;
+  rdfs:range obo:BFO_0000001;
+  rdfs:label "is an interval measurement of"@en;
+  skos:definition "x is_an_interval_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity and y is_measured_by_interval x."@en;
+  skos:example "a measurement of air temperature on the Celsius scale.";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001878 a owl:ObjectProperty;
+  owl:inverseOf cco:ont00001919;
+  rdfs:domain cco:ont00000253;
+  rdfs:range obo:BFO_0000001;
+  rdfs:label "is mention of"@en;
+  skos:definition "x is_mention_of y iff x is an instance Information Bearing Entity and y is an instance of Entity, such that x is used as a reference to y."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001879 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001801;
+  owl:inverseOf cco:ont00001916;
+  rdfs:domain obo:BFO_0000001;
+  rdfs:range cco:ont00000686;
+  rdfs:label "designated by"@en;
+  skos:definition "x designated_by y iff y is an instance of Designative Information Content Entity and x is an instance of Entity and y designates x."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001884 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001801;
+  owl:inverseOf cco:ont00001980;
+  rdfs:domain obo:BFO_0000001;
+  rdfs:range cco:ont00000127;
+  owl:propertyChainAxiom _:genid2;
+  rdfs:label "condition described by"@en;
+  skos:definition "x condition_described_by y iff y is an instance of Performance Specification and x is an instance of Entity and y describes_condition x."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid2 a rdf:List;
+  rdf:first cco:ont00001917;
+  rdf:rest _:genid1 .
+
+_:genid1 a rdf:List;
+  rdf:first obo:BFO_0000176;
+  rdf:rest rdf:nil .
+
+cco:ont00001899 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001942;
+  owl:inverseOf cco:ont00001976;
+  rdfs:domain cco:ont00001175;
+  rdfs:range cco:ont00000253;
+  rdfs:label "language used in"@en;
+  skos:definition "x language_used_by y iff y is an instance of Information Bearing Entity and x is an instance of Language, such that the literal value of y is a string that is encoded according to the syntax of x."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001900 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001997;
+  owl:inverseOf cco:ont00001913;
+  rdfs:domain cco:ont00000469;
+  rdfs:range cco:ont00000253;
+  rdfs:label "is geospatial coordinate reference system of"@en;
+  skos:definition "x is_geospatial_coordinate_reference_system_of y iff y is an instance of Information Bearing Entity and x is an instance of Geospatial Coordinate Reference System, such that x describes the set of standards mentioned in y."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001904 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001917;
+  owl:inverseOf cco:ont00001966;
+  rdfs:domain obo:BFO_0000001;
+  rdfs:range cco:ont00001163;
+  rdfs:label "is measured by"@en;
+  skos:definition "y is_measured_by x iff x is an instance of Measurement Information Content Entity and y is an instance of Entity and y is_a_measurement_of x."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001908 a owl:ObjectProperty;
+  rdfs:subPropertyOf obo:BFO_0000101;
+  rdfs:domain cco:ont00000253;
+  rdfs:range cco:ont00000829;
+  rdfs:label "uses time zone identifier"@en;
+  skos:definition "x uses_time_zone_identifier y iff x is an instance of Information Bearing Entity and y is an instance of Time Zone Identifier, such that y designates the spatial region associated with the time zone mentioned in x."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001912 a owl:ObjectProperty;
+  rdfs:subPropertyOf obo:BFO_0000101;
+  owl:inverseOf cco:ont00001997;
+  rdfs:domain cco:ont00000253;
+  rdfs:range cco:ont00000398;
+  rdfs:label "uses reference system"@en;
+  skos:definition "y uses_reference_system x iff y is an instance of Information Bearing Entity and x is an instance of Reference System, such that x describes the set of standards mentioned in y."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001913 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001912;
+  rdfs:domain cco:ont00000253;
+  rdfs:range cco:ont00000469;
+  rdfs:label "uses geospatial coordinate reference system"@en;
+  skos:definition "y uses_geospatial_coordinate_reference_system x iff y is an instance of Information Bearing Entity and x is an instance of Geospatial Coordinate Reference System, such that x describes the set of standards mentioned in y."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001914 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001904;
+  rdfs:domain obo:BFO_0000001;
+  rdfs:range cco:ont00000293;
+  rdfs:label "is measured by nominal"@en;
+  skos:definition "x is_measured_by_nominal y iff y is an instance of Nominal Measurement Information Content Entity and x is an instance of Entity, such that y classifies x relative to some set of shared, possibly arbitrary, characteristics."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001916 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001808;
+  rdfs:domain cco:ont00000686;
+  rdfs:range obo:BFO_0000001;
+  rdfs:label "designates"@en;
+  skos:definition "x designates y iff x is an instance of a Designative Information Content Entity, and y is an instance of an Entity, such that given some context, x uniquely distinguishes y from other entities."@en;
+  skos:example "a URL designates the location of a Web Page on the internet", "a person's name designates that person",
+    "a vehicle identification number designates some vehicle";
+  skos:scopeNote "Given a stronger temporal interpretation, this property may be functional. For more info please refer to https://github.com/BFO-ontology/BFO-2020/tree/master/src/owl/temporal%20extensions."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001917 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001801;
+  owl:inverseOf cco:ont00001982;
+  rdfs:domain obo:BFO_0000001;
+  rdfs:range cco:ont00000853;
+  rdfs:label "described by"@en;
+  skos:definition "x described_by y iff y is an instance of Descriptive Information Content Entity and x is an instance of Entity and y describes x."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001919 a owl:ObjectProperty;
+  rdfs:domain obo:BFO_0000001;
+  rdfs:range cco:ont00000253;
+  rdfs:label "is mentioned by"@en;
+  skos:definition "x is_mentioned_by y iff y is an instance of Information Bearing Entity and x is an instance of Entity, such that y is used as a reference to x."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001920 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001801;
+  owl:inverseOf cco:ont00001942;
+  rdfs:domain obo:BFO_0000001;
+  rdfs:range cco:ont00000965;
+  rdfs:label "prescribed by"@en;
+  skos:definition "x prescribed_by y iff y is an instance of Directive Information Content Entity and x is an instance of Entity and y prescribes x."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001938 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001808;
+  rdfs:domain cco:ont00000958;
+  rdfs:range obo:BFO_0000001;
+  rdfs:comment "Isomorphism between the carrier of x and the represented entity can be via a direct similarity relation, e.g., grooves in a vinyl record corresponding to sound waves, or linguistic convention, e.g., a court stenographer's transcription of spoken words, as well as others, such as encoding processes for images."@en;
+  rdfs:label "represents"@en;
+  skos:definition "x represents y iff x is an instance of Information Content Entity, y is an instance of Entity, and z is carrier of x, such that x is about y in virtue of there existing an isomorphism between characteristics of z and y."@en;
+  skos:scopeNote "Given a stronger temporal interpretation, this property may be functional. For more info please refer to https://github.com/BFO-ontology/BFO-2020/tree/master/src/owl/temporal%20extensions."@en,
+    "The relationship that is being defined here is that between the content of a photographic image and its object, between the content of a video and its objects and events, between the content of an audio recording and the sounds or events generating those sounds, or between the content of a written transcript and the verbal event that it transcribes."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001942 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001808;
+  rdfs:domain cco:ont00000965;
+  rdfs:range obo:BFO_0000001;
+  rdfs:label "prescribes"@en;
+  skos:definition "x prescribes y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x serves as a rule or guide for y if y an Occurrent, or x serves as a model for y if y is a Continuant."@en;
+  skos:example "A blueprint prescribes some artifact or facility by being a model for it.",
+    "A professional code of conduct prescribes some realizations of a profession (role) by giving rules for how the bearer should act in those realizations.",
+    "An operations plan prescribes an operation by enumerating the tasks that need to be performed in order to achieve the objectives of the operation.";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001961 a owl:ObjectProperty;
+  rdfs:subPropertyOf obo:BFO_0000084;
+  rdfs:domain cco:ont00000120;
+  rdfs:range cco:ont00000253;
+  rdfs:label "is measurement unit of"@en;
+  skos:definition "x is_measurement_unit_of y iff y is an instance of Information Bearing Entity and x is an instance of Measurement Unit, such that x describes the magnitude of measured physical quantity mentioned in y."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001963 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001904;
+  rdfs:domain obo:BFO_0000001;
+  rdfs:range cco:ont00001010;
+  rdfs:label "is measured by ordinal"@en;
+  skos:definition "x is_measured_by_ordinal y iff y is an instance of Ordinal Measurement Information Content Entity and x is an instance of Entity, such that y describes some attribute of x relative to a scale ordered by rank."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001964 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001904;
+  rdfs:domain obo:BFO_0000001;
+  rdfs:range cco:ont00001364;
+  rdfs:label "is measured by interval"@en;
+  skos:definition "y is_measured_by_interval x iff x is an instance of Interval Measurement Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale which has uniform intervals but has a zero value that does not correspond to an absence of the attribute being measured."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001965 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001904;
+  owl:inverseOf cco:ont00001983;
+  rdfs:domain obo:BFO_0000001;
+  rdfs:range cco:ont00001022;
+  rdfs:label "is measured by ratio"@en;
+  skos:definition "y is_measured_by_ratio x iff x is an instance of Ratio Measurement Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to a scale having equal unit values and a zero value that corresponds to the absence of the attribute being measured."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001966 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001982;
+  rdfs:domain cco:ont00001163;
+  rdfs:range obo:BFO_0000001;
+  rdfs:comment "This object property, as well as all of its children are typified as functional properties. This means that for instances x, y, and z if x is a measurement of y and x is a measurement of z, then y = z."@en;
+  rdfs:label "is a measurement of"@en;
+  skos:definition "x is_a_measurement_of y iff x is an instance of Information Content Entity and y is an instance of Entity, such that x describes some attribute of y relative to some scale or classification scheme."@en;
+  skos:scopeNote "Given a stronger temporal interpretation, this property may be functional. For more info please refer to https://github.com/BFO-ontology/BFO-2020/tree/master/src/owl/temporal%20extensions."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001976 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001920;
+  rdfs:domain cco:ont00000253;
+  rdfs:range cco:ont00001175;
+  rdfs:label "uses language"@en;
+  skos:definition "x uses_language y iff x is an instance of an Information Bearing Entity and y is an instance of a Language such that the literal value of x is a string that is encoded according to the syntax of y."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001980 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001808;
+  rdfs:domain cco:ont00000127;
+  rdfs:range obo:BFO_0000001;
+  owl:propertyChainAxiom _:genid4;
+  rdfs:label "describes condition"@en;
+  skos:definition "p describes_condition c iff p is an instance of a Performance Specification and c is an instance of Entity and p has part d, and d is an instance of a Descriptive Information Content Entity, and p prescribes an entity s, and d describes c, and c is an entity that is causally relevant to s existing as prescribed by p."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid4 a rdf:List;
+  rdf:first obo:BFO_0000178;
+  rdf:rest _:genid3 .
+
+_:genid3 a rdf:List;
+  rdf:first cco:ont00001982;
+  rdf:rest rdf:nil .
+
+cco:ont00001982 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001808;
+  rdfs:domain cco:ont00000853;
+  rdfs:range obo:BFO_0000001;
+  rdfs:comment "It is possible that this relation should be a functional property, that is for all x, y, z if x describes y and x describes z then y = z. For example, if a financial report x describes the quarterly results of a company y and that same financial report describes the quarterly results of a company z, then it should be inferred that companies y and z are the same. We refrained from classifying the relation as a functional property on the concern that descriptions are multifaceted and so consequently it may be that the same report would contain descriptions of multiple entities."@en;
+  rdfs:label "describes"@en;
+  skos:definition "x describes y iff x is an instance of Descriptive Information Content Entity, and y is an instance of Entity, such that x is_about the characteristics that identify y."@en;
+  skos:example "the content of a newspaper article describes some current event", "the content of a visitor's log describes some facility visit",
+    "the content of an accident report describes some accident";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001983 a owl:ObjectProperty;
+  rdfs:subPropertyOf cco:ont00001966;
+  rdfs:domain cco:ont00001022;
+  rdfs:range obo:BFO_0000001;
+  rdfs:label "is a ratio measurement of"@en;
+  skos:definition "x is_a_ratio_measurement_of y iff x is an instance of Ratio Measurement Information Content Entity and y is an instance of Entity and x describes some attribute of y relative to a scale having equal unit values and a zero value that corresponds to the absence of the attribute being measured."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001997 a owl:ObjectProperty;
+  rdfs:subPropertyOf obo:BFO_0000084;
+  rdfs:domain cco:ont00000398;
+  rdfs:range cco:ont00000253;
+  rdfs:label "is reference system of"@en;
+  skos:definition "x is_reference_system_of y iff y is an instance of Information Bearing Entity and x is an instance of Reference System, such that x describes the set of standards mentioned in y."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001765 a owl:DatatypeProperty;
+  rdfs:domain cco:ont00000253;
+  rdfs:label "has text value"@en;
+  skos:definition "A data property that has as its range a string value."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001767 a owl:DatatypeProperty;
+  rdfs:domain cco:ont00000253;
+  rdfs:range xsd:dateTime;
+  rdfs:label "has datetime value"@en;
+  skos:definition "A data property that has as its value a datetime value."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001768 a owl:DatatypeProperty;
+  rdfs:domain cco:ont00000253;
+  rdfs:range xsd:anyURI;
+  rdfs:label "has URI value"@en;
+  skos:definition "A data property that has as its range a URI value."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001769 a owl:DatatypeProperty;
+  rdfs:domain cco:ont00000253;
+  rdfs:range xsd:decimal;
+  rdfs:label "has decimal value"@en;
+  skos:definition "A data property that has as its range a decimal value."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001770 a owl:DatatypeProperty;
+  rdfs:domain cco:ont00000253;
+  rdfs:range xsd:double;
+  rdfs:label "has double value"@en;
+  skos:definition "A data property that has as its range a double value."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001771 a owl:DatatypeProperty;
+  rdfs:domain cco:ont00000253;
+  rdfs:label "has date value"@en;
+  skos:definition "A data property that has as its range a date value."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001772 a owl:DatatypeProperty;
+  rdfs:domain cco:ont00000253;
+  rdfs:range xsd:boolean;
+  rdfs:label "has boolean value"@en;
+  skos:definition "A data property that has as its range a boolean value."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001773 a owl:DatatypeProperty;
+  rdfs:domain cco:ont00000253;
+  rdfs:range xsd:integer;
+  rdfs:label "has integer value"@en;
+  skos:definition "A data property that has as its range an integer value."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000003 a owl:Class;
+  rdfs:subClassOf cco:ont00000686;
+  owl:disjointWith cco:ont00000649;
+  rdfs:label "Designative Name"@en;
+  skos:altLabel "Name"@en;
+  skos:definition "A Designative Information Content Entity that consists of a string of characters that designates an entity within a specified cultural or social namespace and which is typically a word or phrase in a natural language that has an accepted cultural or social significance."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000029 a owl:Class;
+  rdfs:subClassOf cco:ont00000745;
+  rdfs:label "Median Point Estimate Information Content Entity"@en;
+  skos:altLabel "Median"@en;
+  skos:definition "A Point Estimate Information Content Entity that is a measurement of a set of values and is equal to either the middle value or the average of the two values which separate the set into two equally populated upper and lower sets."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000067 a owl:Class;
+  rdfs:subClassOf cco:ont00001328;
+  rdfs:comment "In traditional astronomical usage, civil time is mean solar time as calculated from midnight as the beginning of the Civil Day."@en,
+    "Note that Civil Time Reference System is more accurately represented as a Temporal Reference System that participates in an act of usage that is sanctioned by an appropriate civil authority. As such, it should be represented as a defined class."@en;
+  rdfs:label "Civil Time Reference System"@en;
+  skos:definition "A Temporal Reference System that is a statutory time scale as designated by civilian authorities to determine local time(s)."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000073 a owl:Class;
+  owl:equivalentClass _:genid5;
+  rdfs:subClassOf cco:ont00000399;
+  rdfs:label "Temporal Interval Identifier"@en;
+  skos:altLabel "One-Dimensional Temporal Region Identifier"@en;
+  skos:definition "A Temporal Region Identifier that designates some Temporal Interval."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid5 a owl:Class;
+  owl:intersectionOf _:genid8 .
+
+_:genid8 a rdf:List;
+  rdf:first cco:ont00000399;
+  rdf:rest _:genid6 .
+
+_:genid6 a rdf:List;
+  rdf:first _:genid7;
+  rdf:rest rdf:nil .
+
+_:genid7 a owl:Restriction;
+  owl:someValuesFrom obo:BFO_0000038;
+  owl:onProperty cco:ont00001916 .
+
+cco:ont00000077 a owl:Class;
+  rdfs:subClassOf cco:ont00000649;
+  owl:disjointWith cco:ont00000923;
+  rdfs:label "Code Identifier"@en;
+  skos:altLabel "Code ID"@en, "ID Code"@en, "Identifier Code"@en;
+  skos:definition "A Non-Name Identifier that consists of a string of characters that was created and assigned according to an encoding system such that metadata can be derived from the identifier."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000080 a owl:Class;
+  rdfs:subClassOf cco:ont00000827;
+  rdfs:label "Standard Time of Day Identifier"@en;
+  skos:definition "A Time of Day Identifier that designates an approximate Temporal Instant that is part of some Day and is specified using the Hours, Minutes, and Seconds of the Day that preceded the Temporal Instant."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000087 a owl:Class;
+  rdfs:subClassOf cco:ont00000894;
+  rdfs:comment "An Ordinal Date Identifier may or may not also contain a number indicating a specific Year. If both numbers are included, the ISO 8601 ordinal date format stipulates that the two numbers be formatted as YYYY-DDD or YYYYDDD where [YYYY] indicates a year and [DDD] is the day of that year, from 001 through 365 (or 366 in leap years)."@en;
+  rdfs:label "Ordinal Date Identifier"@en;
+  skos:altLabel "Ordinal Date"@en;
+  skos:definition "A Decimal Date Identifier that designates some Day by using a number to indicate the sequential ordering of the Day since the beginning of the Year."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Ordinal_date&oldid=1061989434"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000120 a owl:Class;
+  rdfs:subClassOf cco:ont00000853;
+  rdfs:label "Measurement Unit"@en;
+  skos:definition "A Descriptive Information Content Entity that describes a definite magnitude of a physical quantity, defined and adopted by convention and/or by law, that is used as a standard for measurement of the same physical quantity."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Unit_of_measurement&oldid=1061038125"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000124 a owl:Class;
+  rdfs:subClassOf cco:ont00001328;
+  rdfs:label "Solar Time Reference System"@en;
+  skos:definition "A Temporal Reference System that is based on the position of the Sun in the sky."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000127 a owl:Class;
+  rdfs:subClassOf cco:ont00000965, _:genid9;
+  rdfs:label "Performance Specification"@en;
+  skos:definition "A Directive Information Content Entity that prescribes some aspect of the behavior of a participant in a Process given one or more operating conditions."@en;
+  skos:example "Maximum Speed at high altitude; Rate of Ascent at 10 degrees celsius with nominal payload.";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid9 a owl:Restriction;
+  owl:someValuesFrom obo:BFO_0000001;
+  owl:onProperty cco:ont00001980 .
+
+cco:ont00000146 a owl:Class;
+  rdfs:subClassOf cco:ont00001175;
+  owl:disjointWith cco:ont00000496;
+  rdfs:label "Artificial Language"@en;
+  skos:definition "A Language that is developed through conscious planning and premeditation, rather than one that was developed through use and repetition."@en;
+  skos:example "Esperanto", "Python Programming Language";
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Constructed_language&oldid=1062733589"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000154 a owl:Class;
+  rdfs:subClassOf cco:ont00000745;
+  rdfs:comment "While there is always at least one Mode for every set of data, it is possible for any given set of data to have multiple Modes. The Mode is typically most useful when the members of the set are all Nominal Measurement Information Content Entities."@en;
+  rdfs:label "Mode Point Estimate Information Content Entity"@en;
+  skos:altLabel "Mode"@en, "Statistical Mode"@en;
+  skos:definition "A Point Estimate Information Content Entity that is a measurement of a set of values and is equal to the value or values that occur most often in the set."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000164 a owl:Class;
+  rdfs:subClassOf cco:ont00001010;
+  rdfs:label "Minimum Ordinal Measurement Information Content Entity"@en;
+  skos:definition "An Ordinal Measurement Information Content Entity that is a measurement of some entity in virtue of it being the smallest or having the least amount relative to a nominally described set of like entities."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000186 a owl:Class;
+  rdfs:subClassOf cco:ont00001010;
+  rdfs:label "Artifact Version Ordinality"@en;
+  skos:definition "An Ordinal Measurement Information Content Entity that is about the form of an Artifact which differs in some respects from previous or future forms of that Artifact."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000203 a owl:Class;
+  rdfs:subClassOf cco:ont00000293;
+  rdfs:label "Event Status Nominal Information Content Entity"@en;
+  skos:definition "A Nominal Measurement Information Content Entity that is a measurement of the current state of a process."@en;
+  skos:example "proposed, approved, planned, in progress, completed, failed, or successful";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000223 a owl:Class .
+
+cco:ont00000253 a owl:Class;
+  owl:equivalentClass _:genid10;
+  rdfs:subClassOf obo:BFO_0000030;
+  rdfs:comment "This class continues to use the word ‘bearing’ in its rdfslabel because of potential confusion with the acronym ‘ICE’, which is widely used for information content entity."@en;
+  rdfs:label "Information Bearing Entity"@en;
+  skos:altLabel "IBE"@en, "Information Carrying Entity"@en;
+  skos:definition "An Object upon which an Information Content Entity generically depends."@en;
+  cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000178"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid10 a owl:Class;
+  owl:intersectionOf _:genid13 .
+
+_:genid13 a rdf:List;
+  rdf:first obo:BFO_0000030;
+  rdf:rest _:genid11 .
+
+_:genid11 a rdf:List;
+  rdf:first _:genid12;
+  rdf:rest rdf:nil .
+
+_:genid12 a owl:Restriction;
+  owl:someValuesFrom cco:ont00000958;
+  owl:onProperty obo:BFO_0000101 .
+
+cco:ont00000263 a owl:Class;
+  rdfs:subClassOf cco:ont00001328;
+  rdfs:comment "A single Clock Time System does not provide a complete means for identifying or measuring times. Depending on the particular Clock Time System, it may be compatible for use with one or more other Temporal Reference Systems."@en;
+  rdfs:label "Clock Time System"@en;
+  skos:definition "A Temporal Reference System that is a convention for keeping and displaying the Time of Day."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000275 a owl:Class;
+  rdfs:subClassOf cco:ont00000398;
+  rdfs:comment "Note that, while reference systems and reference frames are treated as synonyms here, some people treat them as related but separate entities. See: http://www.ggos-portal.org/lang_en/GGOS-Portal/EN/Topics/GeodeticApplications/GeodeticReferenceSystemsAndFrames/GeodeticReferenceSystemsAndFrames.html"@en;
+  rdfs:label "Spatial Reference System"@en;
+  skos:altLabel "Coordinate System"@en, "Spatial Coordinate System"@en, "Spatial Reference Frame"@en;
+  skos:definition "A Reference System that describes a set of standards for uniquely identifying the position of an entity or the direction of a vector within a defined spatial region by means of measurements along one or more Coordinate System Axes."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Coordinate_system&oldid=1060461397"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000276 a owl:Class;
+  rdfs:subClassOf cco:ont00000891;
+  rdfs:label "Solar Calendar System"@en;
+  skos:definition "A Calendar System that is designed to organize and identify dates based on the cycles of an Astronomical Body's Orbit around the Sun."@en;
+  skos:scopeNote "Unless otherwise specified, a Solar Calendar System is assumed to be relative to the Orbit of the Earth around the Sun."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Solar_calendar&oldid=1058016588"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000293 a owl:Class;
+  owl:equivalentClass _:genid14;
+  rdfs:subClassOf cco:ont00001163;
+  owl:disjointWith cco:ont00001010, cco:ont00001022, cco:ont00001364;
+  rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en;
+  rdfs:label "Nominal Measurement Information Content Entity"@en;
+  skos:definition "A Measurement Information Content Entity that consists of a symbol that classifies Entities according to some shared, possibly arbitrary, characteristic."@en;
+  skos:example "The sentence \"January 20, 1985 was a cold day in Chicago, IL\" is the carrier of a nominal measurement."@en,
+    "a measurement that classifies automobiles as sedans, coupes, hatchbacks, or convertibles",
+    "a measurement that classifies military intelligence as strategic, operational, or tactical",
+    "a measurement that classifies rocks as igneous, sedimentary, or metamorphic";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid14 a owl:Class;
+  owl:intersectionOf _:genid17 .
+
+_:genid17 a rdf:List;
+  rdf:first cco:ont00001163;
+  rdf:rest _:genid15 .
+
+_:genid15 a rdf:List;
+  rdf:first _:genid16;
+  rdf:rest rdf:nil .
+
+_:genid16 a owl:Restriction;
+  owl:someValuesFrom obo:BFO_0000001;
+  owl:onProperty cco:ont00001868 .
+
+cco:ont00000314 a owl:Class;
+  rdfs:subClassOf obo:BFO_0000019, _:genid18;
+  rdfs:comment "Typically, an IQE will be a complex pattern made up of multiple qualities joined together spatially."@en;
+  rdfs:label "Information Quality Entity"@en;
+  skos:altLabel "IQE"@en;
+  skos:definition "A Quality that concretizes some Information Content Entity."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid18 a owl:Restriction;
+  owl:someValuesFrom cco:ont00000253;
+  owl:onProperty obo:BFO_0000197 .
+
+cco:ont00000326 a owl:Class .
+
+cco:ont00000359 a owl:Class .
+
+cco:ont00000369 a owl:Class;
+  rdfs:subClassOf cco:ont00001010;
+  rdfs:label "Priority Measurement Information Content Entity"@en;
+  skos:altLabel "Criticality Measurement"@en, "Importance Measurement"@en, "Priority Measurement"@en;
+  skos:definition "An Ordinal Measurement Information Content Entity that is a measurement of the relative importance of an entity."@en;
+  skos:example "low, normal, high, urgent, or immediate priority";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000390 a owl:Class;
+  owl:equivalentClass _:genid19;
+  rdfs:subClassOf cco:ont00000686;
+  rdfs:label "Spatial Region Identifier"@en;
+  skos:definition "A Designative Information Content Entity that designates some Spatial Region."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid19 a owl:Class;
+  owl:intersectionOf _:genid22 .
+
+_:genid22 a rdf:List;
+  rdf:first cco:ont00000686;
+  rdf:rest _:genid20 .
+
+_:genid20 a rdf:List;
+  rdf:first _:genid21;
+  rdf:rest rdf:nil .
+
+_:genid21 a owl:Restriction;
+  owl:someValuesFrom obo:BFO_0000006;
+  owl:onProperty cco:ont00001916 .
+
+cco:ont00000398 a owl:Class;
+  rdfs:subClassOf cco:ont00000853;
+  rdfs:label "Reference System"@en;
+  skos:definition "A Descriptive Information Content Entity that describes a set of standards for organizing and understanding data of the specified type or domain."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000399 a owl:Class;
+  owl:equivalentClass _:genid23;
+  rdfs:subClassOf cco:ont00000686;
+  rdfs:label "Temporal Region Identifier"@en;
+  skos:definition "A Designative Information Content Entity that designates some Temporal Region."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid23 a owl:Class;
+  owl:intersectionOf _:genid26 .
+
+_:genid26 a rdf:List;
+  rdf:first cco:ont00000686;
+  rdf:rest _:genid24 .
+
+_:genid24 a rdf:List;
+  rdf:first _:genid25;
+  rdf:rest rdf:nil .
+
+_:genid25 a owl:Restriction;
+  owl:someValuesFrom obo:BFO_0000008;
+  owl:onProperty cco:ont00001916 .
+
+cco:ont00000406 a owl:Class;
+  rdfs:subClassOf cco:ont00000120;
+  rdfs:label "Measurement Unit of Geocoordinate"@en;
+  skos:definition "A Measurement Unit specifying the geospatial coordinates of a location."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000419 a owl:Class;
+  rdfs:subClassOf cco:ont00000077;
+  rdfs:label "Part Number"@en;
+  skos:definition "A Code Identifier that designates a type of part whose instances are designed to be part of some Artifact."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000469 a owl:Class;
+  rdfs:subClassOf cco:ont00000275;
+  rdfs:label "Geospatial Coordinate Reference System"@en;
+  skos:altLabel "Geographic Coordinate System"@en;
+  skos:definition "A Spatial Reference System that is used to determine and identify the location of a point or object at or near the surface of the Earth."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000496 a owl:Class;
+  rdfs:subClassOf cco:ont00001175;
+  rdfs:label "Natural Language"@en;
+  skos:definition "A Language that is developed and evolves through use and repetition, rather than through conscious planning or premeditation."@en;
+  skos:example "English", "Mandarin (Chinese)", "Spanish";
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Natural_language&oldid=1060890461"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000498 a owl:Class .
+
+cco:ont00000529 a owl:Class;
+  owl:equivalentClass _:genid27;
+  rdfs:subClassOf cco:ont00000073;
+  rdfs:label "Date Identifier"@en;
+  skos:altLabel "Day Identifier"@en;
+  skos:definition "A Temporal Interval Identifier that designates some Day."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid27 a owl:Class;
+  owl:intersectionOf _:genid30 .
+
+_:genid30 a rdf:List;
+  rdf:first cco:ont00000073;
+  rdf:rest _:genid28 .
+
+_:genid28 a rdf:List;
+  rdf:first _:genid29;
+  rdf:rest rdf:nil .
+
+_:genid29 a owl:Restriction;
+  owl:someValuesFrom cco:ont00000800;
+  owl:onProperty cco:ont00001916 .
+
+cco:ont00000539 a owl:Class;
+  rdfs:subClassOf cco:ont00001022;
+  rdfs:label "Count Measurement Information Content Entity"@en;
+  skos:definition "A Ratio Measurement Information Content Entity that is a measurement of the number of members of some aggregate."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000540 a owl:Class;
+  owl:equivalentClass _:genid31;
+  rdfs:subClassOf cco:ont00000399;
+  rdfs:label "Temporal Instant Identifier"@en;
+  skos:altLabel "Zero-Dimensional Temporal Region Identifier"@en;
+  skos:definition "A Temporal Region Identifier that designates some Temporal Instant."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid31 a owl:Class;
+  owl:intersectionOf _:genid34 .
+
+_:genid34 a rdf:List;
+  rdf:first cco:ont00000399;
+  rdf:rest _:genid32 .
+
+_:genid32 a rdf:List;
+  rdf:first _:genid33;
+  rdf:rest rdf:nil .
+
+_:genid33 a owl:Restriction;
+  owl:someValuesFrom obo:BFO_0000203;
+  owl:onProperty cco:ont00001916 .
+
+cco:ont00000589 a owl:Class;
+  rdfs:subClassOf cco:ont00000973;
+  rdfs:label "Julian Date Fraction"@en;
+  skos:altLabel "Julian Date Time Identifier"@en, "Julian Day Fraction"@en;
+  skos:definition "A Decimal Time of Day Identifier that designates an approximate Temporal Instant that is part of some Julian Day."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000592 a owl:Class;
+  rdfs:subClassOf cco:ont00001163;
+  rdfs:comment "'Deviation Measurement Information Content Entity' and 'Veracity Measurement Information Content Entity' are complementary notions. Deviation is a measure of whether reality conforms to an ICE (e.g., a plan or prediction), whereas Veracity is a measure of whether a Descriptive ICE conforms to reality."@en,
+    "Note, the term 'accuracy' is avoided due to its ambiguity between: correctness-of-performance (see: 'Reliability Measurement Information Content Entity'), correctness-of-information ('Veracity Measurement Information Content Entity'), and adherance-to-expectations (see: 'Deviation Measurement Information Content Entity')."@en;
+  rdfs:label "Veracity Measurement Information Content Entity"@en;
+  skos:altLabel "Accuracy of Information"@en, "Trueness Measurement"@en, "Veracity Measurement"@en;
+  skos:definition "A Measurement Information Content Entity that is a measurement of the extent to which a description conforms to the reality it describes."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000604 a owl:Class;
+  rdfs:subClassOf cco:ont00001010;
+  rdfs:label "Maximum Ordinal Measurement Information Content Entity"@en;
+  skos:definition "An Ordinal Measurement Information Content Entity that is a measurement of some entity in virtue of it being the largest or having the greatest amount relative to a nominally described set of like entities."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000605 a owl:Class;
+  rdfs:subClassOf cco:ont00000003;
+  rdfs:label "Abbreviated Name"@en;
+  skos:definition "A Designative Name that is a shortened form of a Proper Name."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000626 a owl:Class;
+  rdfs:subClassOf cco:ont00000853;
+  rdfs:comment "Since predictions are inherently about not-yet-existant things, the Modal Relation Ontology term 'describes' (i.e. mro:describes) should be used (instead of the standard cco:describes) to relate instances of Predictive Information Content Entity to the entities they are about."@en;
+  rdfs:label "Predictive Information Content Entity"@en;
+  skos:altLabel "Prediction"@en, "Prediction Information Content Entity"@en;
+  skos:definition "A Descriptive Information Content Entity that describes an uncertain future event."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000630 a owl:Class;
+  rdfs:subClassOf cco:ont00000124;
+  rdfs:label "Universal Time Reference System"@en;
+  skos:definition "A Solar Time Reference System that is based on the average speed of the Earth's rotation and which uses the prime meridian at 0° longitude as a reference point."@en;
+  cco:ont00001753 "UT";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000649 a owl:Class;
+  rdfs:subClassOf cco:ont00000686;
+  rdfs:label "Non-Name Identifier"@en;
+  skos:altLabel "ID"@en, "Identifier"@en;
+  skos:definition "A Designative Information Content Entity that consists of a string of characters that designates an entity within a specified namespace or context, is not a Designative Name, may be automatically or randomly generated, and typically has no preexisting cultural or social significance."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000653 a owl:Class;
+  rdfs:subClassOf cco:ont00000965;
+  rdfs:label "Algorithm"@en;
+  skos:definition "A Directive Information Content Entity that prescribes some Process and contains a finite sequence of unambiguous instructions in order to achieve some Objective."@en;
+  cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000064"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000669 a owl:Class;
+  rdfs:subClassOf cco:ont00001022;
+  rdfs:label "Distance Measurement Information Content Entity"@en;
+  skos:definition "A Ratio Measurement Information Content Entity that is a measurement of a One-Dimensional Extent inhering in some Site that is externally connected to two Independent Continuants."@en;
+  skos:scopeNote "Displacement (vector) is the shortest possible distance (scalar) between two points. Further thought is needed to adequately handle measurements of distance traveled along a path, e.g., a circuitous path or an arc (such as the surface of a planet), versus the simple case of a direct, straight line between two points."@en,
+    "Distance is a measure between two reference points, which are located on or in, or in some manner part of, the two obejcts for which the length of the extent between is sought. For exmple, the center point of the indentation of a ball in the sand and the edge of the foul line, the forwardmost point on a car's bumper and the closest point on the 2-dimensional plane that serves as the fiat boundary of a crosswalk, the center of an antenna array and closest point on ground."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000683 a owl:Class;
+  rdfs:subClassOf cco:ont00000605;
+  rdfs:label "Diminutive Name"@en;
+  skos:definition "An Abbreviated Name that is a familiar form of a Proper Name."@en;
+  skos:example "Alex, Bob, Cathy";
+  skos:scopeNote "\"Familiar form of a Proper Name\" means: that the name is (originally) a short, affectionate version of the fuller name, used (originally) by family or friends."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000686 a owl:Class;
+  owl:equivalentClass _:genid35;
+  rdfs:subClassOf cco:ont00000958;
+  owl:disjointWith cco:ont00000853, cco:ont00000965;
+  rdfs:label "Designative Information Content Entity"@en;
+  skos:altLabel "Designative ICE"@en;
+  skos:definition "An Information Content Entity that consists of a set of symbols that designate some Entity."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid35 a owl:Class;
+  owl:intersectionOf _:genid38 .
+
+_:genid38 a rdf:List;
+  rdf:first cco:ont00000958;
+  rdf:rest _:genid36 .
+
+_:genid36 a rdf:List;
+  rdf:first _:genid37;
+  rdf:rest rdf:nil .
+
+_:genid37 a owl:Restriction;
+  owl:someValuesFrom obo:BFO_0000001;
+  owl:onProperty cco:ont00001916 .
+
+cco:ont00000692 a owl:Class;
+  rdfs:subClassOf cco:ont00001163;
+  rdfs:comment "Every probability measurement is made within a particular context given certain background assumptions."@en;
+  rdfs:label "Probability Measurement Information Content Entity"@en;
+  skos:altLabel "Likelihood Measurement"@en, "Probability Measurement"@en;
+  skos:definition "A Measurement Information Content Entity that is a measurement of the likelihood that a Process or Process Aggregate occurs."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Probability&oldid=1059657543"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000702 a owl:Class .
+
+cco:ont00000729 a owl:Class;
+  rdfs:subClassOf cco:ont00000275;
+  rdfs:label "Spherical Coordinate System"@en;
+  skos:definition "A Spatial Reference System for three-dimensional spatial regions that identifies each point using an ordered triple of numerical coordinates that consist of the radial distance of the point of interest from a fixed origin, its polar angle measured from a fixed zenith direction, and the azimuth angle of its orthogonal projection measured from a fixed direction on a reference plane that passes through the origin and is orthogonal to the zenith."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Spherical_coordinate_system&oldid=1061029174"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000731 a owl:Class;
+  rdfs:subClassOf cco:ont00001163;
+  rdfs:comment "'Deviation Measurement Information Content Entity' and 'Veracity Measurement Information Content Entity' are complementary notions. Deviation is a measure of whether reality conforms to an ICE (e.g., a plan or prediction), whereas Veracity is a measure of whether a Descriptive ICE conforms to reality."@en,
+    "Note, the term 'accuracy' is avoided due to its ambiguity between: correctness-of-performance (see: 'Reliability Measurement Information Content Entity'), correctness-of-information (see: 'Veracity Measurement Information Content Entity'), and adherance-to-expectations ('Deviation Measurement Information Content Entity')."@en;
+  rdfs:label "Deviation Measurement Information Content Entity"@en;
+  skos:altLabel "Conformance Measurement"@en, "Degree of Conformance"@en, "Degree of Deviation"@en,
+    "Deviation Measurement"@en;
+  skos:definition "A Measurement Information Content Entity that is a measurement of the extent to which an entity conforms to how it is expected or supposed to be."@en;
+  skos:example "a missile impact deviates from its target location by 100 feet", "a satellite deviaties from its predicted orbital path by 5 kilometers",
+    "an overweight piece of luggage deviates from an airline's maximum allowed weight by +10 pounds";
+  skos:scopeNote "In order for a Deviation to exist, an entity must first be expected, represented, prescribed, or predicted as being a certain way. Then, at a future time, this value can be compared to its actual, reported, or measured value to determine the Deviation between these values."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000735 a owl:Class;
+  rdfs:subClassOf cco:ont00000406;
+  rdfs:label "Geospatial Region Bounding Box Identifier List"@en;
+  skos:definition "A Measurement Unit of Geocoordinate that is comprised of 4 pairs of coordinates, one for each of the 4 defining points (North, West, South, East) of a Geospatial Region Bounding Box."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000745 a owl:Class;
+  rdfs:subClassOf cco:ont00001176;
+  rdfs:label "Point Estimate Information Content Entity"@en;
+  skos:altLabel "Best Estimate"@en, "Point Estimate"@en, "Point Estimate Measurement Information Content Entity"@en;
+  skos:definition "An Estimate Information Content Entity that consists of a single value for the measured entity."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000749 a owl:Class;
+  rdfs:subClassOf cco:ont00000894, _:genid39;
+  rdfs:label "Julian Day Number"@en;
+  skos:definition "A Decimal Date Identifier that designates some Julian Day by using a number to indicate the sequential ordering of the Day since the Julian Date epoch."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid39 a owl:Restriction;
+  owl:someValuesFrom cco:ont00000498;
+  owl:onProperty cco:ont00001916 .
+
+cco:ont00000798 a owl:Class .
+
+cco:ont00000800 a owl:Class .
+
+cco:ont00000827 a owl:Class;
+  owl:equivalentClass _:genid40;
+  rdfs:subClassOf cco:ont00000540;
+  rdfs:label "Time of Day Identifier"@en;
+  skos:definition "A Temporal Instant Identifier that designates some Time of Day."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid40 a owl:Class;
+  owl:intersectionOf _:genid43 .
+
+_:genid43 a rdf:List;
+  rdf:first cco:ont00000540;
+  rdf:rest _:genid41 .
+
+_:genid41 a rdf:List;
+  rdf:first _:genid42;
+  rdf:rest rdf:nil .
+
+_:genid42 a owl:Restriction;
+  owl:someValuesFrom cco:ont00000223;
+  owl:onProperty cco:ont00001916 .
+
+cco:ont00000829 a owl:Class;
+  rdfs:subClassOf cco:ont00000390;
+  rdfs:comment """Standards of date, time, and time zone data formats:
 ISO/WD 8601-2 (http://www.loc.gov/standards/datetime/iso-tc154-wg5_n0039_iso_wd_8601-2_2016-02-16.pdf)
-W3C (https://www.w3.org/TR/NOTE-datetime)"""@en ,
-                             "There is no class 'Time Zone' (the region), only 'Time Zone Identifier' (the designator for some region). Instances of 'Time Zone Identifier' should be related to instances of 'Information Bearing Entity' by means of the object properites 'uses time zone identifier' and 'time zone identifier used by' as appropriate. This is supposed to be analogous to the way we represent the relationship between measurement values and measurement units, where the relevant instance of Information Bearing Entity 'uses measurement unit' some instance of Measurement Unit (i.e., an instance of Information Content Entity)."@en ;
-                rdfs:label "Time Zone Identifier"@en ;
-                skos:definition "A Spatial Region Identifier that designates the region associated with some uniform standard time for legal, commercial, or social purposes."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000833
-cco:ont00000833 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000973 ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty obo:BFO_0000178 ;
-                                  owl:someValuesFrom cco:ont00000589
-                                ] ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty obo:BFO_0000178 ;
-                                  owl:someValuesFrom cco:ont00000749
-                                ] ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty cco:ont00001916 ;
-                                  owl:someValuesFrom cco:ont00000359
-                                ] ;
-                rdfs:label "Julian Date Identifier"@en ;
-                skos:definition "A Decimal Time of Day Identifier that designates a Julian Date and is composed of both a Julian Day Number and a Julian Date Fraction."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000845
-cco:ont00000845 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001022 ;
-                rdfs:comment "A percentage is one way to express a proportional measure where the decimal expression of the proportion is multiplied by 100, thus giving the proportional value with respect to a whole of 100. E.g., the ratio of pigs to cows on a farm is 44 to 79 (44:79 or 44/79). The proportion of pigs to total animals is 44 to 123 or 44/123. The percentage of pigs is the decimal equivalent of the proportion (0.36) multiplied by a 100 (36%). The percentage can be expressed as a proportion where the numerator value is transformed for a denominator of 100, i.e., 36 of a 100 animals are pigs (36/100)."@en ,
-                             "We may want to add either a subclass for Percentage or a data property (has percentage value) that links the percentage expression for a proportion to the relevant IBE."@en ;
-                rdfs:label "Proportional Ratio Measurement Information Content Entity"@en ;
-                skos:definition "A Ratio Measurement Information Content Entity that is a measurement of a portion of a whole (described by the numerator) compared against that whole (described by the denominator) where the whole is a nominally described set of like entities."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000853
-cco:ont00000853 rdf:type owl:Class ;
-                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000958
-                                                           [ rdf:type owl:Restriction ;
-                                                             owl:onProperty cco:ont00001982 ;
-                                                             owl:someValuesFrom obo:BFO_0000001
-                                                           ]
-                                                         ) ;
-                                      rdf:type owl:Class
-                                    ] ;
-                rdfs:subClassOf cco:ont00000958 ;
-                owl:disjointWith cco:ont00000965 ;
-                rdfs:label "Descriptive Information Content Entity"@en ;
-                skos:altLabel "Descriptive ICE"@en ;
-                skos:definition "An Information Content Entity that consists of a set of propositions that describe some Entity."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000891
-cco:ont00000891 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001328 ;
-                rdfs:label "Calendar System"@en ;
-                skos:definition "A Temporal Reference System that is designed to organize and identify dates."@en ;
-                skos:scopeNote "Calendars typically organize dates through the use of naming and temporal conventions based on Days, Weeks, Months, and Years."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000894
-cco:ont00000894 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000529 ;
-                rdfs:label "Decimal Date Identifier"@en ;
-                skos:definition "A Date Identifier that designates some Day by using a number to indicate the sequential ordering of the Day since a specified Reference Time."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000896
-cco:ont00000896 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000745 ;
-                rdfs:label "Mean Point Estimate Information Content Entity"@en ;
-                skos:altLabel "Arithmetic Mean"@en ,
-                              "Average"@en ,
-                              "Mean"@en ;
-                skos:definition "A Point Estimate Information Content Entity that is a measurement of a set of values and is equal to the sum of all the values in the set divided by the total number of values in the set."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000915
-cco:ont00000915 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000605 ;
-                rdfs:label "Acronym"@en ;
-                skos:definition "An Abbreviated Name that combines the initial letters of a Designative Name and which is pronounced as a word."@en ;
-                skos:example "Wi-Fi, ASCII, OPSEC" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000916
-cco:ont00000916 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000891 ;
-                rdfs:label "Lunar Calendar System"@en ;
-                skos:definition "A Calendar System that is designed to organize and identify dates based on the cycles of the Moon's phases."@en ;
-                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Lunar_calendar&oldid=1055396837"^^xsd:anyURI ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000923
-cco:ont00000923 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000649 ;
-                rdfs:label "Arbitrary Identifier"@en ;
-                skos:altLabel "Arbitrary ID"@en ;
-                skos:definition "A Non-Name Identifier that consists of a string of characters that does not follow an encoding system."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000958
-cco:ont00000958 rdf:type owl:Class ;
-                owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000031
-                                                           [ rdf:type owl:Restriction ;
-                                                             owl:onProperty cco:ont00001808 ;
-                                                             owl:someValuesFrom obo:BFO_0000001
-                                                           ]
-                                                         ) ;
-                                      rdf:type owl:Class
-                                    ] ;
-                rdfs:subClassOf obo:BFO_0000031 ;
-                rdfs:label "Information Content Entity"@en ;
-                skos:altLabel "ICE"@en ;
-                skos:definition "A Generically Dependent Continuant that generically depends on some Information Bearing Entity and stands in relation of aboutness to some Entity."@en ;
-                skos:scopeNote "Information Content Entity is here intended to be a class of Entities whose instances are the informational content of Information Bearing Entities. For example, three instances of information bearers -- such as a bar chart, color-coded map, and a written report -- each of which lists the GDP of Countries for the year 2010 are each different carriers of the same information content. It is this content that is generically dependent upon its carrier. This treatment of Informational Content Entity (cf. the Information Artifact Ontology) leads to a principle of subtyping based upon the relationship that ICE's have with the Entity they are about rather than characteristics such as format, language, measurement scale, or media. The latter are treated here as being Qualities of bearers."@en ;
-                cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000030" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000965
-cco:ont00000965 rdf:type owl:Class ;
-                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000958
-                                                           [ rdf:type owl:Restriction ;
-                                                             owl:onProperty cco:ont00001942 ;
-                                                             owl:someValuesFrom obo:BFO_0000001
-                                                           ]
-                                                         ) ;
-                                      rdf:type owl:Class
-                                    ] ;
-                rdfs:subClassOf cco:ont00000958 ;
-                rdfs:label "Prescriptive Information Content Entity"@en ;
-                skos:altLabel "Directive ICE"@en ;
-                skos:definition "An Information Content Entity that consists of a set of propositions or images (as in the case of a blueprint) that prescribe some Entity."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000973
-cco:ont00000973 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000827 ;
-                rdfs:label "Decimal Time of Day Identifier"@en ;
-                skos:altLabel "Fractional Time of Day Identifier"@en ;
-                skos:definition "A Time of Day Identifier that designates an approximate Temporal Instant that is part of some Day and is specified using a decimal value for the portion of the Day that preceded the Temporal Instant."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00000990
-cco:ont00000990 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000003 ;
-                rdfs:label "Nickname"@en ;
-                skos:definition "A Designative Name that is a familiar or humorous substitute for an entity's Proper Name."@en ;
-                skos:example "Ike, Chief, P-Fox" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001010
-cco:ont00001010 rdf:type owl:Class ;
-                owl:equivalentClass [ owl:intersectionOf ( cco:ont00001163
-                                                           [ rdf:type owl:Restriction ;
-                                                             owl:onProperty cco:ont00001811 ;
-                                                             owl:someValuesFrom obo:BFO_0000001
-                                                           ]
-                                                         ) ;
-                                      rdf:type owl:Class
-                                    ] ;
-                rdfs:subClassOf cco:ont00001163 ;
-                owl:disjointWith cco:ont00001022 ,
-                                 cco:ont00001364 ;
-                rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en ;
-                rdfs:label "Ordinal Measurement Information Content Entity"@en ;
-                skos:definition "A Measurement Information Content Entity that consists of a symbol that places an Entity into some rank order."@en ;
-                skos:example "The sentence \"The coldest day in history in Chicago, IL. is January 20, 1985.\" is the carrier of an ordinal measurment."@en ,
-                             "a measurement that places Geospatial Regions into a rank order of small, medium, large" ,
-                             "a measurement that places military units onto a readiness rank order of red, yellow, green" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001014
-cco:ont00001014 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000003 ;
-                rdfs:label "Proper Name"@en ;
-                skos:definition "A Designative Name that is an official name for a particular entity."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001022
-cco:ont00001022 rdf:type owl:Class ;
-                owl:equivalentClass [ owl:intersectionOf ( cco:ont00001163
-                                                           [ rdf:type owl:Restriction ;
-                                                             owl:onProperty cco:ont00001983 ;
-                                                             owl:someValuesFrom obo:BFO_0000001
-                                                           ]
-                                                         ) ;
-                                      rdf:type owl:Class
-                                    ] ;
-                rdfs:subClassOf cco:ont00001163 ;
-                owl:disjointWith cco:ont00001364 ;
-                rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en ;
-                rdfs:label "Ratio Measurement Information Content Entity"@en ;
-                skos:definition "A Measurement Information Content Entity that consists of a symbol that places a Quality of an Entity onto an interval scale having a true zero value."@en ;
-                skos:example "The sentence \"The temperature reached 240.372 degrees Kelvin on January 20, 1985 in Chicago, IL.\" is the carrier of a ratio measurement as 0 degrees on the Kelvin scale does describe absolute zero."@en ,
-                             "a measurement of the barometric pressure at 1,000 feet above sea level" ,
-                             "a measurement of the measure of air temperature on the Kelvin scale" ,
-                             "a measurement of the number of members in an Organization" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001041
-cco:ont00001041 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001010 ;
-                rdfs:label "Sequence Position Ordinality"@en ;
-                skos:definition "An Ordinal Measurement Information Content Entity that is about the position of some entity in some ordered sequence."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001069
-cco:ont00001069 rdf:type owl:Class ;
-                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000958
-                                                           [ rdf:type owl:Restriction ;
-                                                             owl:onProperty cco:ont00001938 ;
-                                                             owl:someValuesFrom obo:BFO_0000001
-                                                           ]
-                                                         ) ;
-                                      rdf:type owl:Class
-                                    ] ;
-                rdfs:subClassOf cco:ont00000958 ;
-                owl:disjointWith cco:ont00001163 ;
-                rdfs:label "Representational Information Content Entity"@en ;
-                skos:definition "An Information Content Entity that represents some Entity."@en ;
-                skos:example "the content of a court transcript represents a courtroom proceeding" ,
-                             "the content of a photograph of the Statue of Liberty represents the Statue of Liberty" ,
-                             "the content of a video of a sporting event represents that sporting event" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001101
-cco:ont00001101 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001176 ;
-                rdfs:label "Interval Estimate Information Content Entity"@en ;
-                skos:altLabel "Interval Estimate"@en ,
-                              "Interval Estimate Measurement Information Content Entity"@en ;
-                skos:definition "An Estimate Information Content Entity that consists of an interval of possible (or probable) values for the measured entity."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001146
-cco:ont00001146 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001328 ;
-                rdfs:comment "Sidereal Time is the angle measured from an observer's meridian along the celestial equator to the Great Circle that passes through the March equinox and both poles. This angle is usually expressed in Hours, Minutes, and Seconds."@en ;
-                rdfs:label "Sidereal Time Reference System"@en ;
-                skos:definition "A Temporal Reference System that is based on Earth's rate of rotation measured relative to one or more fixed Stars (rather than the Sun)."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001149
-cco:ont00001149 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001101 ;
-                rdfs:label "Data Range Interval Estimate Information Content Entity"@en ;
-                skos:definition "A Ratio Measurement Information Content Entity that is a measurement of a set of values and is equal to the absolute difference between the largest value and the smallest value in the set."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001163
-cco:ont00001163 rdf:type owl:Class ;
-                owl:equivalentClass [ owl:intersectionOf ( cco:ont00000853
-                                                           [ rdf:type owl:Restriction ;
-                                                             owl:onProperty cco:ont00001966 ;
-                                                             owl:someValuesFrom obo:BFO_0000001
-                                                           ]
-                                                         ) ;
-                                      rdf:type owl:Class
-                                    ] ;
-                rdfs:subClassOf cco:ont00000853 ;
-                rdfs:label "Measurement Information Content Entity"@en ;
-                skos:altLabel "Measurement ICE"@en ;
-                skos:definition "A Descriptive Information Content Entity that describes the extent, dimensions, quantity, or quality of an Entity relative to some standard."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001175
-cco:ont00001175 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000965 ;
-                rdfs:label "Language"@en ;
-                skos:definition "A Directive Information Content Entity that prescribes a canonical format for communication."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001176
-cco:ont00001176 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001163 ;
-                rdfs:label "Estimate Information Content Entity"@en ;
-                skos:altLabel "Estimate"@en ,
-                              "Estimate Measurement Information Content Entity"@en ,
-                              "Estimated Value"@en ;
-                skos:definition "A Measurement Information Content Entity that is a measurement of an entity based on partial information about that entity or an appropriately similar entity."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001205
-cco:ont00001205 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000398 ;
-                rdfs:label "Priority Scale"@en ;
-                skos:definition "A Reference System that is designed to be used to rank or identify the importance of entities of the specified type."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001235
-cco:ont00001235 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000829 ;
-                rdfs:label "Military Time Zone Identifier"@en ;
-                skos:definition "A Time Zone Identifier that designates a spatial region where the local time is calculated according to the specified offset from Zulu time, which has no offset from Coordinated Universal Time."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001238
-cco:ont00001238 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000605 ;
-                rdfs:label "Initialism"@en ;
-                skos:definition "An Abbreviated Name that consists of the initial letters of some words (or syllables) in a Designative Name, and in which each letter is pronounced separately."@en ;
-                skos:example "USA, CPU, BBC" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001256
-cco:ont00001256 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001163 ;
-                rdfs:comment "Note, the term 'accuracy' is avoided due to its ambiguity between: correctness-of-performance ('Reliability Measurement Information Content Entity'), correctness-of-information (see: 'Veracity Measurement Information Content Entity'), and adherance-to-expectations (see: 'Deviation Measurement Information Content Entity')."@en ;
-                rdfs:label "Reliability Measurement Information Content Entity"@en ;
-                skos:altLabel "Accuracy of Process"@en ,
-                              "Reliability Measurement"@en ;
-                skos:definition "A Measurement Information Content Entity that is a measurement of the extent to which an entity can consistently produce an outcome."@en ;
-                skos:scopeNote "Reliability concerns both a measure of past performance and the expectation that future performance will conform to the range of past performances."@en ;
-                cco:ont00001754 "https://en.wikipedia.org/wiki/Reliability_(statistics)" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001309
-cco:ont00001309 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000077 ;
-                rdfs:label "Lot Number"@en ;
-                skos:definition "A Code Identifier that designates a particular quantity or lot of material from a single manufacturer."@en ;
-                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Lot_number&oldid=1061846325"^^xsd:anyURI ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001328
-cco:ont00001328 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000398 ;
-                rdfs:label "Temporal Reference System"@en ;
-                skos:altLabel "Temporal Reference Frame"@en ,
-                              "Time Scale"@en ;
-                skos:definition "A Reference System that describes a set of standards for measuring time as well as understanding the context of and organizing temporal data."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001331
-cco:ont00001331 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00001014 ;
-                rdfs:label "Legal Name"@en ;
-                skos:definition "A Proper Name that is an official name for the designated entity as determined by a Government or court of law."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001340
-cco:ont00001340 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000529 ;
-                rdfs:label "Calendar Date Identifier"@en ;
-                skos:definition "A Date Identifier that designates some Day by using a combination of Day, Week, Month, or Year Identifiers formatted according to an implementation of a Calendar System."@en ;
-                skos:example "January 1, 2018; 1 January 2018; 01/01/18; 01Jan18" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001351
-cco:ont00001351 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000275 ;
-                rdfs:label "Cartesian Coordinate System"@en ;
-                skos:altLabel "Rectangular Coordinate System"@en ;
-                skos:definition "A Spatial Reference System that identifies each point in a spatial region of n-dimensions using an ordered n-tuple of numerical coordinates that are the signed (i.e. positive or negative) distances measured in the same unit of length from the zero point where the fixed perpendicular Coordinate System Axes meet."@en ;
-                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Cartesian_coordinate_system&oldid=1058613323"^^xsd:anyURI ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001352
-cco:ont00001352 rdf:type owl:Class ;
-                rdfs:subClassOf cco:ont00000829 ;
-                rdfs:comment "Greenwich Mean Time (GMT) is the mean solar time at the Royal Observatory in Greenwich, London and has been superseded by Coordinated Universal Time (UTC)."@en ;
-                rdfs:label "Greenwich Mean Time Zone Identifier"@en ;
-                skos:definition "A Time Zone Identifier that designates a spatial region where the local time is calculated according to the specified offset from Greenwich Mean Time."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001364
-cco:ont00001364 rdf:type owl:Class ;
-                owl:equivalentClass [ owl:intersectionOf ( cco:ont00001163
-                                                           [ rdf:type owl:Restriction ;
-                                                             owl:onProperty cco:ont00001877 ;
-                                                             owl:someValuesFrom obo:BFO_0000001
-                                                           ]
-                                                         ) ;
-                                      rdf:type owl:Class
-                                    ] ;
-                rdfs:subClassOf cco:ont00001163 ;
-                rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en ;
-                rdfs:label "Interval Measurement Information Content Entity"@en ;
-                skos:definition "A Measurement Information Content Entity that places a Quality of an Entity onto some interval scale having no true zero value."@en ;
-                skos:example "The sentence \"The temperature reached -27 degrees Fahrenheit on January 20, 1985 in Chicago, IL.\" is the carrier of an interval measurement as 0 degrees on the Fahrenheit scale does not describe absolute zero."@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-#################################################################
-#    Individuals
-#################################################################
-
-###  https://www.commoncoreontologies.org/ont00001392
-cco:ont00001392 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT-8"@en ;
-                skos:altLabel "PST"@en ,
-                              "Pacific Standard Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001395
-cco:ont00001395 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT-3:30"@en ;
-                skos:altLabel "Newfoundland Standard Time"@en ;
-                cco:ont00001753 "NST" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001398
-cco:ont00001398 rdf:type owl:NamedIndividual ,
-                         cco:ont00000469 ;
-                rdfs:label "Global Area Reference System"@en ;
-                cco:ont00001753 "GARS" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001403
-cco:ont00001403 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC+2"@en ;
-                rdfs:label "Bravo Time Zone"@en ;
-                cco:ont00001753 "B" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001405
-cco:ont00001405 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT-2"@en ;
-                skos:altLabel "BET"@en ,
-                              "Brazil Eastern Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001406
-cco:ont00001406 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT+9:30"@en ;
-                skos:altLabel "Australian Central Standard Time"@en ;
-                cco:ont00001753 "ACST" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001408
-cco:ont00001408 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC-11"@en ;
-                rdfs:label "X-ray Time Zone"@en ;
-                cco:ont00001753 "X" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001412
-cco:ont00001412 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC+0"@en ;
-                rdfs:label "GMT"@en ;
-                skos:altLabel "Greenwich Mean Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001414
-cco:ont00001414 rdf:type owl:NamedIndividual ,
-                         cco:ont00001328 ;
-                rdfs:comment "TT is an astronomical time standard that is a theoretical ideal designed to be free of the irregularities in Earth's rotation and is primarily used for time measurements of astronomical observations made from the surface of Earth. It was formerly called Terrestrial Dynamical Time (TDT), which was formulated to replace Ephemeris Time (ET)."@en ;
-                rdfs:label "Terrestrial Time"@en ;
-                cco:ont00001753 "TT" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001417
-cco:ont00001417 rdf:type owl:NamedIndividual ,
-                         cco:ont00001328 ;
-                rdfs:comment "ET is an astronomical time scale that was adopted as a standard in 1952 by the IAU but has since been superseded and is no longer actively used. ET is based on the ephemeris second, which was defined as a fraction of the tropical year for 1900 January 01 as calculated using Newcomb's 1895 tables of the Sun. ET was designed to avoid problems caused by variations in Earth's rotational period and was used for Solar System ephemeris calculations until being replaced by Terrestrial Dynamical Time (TDT) in 1979."@en ;
-                rdfs:label "Ephemeris Time"@en ;
-                cco:ont00001753 "ET" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001419
-cco:ont00001419 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT+5"@en ;
-                skos:altLabel "PLT"@en ,
-                              "Pakistan Lahore Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001421
-cco:ont00001421 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC-6"@en ;
-                rdfs:label "Sierra Time Zone"@en ;
-                cco:ont00001753 "S" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001424
-cco:ont00001424 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC+1"@en ;
-                rdfs:label "Alpha Time Zone"@en ;
-                cco:ont00001753 "A" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001430
-cco:ont00001430 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC+6"@en ;
-                rdfs:label "Foxtrot Time Zone"@en ;
-                cco:ont00001753 "F" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001431
-cco:ont00001431 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC-10"@en ;
-                rdfs:label "Whiskey Time Zone"@en ;
-                cco:ont00001753 "W" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001434
-cco:ont00001434 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT+1"@en ;
-                skos:altLabel "ECT"@en ,
-                              "European Central Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001436
-cco:ont00001436 rdf:type owl:NamedIndividual ,
-                         cco:ont00000630 ;
-                rdfs:label "Universal Time 1 D"@en ;
-                cco:ont00001753 "UT1D" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001439
-cco:ont00001439 rdf:type owl:NamedIndividual ,
-                         cco:ont00000263 ;
-                rdfs:label "Twenty-Four-Hour Clock Time System"@en ;
-                skos:altLabel "24-Hour Clock"@en ,
-                              "24-Hour Clock Time System"@en ,
-                              "Military Time"@en ,
-                              "Military Time System"@en ,
-                              "Twenty-Four Hour Clock Time System"@en ,
-                              "Twenty-Four-Hour Clock"@en ;
-                skos:definition "A Clock Time System for time keeping in which the Day runs from midnight to midnight and is divided into 24 Hours, indicated by the Hours passed since midnight, from 0 to 23."@en ;
-                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=24-hour_clock&oldid=1063744105"^^xsd:anyURI ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001440
-cco:ont00001440 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT-9"@en ;
-                skos:altLabel "AST"@en ,
-                              "Alaska Standard Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001446
-cco:ont00001446 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Mike Time Zone is the same local time as Yankee Time Zone, but is 1 Day (i.e. 24 Hours) ahead of Yankee Time Zone as they are on opposite sides of the International Date Line."@en ,
-                             "Offset from Universal Coordinated Time = UTC+12"@en ;
-                rdfs:label "Mike Time Zone"@en ;
-                cco:ont00001753 "M" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001454
-cco:ont00001454 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC+11"@en ;
-                rdfs:label "Lima Time Zone"@en ;
-                cco:ont00001753 "L" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001457
-cco:ont00001457 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC-4"@en ;
-                rdfs:label "Quebec Time Zone"@en ;
-                cco:ont00001753 "Q" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001461
-cco:ont00001461 rdf:type owl:NamedIndividual ,
-                         cco:ont00001328 ;
-                rdfs:comment "TDB is a linear scaling of Barycentric Coordinate Time (TCB) and is a relativistic coordinate time scale used in astronomy as a time standard that accounts for time dilation when calculating Orbits and Ephemerides of Astronomical Bodies and interplanetary Spacecraft in the Solar System. TDB is a successor of Ephemeris Time (ET) and is nearly equivalent to the time scale Teph used for DE405 planetary and lunar ephemerides generated by the Jet Propulsion Laboratory."@en ;
-                rdfs:label "Barycentric Dynamical Time"@en ;
-                cco:ont00001753 "TDB" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001467
-cco:ont00001467 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT-4"@en ;
-                skos:altLabel "PRT"@en ,
-                              "Puerto Rico and US Virgin Islands Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001468
-cco:ont00001468 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT+10"@en ;
-                skos:altLabel "AET"@en ,
-                              "Australia Eastern Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001476
-cco:ont00001476 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT+4"@en ;
-                skos:altLabel "NET"@en ,
-                              "Near East Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001480
-cco:ont00001480 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC+9"@en ;
-                rdfs:label "India Time Zone"@en ;
-                cco:ont00001753 "I" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001488
-cco:ont00001488 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC-7"@en ;
-                rdfs:label "Tango Time Zone"@en ;
-                cco:ont00001753 "T" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001491
-cco:ont00001491 rdf:type owl:NamedIndividual ,
-                         cco:ont00000630 ;
-                rdfs:label "Universal Time 1 A"@en ;
-                cco:ont00001753 "UT1A" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001500
-cco:ont00001500 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC+5"@en ;
-                rdfs:label "Echo Time Zone"@en ;
-                cco:ont00001753 "E" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001506
-cco:ont00001506 rdf:type owl:NamedIndividual ,
-                         cco:ont00000630 ;
-                rdfs:label "Universal Time 1 F"@en ;
-                cco:ont00001753 "UT1F" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001516
-cco:ont00001516 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC-2"@en ;
-                rdfs:label "Oscar Time Zone"@en ;
-                cco:ont00001753 "O" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001524
-cco:ont00001524 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT-11"@en ;
-                skos:altLabel "MIT"@en ,
-                              "Midway Islands Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001527
-cco:ont00001527 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC+8"@en ;
-                rdfs:label "Hotel Time Zone"@en ;
-                cco:ont00001753 "H" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001529
-cco:ont00001529 rdf:type owl:NamedIndividual ,
-                         cco:ont00001328 ;
-                rdfs:comment """\"TCG is a coordinate time standard intended to be used as the independent variable of time for all calculations pertaining to precession, nutation, the Moon, and artificial satellites of the Earth. It is equivalent to the proper time experienced by a clock at rest in a coordinate frame co-moving with the center of the Earth: that is, a clock that performs exactly the same movements as the Earth but is outside the Earth's gravity well. It is therefore not influenced by the gravitational time dilation caused by the Earth.\"
-From: (https://en.wikipedia.org/wiki/Geocentric_Coordinate_Time)"""@en ;
-                rdfs:label "Geocentric Coordinate Time"@en ;
-                cco:ont00001753 "TCG" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001534
-cco:ont00001534 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT+7"@en ;
-                skos:altLabel "VST"@en ,
-                              "Vietnam Standard Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001537
-cco:ont00001537 rdf:type owl:NamedIndividual ,
-                         cco:ont00000067 ,
-                         cco:ont00000630 ;
-                rdfs:comment "UTC is a variant of Universal Time that is calculated by combining Universal Time 1 with International Atomic Time by occasionally adding leap seconds to TAI in order to maintain UTC within 0.9 seconds of UT1. The difference between UTC and UT1 is called DUT1 and always has a value between -0.9 seconds and +0.9 seconds. Coordinated Universal Time is the current basis for civil time and is the reference time for time zones, whose local times are defined based on an offset from UTC."@en ;
-                rdfs:label "Coordinated Universal Time"@en ;
-                cco:ont00001753 "UTC" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001541
-cco:ont00001541 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT+12"@en ;
-                skos:altLabel "NST"@en ,
-                              "New Zealand Standard Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001548
-cco:ont00001548 rdf:type owl:NamedIndividual ,
-                         cco:ont00000630 ;
-                rdfs:comment "UT1R is a variant of Universal Time that is a smoothed version of UT1 by filtering out periodic variations due to tidal waves."@en ;
-                rdfs:label "Universal Time 1 R"@en ;
-                cco:ont00001753 "UT1R" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001550
-cco:ont00001550 rdf:type owl:NamedIndividual ,
-                         cco:ont00000276 ;
-                rdfs:comment "The Julian Calendar was proposed by Julius Caesar as a reform of the Roman Calendar, took effect on 1 January 46 BC, and was the predominant Calendar System in Europe until being largely replaced by the Gregorian Calendar."@en ;
-                rdfs:label "Julian Calendar"@en ;
-                skos:definition "A Solar Calendar System that has a regular Year of 365 24-Hour Days divided into 12 Months with a leap day added at the end of February every 4 Years such that the average length of a Julian Year is 365.25 Days."@en ;
-                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Julian_calendar&oldid=1063127575"^^xsd:anyURI ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001553
-cco:ont00001553 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT+6"@en ;
-                skos:altLabel "BST"@en ,
-                              "Bangladesh Standard Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001554
-cco:ont00001554 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT-10"@en ;
-                skos:altLabel "HST"@en ,
-                              "Hawaii Standard Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001565
-cco:ont00001565 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT-5"@en ;
-                skos:altLabel "EST"@en ,
-                              "Eastern Standard Time"@en ,
-                              "IET"@en ,
-                              "Indiana Eastern Standard Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001570
-cco:ont00001570 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT+2"@en ;
-                skos:altLabel "EET"@en ,
-                              "Eastern European Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001580
-cco:ont00001580 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC-3"@en ;
-                rdfs:label "Papa Time Zone"@en ;
-                cco:ont00001753 "P" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001581
-cco:ont00001581 rdf:type owl:NamedIndividual ,
-                         cco:ont00000469 ;
-                rdfs:comment """The ITRS definition fulfills the following conditions:
+W3C (https://www.w3.org/TR/NOTE-datetime)"""@en,
+    "There is no class 'Time Zone' (the region), only 'Time Zone Identifier' (the designator for some region). Instances of 'Time Zone Identifier' should be related to instances of 'Information Bearing Entity' by means of the object properites 'uses time zone identifier' and 'time zone identifier used by' as appropriate. This is supposed to be analogous to the way we represent the relationship between measurement values and measurement units, where the relevant instance of Information Bearing Entity 'uses measurement unit' some instance of Measurement Unit (i.e., an instance of Information Content Entity)."@en;
+  rdfs:label "Time Zone Identifier"@en;
+  skos:definition "A Spatial Region Identifier that designates the region associated with some uniform standard time for legal, commercial, or social purposes."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000833 a owl:Class;
+  rdfs:subClassOf cco:ont00000973, _:genid44, _:genid45, _:genid46;
+  rdfs:label "Julian Date Identifier"@en;
+  skos:definition "A Decimal Time of Day Identifier that designates a Julian Date and is composed of both a Julian Day Number and a Julian Date Fraction."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid44 a owl:Restriction;
+  owl:someValuesFrom cco:ont00000589;
+  owl:onProperty obo:BFO_0000178 .
+
+_:genid45 a owl:Restriction;
+  owl:someValuesFrom cco:ont00000749;
+  owl:onProperty obo:BFO_0000178 .
+
+_:genid46 a owl:Restriction;
+  owl:someValuesFrom cco:ont00000359;
+  owl:onProperty cco:ont00001916 .
+
+cco:ont00000845 a owl:Class;
+  rdfs:subClassOf cco:ont00001022;
+  rdfs:comment "A percentage is one way to express a proportional measure where the decimal expression of the proportion is multiplied by 100, thus giving the proportional value with respect to a whole of 100. E.g., the ratio of pigs to cows on a farm is 44 to 79 (44:79 or 44/79). The proportion of pigs to total animals is 44 to 123 or 44/123. The percentage of pigs is the decimal equivalent of the proportion (0.36) multiplied by a 100 (36%). The percentage can be expressed as a proportion where the numerator value is transformed for a denominator of 100, i.e., 36 of a 100 animals are pigs (36/100)."@en,
+    "We may want to add either a subclass for Percentage or a data property (has percentage value) that links the percentage expression for a proportion to the relevant IBE."@en;
+  rdfs:label "Proportional Ratio Measurement Information Content Entity"@en;
+  skos:definition "A Ratio Measurement Information Content Entity that is a measurement of a portion of a whole (described by the numerator) compared against that whole (described by the denominator) where the whole is a nominally described set of like entities."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000853 a owl:Class;
+  owl:equivalentClass _:genid47;
+  rdfs:subClassOf cco:ont00000958;
+  owl:disjointWith cco:ont00000965;
+  rdfs:label "Descriptive Information Content Entity"@en;
+  skos:altLabel "Descriptive ICE"@en;
+  skos:definition "An Information Content Entity that consists of a set of propositions that describe some Entity."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid47 a owl:Class;
+  owl:intersectionOf _:genid50 .
+
+_:genid50 a rdf:List;
+  rdf:first cco:ont00000958;
+  rdf:rest _:genid48 .
+
+_:genid48 a rdf:List;
+  rdf:first _:genid49;
+  rdf:rest rdf:nil .
+
+_:genid49 a owl:Restriction;
+  owl:someValuesFrom obo:BFO_0000001;
+  owl:onProperty cco:ont00001982 .
+
+cco:ont00000891 a owl:Class;
+  rdfs:subClassOf cco:ont00001328;
+  rdfs:label "Calendar System"@en;
+  skos:definition "A Temporal Reference System that is designed to organize and identify dates."@en;
+  skos:scopeNote "Calendars typically organize dates through the use of naming and temporal conventions based on Days, Weeks, Months, and Years."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000894 a owl:Class;
+  rdfs:subClassOf cco:ont00000529;
+  rdfs:label "Decimal Date Identifier"@en;
+  skos:definition "A Date Identifier that designates some Day by using a number to indicate the sequential ordering of the Day since a specified Reference Time."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000896 a owl:Class;
+  rdfs:subClassOf cco:ont00000745;
+  rdfs:label "Mean Point Estimate Information Content Entity"@en;
+  skos:altLabel "Arithmetic Mean"@en, "Average"@en, "Mean"@en;
+  skos:definition "A Point Estimate Information Content Entity that is a measurement of a set of values and is equal to the sum of all the values in the set divided by the total number of values in the set."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000915 a owl:Class;
+  rdfs:subClassOf cco:ont00000605;
+  rdfs:label "Acronym"@en;
+  skos:definition "An Abbreviated Name that combines the initial letters of a Designative Name and which is pronounced as a word."@en;
+  skos:example "Wi-Fi, ASCII, OPSEC";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000916 a owl:Class;
+  rdfs:subClassOf cco:ont00000891;
+  rdfs:label "Lunar Calendar System"@en;
+  skos:definition "A Calendar System that is designed to organize and identify dates based on the cycles of the Moon's phases."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Lunar_calendar&oldid=1055396837"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000923 a owl:Class;
+  rdfs:subClassOf cco:ont00000649;
+  rdfs:label "Arbitrary Identifier"@en;
+  skos:altLabel "Arbitrary ID"@en;
+  skos:definition "A Non-Name Identifier that consists of a string of characters that does not follow an encoding system."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000958 a owl:Class;
+  owl:equivalentClass _:genid51;
+  rdfs:subClassOf obo:BFO_0000031;
+  rdfs:label "Information Content Entity"@en;
+  skos:altLabel "ICE"@en;
+  skos:definition "A Generically Dependent Continuant that generically depends on some Information Bearing Entity and stands in relation of aboutness to some Entity."@en;
+  skos:scopeNote "Information Content Entity is here intended to be a class of Entities whose instances are the informational content of Information Bearing Entities. For example, three instances of information bearers -- such as a bar chart, color-coded map, and a written report -- each of which lists the GDP of Countries for the year 2010 are each different carriers of the same information content. It is this content that is generically dependent upon its carrier. This treatment of Informational Content Entity (cf. the Information Artifact Ontology) leads to a principle of subtyping based upon the relationship that ICE's have with the Entity they are about rather than characteristics such as format, language, measurement scale, or media. The latter are treated here as being Qualities of bearers."@en;
+  cco:ont00001754 "http://purl.obolibrary.org/obo/IAO_0000030";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid51 a owl:Class;
+  owl:intersectionOf _:genid54 .
+
+_:genid54 a rdf:List;
+  rdf:first obo:BFO_0000031;
+  rdf:rest _:genid52 .
+
+_:genid52 a rdf:List;
+  rdf:first _:genid53;
+  rdf:rest rdf:nil .
+
+_:genid53 a owl:Restriction;
+  owl:someValuesFrom obo:BFO_0000001;
+  owl:onProperty cco:ont00001808 .
+
+cco:ont00000965 a owl:Class;
+  owl:equivalentClass _:genid55;
+  rdfs:subClassOf cco:ont00000958;
+  rdfs:label "Prescriptive Information Content Entity"@en;
+  skos:altLabel "Directive ICE"@en;
+  skos:definition "An Information Content Entity that consists of a set of propositions or images (as in the case of a blueprint) that prescribe some Entity."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid55 a owl:Class;
+  owl:intersectionOf _:genid58 .
+
+_:genid58 a rdf:List;
+  rdf:first cco:ont00000958;
+  rdf:rest _:genid56 .
+
+_:genid56 a rdf:List;
+  rdf:first _:genid57;
+  rdf:rest rdf:nil .
+
+_:genid57 a owl:Restriction;
+  owl:someValuesFrom obo:BFO_0000001;
+  owl:onProperty cco:ont00001942 .
+
+cco:ont00000973 a owl:Class;
+  rdfs:subClassOf cco:ont00000827;
+  rdfs:label "Decimal Time of Day Identifier"@en;
+  skos:altLabel "Fractional Time of Day Identifier"@en;
+  skos:definition "A Time of Day Identifier that designates an approximate Temporal Instant that is part of some Day and is specified using a decimal value for the portion of the Day that preceded the Temporal Instant."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00000990 a owl:Class;
+  rdfs:subClassOf cco:ont00000003;
+  rdfs:label "Nickname"@en;
+  skos:definition "A Designative Name that is a familiar or humorous substitute for an entity's Proper Name."@en;
+  skos:example "Ike, Chief, P-Fox";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001010 a owl:Class;
+  owl:equivalentClass _:genid59;
+  rdfs:subClassOf cco:ont00001163;
+  owl:disjointWith cco:ont00001022, cco:ont00001364;
+  rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en;
+  rdfs:label "Ordinal Measurement Information Content Entity"@en;
+  skos:definition "A Measurement Information Content Entity that consists of a symbol that places an Entity into some rank order."@en;
+  skos:example "The sentence \"The coldest day in history in Chicago, IL. is January 20, 1985.\" is the carrier of an ordinal measurment."@en,
+    "a measurement that places Geospatial Regions into a rank order of small, medium, large",
+    "a measurement that places military units onto a readiness rank order of red, yellow, green";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid59 a owl:Class;
+  owl:intersectionOf _:genid62 .
+
+_:genid62 a rdf:List;
+  rdf:first cco:ont00001163;
+  rdf:rest _:genid60 .
+
+_:genid60 a rdf:List;
+  rdf:first _:genid61;
+  rdf:rest rdf:nil .
+
+_:genid61 a owl:Restriction;
+  owl:someValuesFrom obo:BFO_0000001;
+  owl:onProperty cco:ont00001811 .
+
+cco:ont00001014 a owl:Class;
+  rdfs:subClassOf cco:ont00000003;
+  rdfs:label "Proper Name"@en;
+  skos:definition "A Designative Name that is an official name for a particular entity."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001022 a owl:Class;
+  owl:equivalentClass _:genid63;
+  rdfs:subClassOf cco:ont00001163;
+  owl:disjointWith cco:ont00001364 .
+
+_:genid63 a owl:Class;
+  owl:intersectionOf _:genid66 .
+
+_:genid66 a rdf:List;
+  rdf:first cco:ont00001163;
+  rdf:rest _:genid64 .
+
+_:genid64 a rdf:List;
+  rdf:first _:genid65;
+  rdf:rest rdf:nil .
+
+_:genid65 a owl:Restriction;
+  owl:someValuesFrom obo:BFO_0000001;
+  owl:onProperty cco:ont00001983 .
+# 
+# https://www.commoncoreontologies.org/ont00001041
+# 
+# https://www.commoncoreontologies.org/ont00001046
+# 
+# https://www.commoncoreontologies.org/ont00001069
+# 
+# https://www.commoncoreontologies.org/ont00001101
+# 
+# https://www.commoncoreontologies.org/ont00001146
+# 
+# https://www.commoncoreontologies.org/ont00001149
+# 
+# https://www.commoncoreontologies.org/ont00001163
+# 
+# https://www.commoncoreontologies.org/ont00001175
+# 
+# https://www.commoncoreontologies.org/ont00001176
+# 
+# https://www.commoncoreontologies.org/ont00001205
+# 
+# https://www.commoncoreontologies.org/ont00001235
+# 
+# https://www.commoncoreontologies.org/ont00001238
+# 
+# https://www.commoncoreontologies.org/ont00001256
+# 
+# https://www.commoncoreontologies.org/ont00001309
+# 
+# https://www.commoncoreontologies.org/ont00001328
+# 
+# https://www.commoncoreontologies.org/ont00001331
+# 
+# https://www.commoncoreontologies.org/ont00001340
+# 
+# https://www.commoncoreontologies.org/ont00001351
+# 
+# https://www.commoncoreontologies.org/ont00001352
+# 
+# https://www.commoncoreontologies.org/ont00001364
+# 
+# https://www.commoncoreontologies.org/ont00002001
+# 
+# https://www.commoncoreontologies.org/ont00002002
+# 
+# https://www.commoncoreontologies.org/ont00002003
+# 
+# https://www.commoncoreontologies.org/ont00002004
+# 
+# https://www.commoncoreontologies.org/ont00002005
+# 
+# https://www.commoncoreontologies.org/ont00002006
+# 
+# https://www.commoncoreontologies.org/ont00002007
+# 
+# https://www.commoncoreontologies.org/ont00002008
+# 
+# https://www.commoncoreontologies.org/ont00002009
+# 
+# https://www.commoncoreontologies.org/ont00002010
+# 
+# https://www.commoncoreontologies.org/ont00002011
+# 
+# https://www.commoncoreontologies.org/ont00002012
+# 
+# https://www.commoncoreontologies.org/ont00002013
+# 
+# https://www.commoncoreontologies.org/ont00002014
+# 
+# https://www.commoncoreontologies.org/ont00002015
+# 
+# https://www.commoncoreontologies.org/ont00002016
+# 
+# https://www.commoncoreontologies.org/ont00002017
+# 
+# https://www.commoncoreontologies.org/ont00002018
+# 
+# https://www.commoncoreontologies.org/ont00002019
+# 
+# https://www.commoncoreontologies.org/ont00002020
+# 
+# https://www.commoncoreontologies.org/ont00002021
+# 
+# https://www.commoncoreontologies.org/ont00002022
+# 
+# https://www.commoncoreontologies.org/ont00002023
+# 
+# https://www.commoncoreontologies.org/ont00002024
+# 
+# https://www.commoncoreontologies.org/ont00002025
+# 
+# https://www.commoncoreontologies.org/ont00002026
+# 
+# https://www.commoncoreontologies.org/ont00002027
+# 
+# https://www.commoncoreontologies.org/ont00002028
+# 
+# https://www.commoncoreontologies.org/ont00002029
+# 
+# https://www.commoncoreontologies.org/ont00002030
+# 
+# https://www.commoncoreontologies.org/ont00002031
+# 
+# https://www.commoncoreontologies.org/ont00002032
+# 
+# https://www.commoncoreontologies.org/ont00002033
+# 
+# https://www.commoncoreontologies.org/ont00002034
+# 
+# https://www.commoncoreontologies.org/ont00002035
+# 
+# https://www.commoncoreontologies.org/ont00002036
+# 
+# https://www.commoncoreontologies.org/ont00002037
+# 
+# https://www.commoncoreontologies.org/ont00002038
+# 
+# https://www.commoncoreontologies.org/ont00002039
+# 
+# https://www.commoncoreontologies.org/ont00002040
+# 
+# https://www.commoncoreontologies.org/ont00002041
+# 
+# https://www.commoncoreontologies.org/ont00002042
+# 
+# https://www.commoncoreontologies.org/ont00002043
+# 
+# https://www.commoncoreontologies.org/ont00002044
+# 
+# https://www.commoncoreontologies.org/ont00002045
+# 
+# 
+# 
+# #################################################################
+# #
+# #    Individuals
+# #
+# #################################################################
+# 
+# 
+# https://www.commoncoreontologies.org/ont00001392
+# 
+# https://www.commoncoreontologies.org/ont00001395
+# 
+# https://www.commoncoreontologies.org/ont00001398
+# 
+# https://www.commoncoreontologies.org/ont00001403
+# 
+# https://www.commoncoreontologies.org/ont00001405
+# 
+# https://www.commoncoreontologies.org/ont00001406
+# 
+# https://www.commoncoreontologies.org/ont00001408
+# 
+# https://www.commoncoreontologies.org/ont00001412
+# 
+# https://www.commoncoreontologies.org/ont00001414
+# 
+# https://www.commoncoreontologies.org/ont00001417
+# 
+# https://www.commoncoreontologies.org/ont00001419
+# 
+# https://www.commoncoreontologies.org/ont00001421
+# 
+# https://www.commoncoreontologies.org/ont00001424
+# 
+# https://www.commoncoreontologies.org/ont00001430
+# 
+# https://www.commoncoreontologies.org/ont00001431
+# 
+# https://www.commoncoreontologies.org/ont00001434
+# 
+# https://www.commoncoreontologies.org/ont00001436
+# 
+# https://www.commoncoreontologies.org/ont00001439
+# 
+# https://www.commoncoreontologies.org/ont00001440
+# 
+# https://www.commoncoreontologies.org/ont00001446
+# 
+# https://www.commoncoreontologies.org/ont00001454
+# 
+# https://www.commoncoreontologies.org/ont00001457
+# 
+# https://www.commoncoreontologies.org/ont00001461
+# 
+# https://www.commoncoreontologies.org/ont00001467
+# 
+# https://www.commoncoreontologies.org/ont00001468
+# 
+# https://www.commoncoreontologies.org/ont00001476
+# 
+# https://www.commoncoreontologies.org/ont00001480
+# 
+# https://www.commoncoreontologies.org/ont00001488
+# 
+# https://www.commoncoreontologies.org/ont00001491
+# 
+# https://www.commoncoreontologies.org/ont00001500
+# 
+# https://www.commoncoreontologies.org/ont00001506
+# 
+# https://www.commoncoreontologies.org/ont00001516
+# 
+# https://www.commoncoreontologies.org/ont00001524
+# 
+# https://www.commoncoreontologies.org/ont00001527
+# 
+# https://www.commoncoreontologies.org/ont00001529
+# 
+# https://www.commoncoreontologies.org/ont00001534
+# 
+# https://www.commoncoreontologies.org/ont00001537
+# 
+# https://www.commoncoreontologies.org/ont00001541
+# 
+# https://www.commoncoreontologies.org/ont00001548
+# 
+# https://www.commoncoreontologies.org/ont00001550
+# 
+# https://www.commoncoreontologies.org/ont00001553
+# 
+# https://www.commoncoreontologies.org/ont00001554
+# 
+# https://www.commoncoreontologies.org/ont00001565
+# 
+# https://www.commoncoreontologies.org/ont00001570
+# 
+# https://www.commoncoreontologies.org/ont00001580
+# 
+# https://www.commoncoreontologies.org/ont00001581
+# 
+# https://www.commoncoreontologies.org/ont00001582
+# 
+# https://www.commoncoreontologies.org/ont00001584
+# 
+# https://www.commoncoreontologies.org/ont00001588
+# 
+# https://www.commoncoreontologies.org/ont00001590
+# 
+# https://www.commoncoreontologies.org/ont00001591
+# 
+# https://www.commoncoreontologies.org/ont00001597
+# 
+# https://www.commoncoreontologies.org/ont00001599
+# 
+# https://www.commoncoreontologies.org/ont00001603
+# 
+# https://www.commoncoreontologies.org/ont00001607
+# 
+# https://www.commoncoreontologies.org/ont00001615
+# 
+# https://www.commoncoreontologies.org/ont00001624
+# 
+# https://www.commoncoreontologies.org/ont00001625
+# 
+# https://www.commoncoreontologies.org/ont00001626
+# 
+# https://www.commoncoreontologies.org/ont00001628
+# 
+# https://www.commoncoreontologies.org/ont00001630
+# 
+# https://www.commoncoreontologies.org/ont00001634
+# 
+# https://www.commoncoreontologies.org/ont00001648
+# 
+# https://www.commoncoreontologies.org/ont00001658
+# 
+# https://www.commoncoreontologies.org/ont00001660
+# 
+# https://www.commoncoreontologies.org/ont00001661
+# 
+# https://www.commoncoreontologies.org/ont00001666
+# 
+# https://www.commoncoreontologies.org/ont00001674
+# 
+# https://www.commoncoreontologies.org/ont00001691
+# 
+# https://www.commoncoreontologies.org/ont00001692
+# 
+# https://www.commoncoreontologies.org/ont00001693
+# 
+# https://www.commoncoreontologies.org/ont00001695
+# 
+# https://www.commoncoreontologies.org/ont00001700
+# 
+# https://www.commoncoreontologies.org/ont00001701
+# 
+# https://www.commoncoreontologies.org/ont00001702
+# 
+# https://www.commoncoreontologies.org/ont00001704
+# 
+# https://www.commoncoreontologies.org/ont00001712
+# 
+# https://www.commoncoreontologies.org/ont00001716
+# 
+# https://www.commoncoreontologies.org/ont00001723
+# 
+# https://www.commoncoreontologies.org/ont00001727
+# 
+# https://www.commoncoreontologies.org/ont00001732
+# 
+# Generated by the OWL API (version 4.5.26.2023-07-17T20:34:13Z) https://github.com/owlcs/owlapi
+
+cco:ont00001022 rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en;
+  rdfs:label "Ratio Measurement Information Content Entity"@en;
+  skos:definition "A Measurement Information Content Entity that consists of a symbol that places a Quality of an Entity onto an interval scale having a true zero value."@en;
+  skos:example "The sentence \"The temperature reached 240.372 degrees Kelvin on January 20, 1985 in Chicago, IL.\" is the carrier of a ratio measurement as 0 degrees on the Kelvin scale does describe absolute zero."@en,
+    "a measurement of the barometric pressure at 1,000 feet above sea level", "a measurement of the measure of air temperature on the Kelvin scale",
+    "a measurement of the number of members in an Organization";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001041 a owl:Class;
+  rdfs:subClassOf cco:ont00001010;
+  rdfs:label "Sequence Position Ordinality"@en;
+  skos:definition "An Ordinal Measurement Information Content Entity that is about the position of some entity in some ordered sequence."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001046 a owl:Class .
+
+cco:ont00001069 a owl:Class;
+  owl:equivalentClass _:genid67;
+  rdfs:subClassOf cco:ont00000958;
+  owl:disjointWith cco:ont00001163;
+  rdfs:label "Representational Information Content Entity"@en;
+  skos:definition "An Information Content Entity that represents some Entity."@en;
+  skos:example "the content of a court transcript represents a courtroom proceeding",
+    "the content of a photograph of the Statue of Liberty represents the Statue of Liberty",
+    "the content of a video of a sporting event represents that sporting event";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid67 a owl:Class;
+  owl:intersectionOf _:genid70 .
+
+_:genid70 a rdf:List;
+  rdf:first cco:ont00000958;
+  rdf:rest _:genid68 .
+
+_:genid68 a rdf:List;
+  rdf:first _:genid69;
+  rdf:rest rdf:nil .
+
+_:genid69 a owl:Restriction;
+  owl:someValuesFrom obo:BFO_0000001;
+  owl:onProperty cco:ont00001938 .
+
+cco:ont00001101 a owl:Class;
+  rdfs:subClassOf cco:ont00001176;
+  rdfs:label "Interval Estimate Information Content Entity"@en;
+  skos:altLabel "Interval Estimate"@en, "Interval Estimate Measurement Information Content Entity"@en;
+  skos:definition "An Estimate Information Content Entity that consists of an interval of possible (or probable) values for the measured entity."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001146 a owl:Class;
+  rdfs:subClassOf cco:ont00001328;
+  rdfs:comment "Sidereal Time is the angle measured from an observer's meridian along the celestial equator to the Great Circle that passes through the March equinox and both poles. This angle is usually expressed in Hours, Minutes, and Seconds."@en;
+  rdfs:label "Sidereal Time Reference System"@en;
+  skos:definition "A Temporal Reference System that is based on Earth's rate of rotation measured relative to one or more fixed Stars (rather than the Sun)."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001149 a owl:Class;
+  rdfs:subClassOf cco:ont00001101;
+  rdfs:label "Data Range Interval Estimate Information Content Entity"@en;
+  skos:definition "A Ratio Measurement Information Content Entity that is a measurement of a set of values and is equal to the absolute difference between the largest value and the smallest value in the set."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001163 a owl:Class;
+  owl:equivalentClass _:genid71;
+  rdfs:subClassOf cco:ont00000853;
+  rdfs:label "Measurement Information Content Entity"@en;
+  skos:altLabel "Measurement ICE"@en;
+  skos:definition "A Descriptive Information Content Entity that describes the extent, dimensions, quantity, or quality of an Entity relative to some standard."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid71 a owl:Class;
+  owl:intersectionOf _:genid74 .
+
+_:genid74 a rdf:List;
+  rdf:first cco:ont00000853;
+  rdf:rest _:genid72 .
+
+_:genid72 a rdf:List;
+  rdf:first _:genid73;
+  rdf:rest rdf:nil .
+
+_:genid73 a owl:Restriction;
+  owl:someValuesFrom obo:BFO_0000001;
+  owl:onProperty cco:ont00001966 .
+
+cco:ont00001175 a owl:Class;
+  rdfs:subClassOf cco:ont00000965;
+  rdfs:label "Language"@en;
+  skos:definition "A Directive Information Content Entity that prescribes a canonical format for communication."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001176 a owl:Class;
+  rdfs:subClassOf cco:ont00001163;
+  rdfs:label "Estimate Information Content Entity"@en;
+  skos:altLabel "Estimate"@en, "Estimate Measurement Information Content Entity"@en,
+    "Estimated Value"@en;
+  skos:definition "A Measurement Information Content Entity that is a measurement of an entity based on partial information about that entity or an appropriately similar entity."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001205 a owl:Class;
+  rdfs:subClassOf cco:ont00000398;
+  rdfs:label "Priority Scale"@en;
+  skos:definition "A Reference System that is designed to be used to rank or identify the importance of entities of the specified type."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001235 a owl:Class;
+  rdfs:subClassOf cco:ont00000829;
+  rdfs:label "Military Time Zone Identifier"@en;
+  skos:definition "A Time Zone Identifier that designates a spatial region where the local time is calculated according to the specified offset from Zulu time, which has no offset from Coordinated Universal Time."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001238 a owl:Class;
+  rdfs:subClassOf cco:ont00000605;
+  rdfs:label "Initialism"@en;
+  skos:definition "An Abbreviated Name that consists of the initial letters of some words (or syllables) in a Designative Name, and in which each letter is pronounced separately."@en;
+  skos:example "USA, CPU, BBC";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001256 a owl:Class;
+  rdfs:subClassOf cco:ont00001163;
+  rdfs:comment "Note, the term 'accuracy' is avoided due to its ambiguity between: correctness-of-performance ('Reliability Measurement Information Content Entity'), correctness-of-information (see: 'Veracity Measurement Information Content Entity'), and adherance-to-expectations (see: 'Deviation Measurement Information Content Entity')."@en;
+  rdfs:label "Reliability Measurement Information Content Entity"@en;
+  skos:altLabel "Accuracy of Process"@en, "Reliability Measurement"@en;
+  skos:definition "A Measurement Information Content Entity that is a measurement of the extent to which an entity can consistently produce an outcome."@en;
+  skos:scopeNote "Reliability concerns both a measure of past performance and the expectation that future performance will conform to the range of past performances."@en;
+  cco:ont00001754 "https://en.wikipedia.org/wiki/Reliability_(statistics)";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001309 a owl:Class;
+  rdfs:subClassOf cco:ont00000077;
+  rdfs:label "Lot Number"@en;
+  skos:definition "A Code Identifier that designates a particular quantity or lot of material from a single manufacturer."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Lot_number&oldid=1061846325"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001328 a owl:Class;
+  rdfs:subClassOf cco:ont00000398;
+  rdfs:label "Temporal Reference System"@en;
+  skos:altLabel "Temporal Reference Frame"@en, "Time Scale"@en;
+  skos:definition "A Reference System that describes a set of standards for measuring time as well as understanding the context of and organizing temporal data."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001331 a owl:Class;
+  rdfs:subClassOf cco:ont00001014;
+  rdfs:label "Legal Name"@en;
+  skos:definition "A Proper Name that is an official name for the designated entity as determined by a Government or court of law."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001340 a owl:Class;
+  rdfs:subClassOf cco:ont00000529;
+  rdfs:label "Calendar Date Identifier"@en;
+  skos:definition "A Date Identifier that designates some Day by using a combination of Day, Week, Month, or Year Identifiers formatted according to an implementation of a Calendar System."@en;
+  skos:example "January 1, 2018; 1 January 2018; 01/01/18; 01Jan18";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001351 a owl:Class;
+  rdfs:subClassOf cco:ont00000275;
+  rdfs:label "Cartesian Coordinate System"@en;
+  skos:altLabel "Rectangular Coordinate System"@en;
+  skos:definition "A Spatial Reference System that identifies each point in a spatial region of n-dimensions using an ordered n-tuple of numerical coordinates that are the signed (i.e. positive or negative) distances measured in the same unit of length from the zero point where the fixed perpendicular Coordinate System Axes meet."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Cartesian_coordinate_system&oldid=1058613323"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001352 a owl:Class;
+  rdfs:subClassOf cco:ont00000829;
+  rdfs:comment "Greenwich Mean Time (GMT) is the mean solar time at the Royal Observatory in Greenwich, London and has been superseded by Coordinated Universal Time (UTC)."@en;
+  rdfs:label "Greenwich Mean Time Zone Identifier"@en;
+  skos:definition "A Time Zone Identifier that designates a spatial region where the local time is calculated according to the specified offset from Greenwich Mean Time."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001364 a owl:Class;
+  owl:equivalentClass _:genid75;
+  rdfs:subClassOf cco:ont00001163;
+  rdfs:comment "Four of the subtypes of measurements used here (Interval, Nominal, Ordinal, and Ratio) were originally defined by S.S. Stevens in the article \"On the Theory of Scales of Measurement\" in Science, Vol. 103 No. 2684 on June 7, 1946. For an introductory article with links to additional content including criticisms and alternate classifications of measurements see https://en.wikipedia.org/wiki/Level_of_measurement"@en;
+  rdfs:label "Interval Measurement Information Content Entity"@en;
+  skos:definition "A Measurement Information Content Entity that places a Quality of an Entity onto some interval scale having no true zero value."@en;
+  skos:example "The sentence \"The temperature reached -27 degrees Fahrenheit on January 20, 1985 in Chicago, IL.\" is the carrier of an interval measurement as 0 degrees on the Fahrenheit scale does not describe absolute zero."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+_:genid75 a owl:Class;
+  owl:intersectionOf _:genid78 .
+
+_:genid78 a rdf:List;
+  rdf:first cco:ont00001163;
+  rdf:rest _:genid76 .
+
+_:genid76 a rdf:List;
+  rdf:first _:genid77;
+  rdf:rest rdf:nil .
+
+_:genid77 a owl:Restriction;
+  owl:someValuesFrom obo:BFO_0000001;
+  owl:onProperty cco:ont00001877 .
+
+cco:ont00002001 a owl:Class;
+  rdfs:subClassOf cco:ont00000958;
+  rdfs:label "Media Content Entity";
+  skos:definition "An information content entity presented in a canonical media format."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002002 a owl:Class;
+  rdfs:subClassOf cco:ont00002001;
+  rdfs:label "Certificate"@en;
+  skos:definition "A Media Content Entity that attests to certain demonstrated characteristics of an Object, Person, or Organization."@en;
+  cco:ont00001754 "http://www.dictionary.com/browse/degree";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002003 a owl:Class;
+  rdfs:subClassOf cco:ont00002002;
+  rdfs:label "Academic Degree"@en;
+  skos:definition "A Certificate issued by an Educational Organization to a Person to indicate that the Person has satisfactorily completed a course of study, or as an honorary recognition of the Person's achievement."@en;
+  cco:ont00001754 "http://www.dictionary.com/browse/degree";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002004 a owl:Class;
+  rdfs:subClassOf cco:ont00002001;
+  rdfs:label "Image"@en;
+  skos:definition "A Media Content Entity represents some entity owing to a visual isomorphism between the carrying artifact and the entity."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Image&oldid=1062709732"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002005 a owl:Class;
+  rdfs:subClassOf cco:ont00002004;
+  rdfs:label "Chart"@en;
+  skos:definition "An Image that is prescribed by some canonical visual format."@en;
+  cco:ont00001754 "Adapted from “Chart.” Merriam-Webster.com Dictionary, Merriam-Webster, https://www.merriam-webster.com/dictionary/chart. Accessed 4 Aug. 2024.";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002006 a owl:Class;
+  rdfs:subClassOf cco:ont00002001;
+  rdfs:label "Database"@en;
+  skos:definition "A Media Content Entity that is designed to be rapidly searchable and retrievable."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Database&oldid=1057024641"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002007 a owl:Class;
+  rdfs:subClassOf cco:ont00002001;
+  rdfs:label "List"@en;
+  skos:definition "A Media Content Entity whose parts are the subject of some Sequence Position Ordinality."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=List_(abstract_data_type)&oldid=1041588680"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002008 a owl:Class;
+  rdfs:subClassOf cco:ont00002007;
+  rdfs:label "Code List"@en;
+  skos:definition "A List whose parts are Code Identifiers."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002009 a owl:Class;
+  rdfs:subClassOf cco:ont00002001;
+  rdfs:label "Video"@en;
+  skos:definition "A Media Content Entity that contains a sequence of representations that are presented sufficiently rapidly to create the appearance of motion and continuity."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Video&oldid=1049376249"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002010 a owl:Class;
+  rdfs:subClassOf cco:ont00002001;
+  rdfs:label "Message"@en;
+  skos:definition "A Media Content Entity that is relatively brief and designed to be transmitted from a sender to a recipient."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Message&oldid=1060098631"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002011 a owl:Class;
+  rdfs:subClassOf cco:ont00002010;
+  rdfs:label "Warning Message"@en;
+  skos:definition "A Message that describes a possible or impending threat."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002012 a owl:Class;
+  rdfs:subClassOf cco:ont00002010;
+  rdfs:label "Email Message"@en;
+  skos:definition "A Message that is transmitted to the recipient's Email Box."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Email&oldid=1063646749"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002013 a owl:Class;
+  rdfs:subClassOf cco:ont00002010;
+  rdfs:label "Notification Message"@en;
+  skos:definition "A Message that describes a scenario that has been determined to merit attention by the recipient."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002014 a owl:Class;
+  rdfs:subClassOf cco:ont00002001;
+  rdfs:comment "For information on types of barcodes, see: https://www.scandit.com/types-barcodes-choosing-right-barcode/"@en;
+  rdfs:label "Barcode"@en;
+  skos:definition "A Media Content Entity that represents one or more geometric shapes that have, as part, some Directive Information Content Entity."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Barcode&oldid=1059844765"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002015 a owl:Class;
+  rdfs:subClassOf cco:ont00002014;
+  rdfs:label "Two-Dimensional Barcode"@en;
+  skos:definition "A Barcode that represents lines of varying widths, spacing, height, and color that has, as part, some Directive Information Content Entity."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002016 a owl:Class;
+  rdfs:subClassOf cco:ont00002015;
+  rdfs:label "Aztec Code"@en;
+  skos:definition "A Two-Dimensional Barcode that is used by the transportation industry to scan tickets."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002017 a owl:Class;
+  rdfs:subClassOf cco:ont00002015;
+  rdfs:label "Data Matrix Code"@en;
+  skos:definition "A Two-Dimensional Barcode that represents cells arranged in rectangular patterns and is used for marking small items in logistics and operations."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002018 a owl:Class;
+  rdfs:subClassOf cco:ont00002015;
+  rdfs:label "QR Code"@en;
+  skos:definition "A Two-Dimensional Barcode that represents numeric, alphanumeric, binary, or kanji information and is used primarily for tracking and marketing."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002019 a owl:Class;
+  rdfs:subClassOf cco:ont00002015;
+  rdfs:label "PDF417 Code"@en;
+  skos:definition "A Two-Dimensional Barcode that is used in applications that require the storage of huge amounts of data."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002020 a owl:Class;
+  rdfs:subClassOf cco:ont00002014;
+  rdfs:label "One-Dimensional Barcode"@en;
+  skos:definition "A Barcode that represents parallel lines of varying widths and spacing that concretize some Directive Information Content Entity."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002021 a owl:Class;
+  rdfs:subClassOf cco:ont00002020;
+  rdfs:label "Codabar Barcode"@en;
+  skos:definition "A One-Dimensional Barcode that represents numbers 0-9 and the characters -$:/.+ and is intended for use by logistics and healthcare professionals."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002022 a owl:Class;
+  rdfs:subClassOf cco:ont00002020;
+  rdfs:label "Code 93 Barcode"@en;
+  skos:definition "A One-Dimensional Barcode that represents 93 ASCII characters and is used in logistics to identify packages in retail inventory, lable electornic components, and provide supplementary delivery information."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002023 a owl:Class;
+  rdfs:subClassOf cco:ont00002020;
+  rdfs:label "ITF Barcode"@en;
+  skos:definition "A One-Dimensional Barcode that represents an even number of numerical characters and is used primarily in packaging and distribution."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002024 a owl:Class;
+  rdfs:subClassOf cco:ont00002020;
+  rdfs:label "MSI Plessey Barcode"@en;
+  skos:definition "A One-Dimensional Barcode that represents an indefinite number of numerical characters and is used for inventory control and marking storage containers and shelves in warehouse environments."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002025 a owl:Class;
+  rdfs:subClassOf cco:ont00002020;
+  rdfs:label "EAN Barcode"@en;
+  skos:definition "A One-Dimensional Barcode that represents 8 or 13 numerical digits and is used to scan consumer goods."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002026 a owl:Class;
+  rdfs:subClassOf cco:ont00002025;
+  rdfs:label "ISSN Barcode"@en;
+  skos:definition "An EAN Barcode that is designed to designate a periodical."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002027 a owl:Class;
+  rdfs:subClassOf cco:ont00002025;
+  rdfs:label "JAN-13 Barcode"@en;
+  skos:definition "An EAN Barcode that is designed to designate 13 numerical digits and is used primarily in Japan to designate products at the point of sale."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002028 a owl:Class;
+  rdfs:subClassOf cco:ont00002025;
+  rdfs:label "EAN-13 Barcode"@en;
+  skos:definition "An EAN Barcode that represents 13 numerical digits and is used to designate products at the point of sale."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002029 a owl:Class;
+  rdfs:subClassOf cco:ont00002025;
+  rdfs:label "EAN-8 Barcode"@en;
+  skos:definition "An EAN Barcode that represents 8 numerical digits and is used to designate products at the point of sale."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002030 a owl:Class;
+  rdfs:subClassOf cco:ont00002025;
+  rdfs:label "ISBN Barcode"@en;
+  skos:definition "An EAN Barcode that is designed to designate a book."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002031 a owl:Class;
+  rdfs:subClassOf cco:ont00002020;
+  rdfs:comment "Further variants of GS1 DataBar have not been defined here."@en;
+  rdfs:label "GS1 DataBar Barcode"@en;
+  skos:definition "A One-Dimensional Barcode that represents 12-14 numerical digits and is used in retail and healthcare."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002032 a owl:Class;
+  rdfs:subClassOf cco:ont00002020;
+  rdfs:label "Code 39 Barcode"@en;
+  skos:definition "A One-Dimensional Barcode that represents 39 characters that are numbers 0-9, capital letters A-Z, or the symbols -.$/+% and space and is used primarily in automotive and defense industries."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002033 a owl:Class;
+  rdfs:subClassOf cco:ont00002020;
+  rdfs:label "Code 128 Barcode"@en;
+  skos:definition "A One-Dimensional Barcode that represents to 128 ASCII characters and is used primarily in supply chains."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002034 a owl:Class;
+  rdfs:subClassOf cco:ont00002020;
+  rdfs:label "UPC Barcode"@en;
+  skos:definition "A One-Dimensional Barcode that represents 6 or 12 numerical digits and is used to scan consumer goods."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002035 a owl:Class;
+  rdfs:subClassOf cco:ont00002034;
+  rdfs:label "UPC-A Barcode"@en;
+  skos:definition "A UPC Barcode that represents 12 numerical digits."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002036 a owl:Class;
+  rdfs:subClassOf cco:ont00002034;
+  rdfs:label "UPC-E Barcode"@en;
+  skos:definition "A UPC Barcode that represents 6 numerical digits."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002037 a owl:Class;
+  rdfs:subClassOf cco:ont00002001;
+  rdfs:label "Information Line"@en;
+  skos:definition "A Media Content entity consisting of a single line or row in some Document Content entity of which it is a part."@en;
+  skos:example "a line in a computer file that bears a portion of code for some computer program",
+    "a line of data in a database", "a line of text in a book";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002038 a owl:Class;
+  rdfs:subClassOf cco:ont00000958;
+  rdfs:label "Document Field Content"@en;
+  skos:altLabel "Document Field"@en;
+  skos:definition "A Media Content Entity that is a part of some document content entity, and which  prescribes the eliciation of information to be written or selected within the document content entity."@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002039 a owl:Class;
+  rdfs:subClassOf cco:ont00002001;
+  rdfs:label "Document Content Entity"@en;
+  skos:altLabel "Document"@en;
+  skos:definition "A Media Information Content that consists of a series of paragraphs of text or diagrams that are intended to be carried by physical pieces of paper or an electronic word processor file."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Document&oldid=1057829688"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002040 a owl:Class;
+  rdfs:subClassOf cco:ont00002039;
+  rdfs:label "Book"@en;
+  skos:definition "A Document Content Entity that canonically appears as ink on paper or parchment, or other materials fastened together to hinge at one side."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Book&oldid=1063132471"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002041 a owl:Class;
+  rdfs:subClassOf cco:ont00002039;
+  rdfs:label "Transcript"@en;
+  skos:definition "A Document Content Entity that was originally recorded in a different medium."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Transcript&oldid=1038510063"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002042 a owl:Class;
+  rdfs:subClassOf cco:ont00002039;
+  rdfs:label "Spreadsheet"@en;
+  skos:definition "A Document Content Entity that canonically appears as a interactive, tabular form."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Spreadsheet&oldid=1064060503"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002043 a owl:Class;
+  rdfs:subClassOf cco:ont00002039;
+  rdfs:label "Report"@en;
+  skos:definition "A Document Content entity that conveys an account of some event, situation, or the result of some observation or inquiry."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Report&oldid=1063765657"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002044 a owl:Class;
+  rdfs:subClassOf cco:ont00002039;
+  rdfs:label "Form Document"@en;
+  skos:definition "A Document Content Entity that has Document Field Contents as parts."@en;
+  cco:ont00001754 "https://en.wikipedia.org/wiki/Form_(document)";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00002045 a owl:Class;
+  rdfs:subClassOf cco:ont00002039;
+  rdfs:label "Journal Article"@en;
+  skos:definition "A Document Content Entity that is part of a Journal Issue."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Academic_journal&oldid=1059723283"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001392 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT-8"@en;
+  skos:altLabel "PST"@en, "Pacific Standard Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001395 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT-3:30"@en;
+  skos:altLabel "Newfoundland Standard Time"@en;
+  cco:ont00001753 "NST";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001398 a owl:NamedIndividual, cco:ont00000469;
+  rdfs:label "Global Area Reference System"@en;
+  cco:ont00001753 "GARS";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001403 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC+2"@en;
+  rdfs:label "Bravo Time Zone"@en;
+  cco:ont00001753 "B";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001405 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT-2"@en;
+  skos:altLabel "BET"@en, "Brazil Eastern Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001406 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT+9:30"@en;
+  skos:altLabel "Australian Central Standard Time"@en;
+  cco:ont00001753 "ACST";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001408 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC-11"@en;
+  rdfs:label "X-ray Time Zone"@en;
+  cco:ont00001753 "X";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001412 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC+0"@en;
+  rdfs:label "GMT"@en;
+  skos:altLabel "Greenwich Mean Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001414 a owl:NamedIndividual, cco:ont00001328;
+  rdfs:comment "TT is an astronomical time standard that is a theoretical ideal designed to be free of the irregularities in Earth's rotation and is primarily used for time measurements of astronomical observations made from the surface of Earth. It was formerly called Terrestrial Dynamical Time (TDT), which was formulated to replace Ephemeris Time (ET)."@en;
+  rdfs:label "Terrestrial Time"@en;
+  cco:ont00001753 "TT";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001417 a owl:NamedIndividual, cco:ont00001328;
+  rdfs:comment "ET is an astronomical time scale that was adopted as a standard in 1952 by the IAU but has since been superseded and is no longer actively used. ET is based on the ephemeris second, which was defined as a fraction of the tropical year for 1900 January 01 as calculated using Newcomb's 1895 tables of the Sun. ET was designed to avoid problems caused by variations in Earth's rotational period and was used for Solar System ephemeris calculations until being replaced by Terrestrial Dynamical Time (TDT) in 1979."@en;
+  rdfs:label "Ephemeris Time"@en;
+  cco:ont00001753 "ET";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001419 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT+5"@en;
+  skos:altLabel "PLT"@en, "Pakistan Lahore Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001421 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC-6"@en;
+  rdfs:label "Sierra Time Zone"@en;
+  cco:ont00001753 "S";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001424 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC+1"@en;
+  rdfs:label "Alpha Time Zone"@en;
+  cco:ont00001753 "A";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001430 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC+6"@en;
+  rdfs:label "Foxtrot Time Zone"@en;
+  cco:ont00001753 "F";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001431 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC-10"@en;
+  rdfs:label "Whiskey Time Zone"@en;
+  cco:ont00001753 "W";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001434 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT+1"@en;
+  skos:altLabel "ECT"@en, "European Central Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001436 a owl:NamedIndividual, cco:ont00000630;
+  rdfs:label "Universal Time 1 D"@en;
+  cco:ont00001753 "UT1D";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001439 a owl:NamedIndividual, cco:ont00000263;
+  rdfs:label "Twenty-Four-Hour Clock Time System"@en;
+  skos:altLabel "24-Hour Clock"@en, "24-Hour Clock Time System"@en, "Military Time"@en,
+    "Military Time System"@en, "Twenty-Four Hour Clock Time System"@en, "Twenty-Four-Hour Clock"@en;
+  skos:definition "A Clock Time System for time keeping in which the Day runs from midnight to midnight and is divided into 24 Hours, indicated by the Hours passed since midnight, from 0 to 23."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=24-hour_clock&oldid=1063744105"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001440 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT-9"@en;
+  skos:altLabel "AST"@en, "Alaska Standard Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001446 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Mike Time Zone is the same local time as Yankee Time Zone, but is 1 Day (i.e. 24 Hours) ahead of Yankee Time Zone as they are on opposite sides of the International Date Line."@en,
+    "Offset from Universal Coordinated Time = UTC+12"@en;
+  rdfs:label "Mike Time Zone"@en;
+  cco:ont00001753 "M";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001454 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC+11"@en;
+  rdfs:label "Lima Time Zone"@en;
+  cco:ont00001753 "L";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001457 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC-4"@en;
+  rdfs:label "Quebec Time Zone"@en;
+  cco:ont00001753 "Q";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001461 a owl:NamedIndividual, cco:ont00001328;
+  rdfs:comment "TDB is a linear scaling of Barycentric Coordinate Time (TCB) and is a relativistic coordinate time scale used in astronomy as a time standard that accounts for time dilation when calculating Orbits and Ephemerides of Astronomical Bodies and interplanetary Spacecraft in the Solar System. TDB is a successor of Ephemeris Time (ET) and is nearly equivalent to the time scale Teph used for DE405 planetary and lunar ephemerides generated by the Jet Propulsion Laboratory."@en;
+  rdfs:label "Barycentric Dynamical Time"@en;
+  cco:ont00001753 "TDB";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001467 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT-4"@en;
+  skos:altLabel "PRT"@en, "Puerto Rico and US Virgin Islands Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001468 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT+10"@en;
+  skos:altLabel "AET"@en, "Australia Eastern Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001476 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT+4"@en;
+  skos:altLabel "NET"@en, "Near East Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001480 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC+9"@en;
+  rdfs:label "India Time Zone"@en;
+  cco:ont00001753 "I";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001488 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC-7"@en;
+  rdfs:label "Tango Time Zone"@en;
+  cco:ont00001753 "T";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001491 a owl:NamedIndividual, cco:ont00000630;
+  rdfs:label "Universal Time 1 A"@en;
+  cco:ont00001753 "UT1A";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001500 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC+5"@en;
+  rdfs:label "Echo Time Zone"@en;
+  cco:ont00001753 "E";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001506 a owl:NamedIndividual, cco:ont00000630;
+  rdfs:label "Universal Time 1 F"@en;
+  cco:ont00001753 "UT1F";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001516 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC-2"@en;
+  rdfs:label "Oscar Time Zone"@en;
+  cco:ont00001753 "O";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001524 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT-11"@en;
+  skos:altLabel "MIT"@en, "Midway Islands Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001527 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC+8"@en;
+  rdfs:label "Hotel Time Zone"@en;
+  cco:ont00001753 "H";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001529 a owl:NamedIndividual, cco:ont00001328;
+  rdfs:comment """\"TCG is a coordinate time standard intended to be used as the independent variable of time for all calculations pertaining to precession, nutation, the Moon, and artificial satellites of the Earth. It is equivalent to the proper time experienced by a clock at rest in a coordinate frame co-moving with the center of the Earth: that is, a clock that performs exactly the same movements as the Earth but is outside the Earth's gravity well. It is therefore not influenced by the gravitational time dilation caused by the Earth.\"
+From: (https://en.wikipedia.org/wiki/Geocentric_Coordinate_Time)"""@en;
+  rdfs:label "Geocentric Coordinate Time"@en;
+  cco:ont00001753 "TCG";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001534 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT+7"@en;
+  skos:altLabel "VST"@en, "Vietnam Standard Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001537 a owl:NamedIndividual, cco:ont00000067, cco:ont00000630;
+  rdfs:comment "UTC is a variant of Universal Time that is calculated by combining Universal Time 1 with International Atomic Time by occasionally adding leap seconds to TAI in order to maintain UTC within 0.9 seconds of UT1. The difference between UTC and UT1 is called DUT1 and always has a value between -0.9 seconds and +0.9 seconds. Coordinated Universal Time is the current basis for civil time and is the reference time for time zones, whose local times are defined based on an offset from UTC."@en;
+  rdfs:label "Coordinated Universal Time"@en;
+  cco:ont00001753 "UTC";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001541 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT+12"@en;
+  skos:altLabel "NST"@en, "New Zealand Standard Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001548 a owl:NamedIndividual, cco:ont00000630;
+  rdfs:comment "UT1R is a variant of Universal Time that is a smoothed version of UT1 by filtering out periodic variations due to tidal waves."@en;
+  rdfs:label "Universal Time 1 R"@en;
+  cco:ont00001753 "UT1R";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001550 a owl:NamedIndividual, cco:ont00000276;
+  rdfs:comment "The Julian Calendar was proposed by Julius Caesar as a reform of the Roman Calendar, took effect on 1 January 46 BC, and was the predominant Calendar System in Europe until being largely replaced by the Gregorian Calendar."@en;
+  rdfs:label "Julian Calendar"@en;
+  skos:definition "A Solar Calendar System that has a regular Year of 365 24-Hour Days divided into 12 Months with a leap day added at the end of February every 4 Years such that the average length of a Julian Year is 365.25 Days."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Julian_calendar&oldid=1063127575"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001553 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT+6"@en;
+  skos:altLabel "BST"@en, "Bangladesh Standard Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001554 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT-10"@en;
+  skos:altLabel "HST"@en, "Hawaii Standard Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001565 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT-5"@en;
+  skos:altLabel "EST"@en, "Eastern Standard Time"@en, "IET"@en, "Indiana Eastern Standard Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001570 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT+2"@en;
+  skos:altLabel "EET"@en, "Eastern European Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001580 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC-3"@en;
+  rdfs:label "Papa Time Zone"@en;
+  cco:ont00001753 "P";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001581 a owl:NamedIndividual, cco:ont00000469;
+  rdfs:comment """The ITRS definition fulfills the following conditions:
 1. It is geocentric, the center of mass being defined for the whole earth, including oceans and atmosphere.
 2. The unit of length is the metre (SI). This scale is consistent with the TCG time coordinate for a geocentric local frame, in agreement with IAU and IUGG (1991) resolutions. This is obtained by appropriate relativistic modelling.
 3. Its orientation was initially given by the BIH orientation at 1984.0.
 4. The time evolution of the orientation is ensured by using a no-net-rotation condition with regards to horizontal tectonic motions over the whole earth.
-From: (https://www.iers.org/IERS/EN/Science/ITRS/ITRS.html)"""@en ;
-                rdfs:label "International Terrestrial Reference System"@en ;
-                cco:ont00001753 "ITRS" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001582
-cco:ont00001582 rdf:type owl:NamedIndividual ,
-                         cco:ont00000469 ;
-                rdfs:label "Universal Transverse Mercator Reference System"@en ;
-                cco:ont00001753 "UTM" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001584
-cco:ont00001584 rdf:type owl:NamedIndividual ,
-                         cco:ont00000469 ;
-                rdfs:label "World Geographic Reference System"@en ;
-                cco:ont00001753 "WGRS" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001588
-cco:ont00001588 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT+9"@en ;
-                skos:altLabel "JST"@en ,
-                              "Japan Standard Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001590
-cco:ont00001590 rdf:type owl:NamedIndividual ,
-                         cco:ont00001328 ;
-                rdfs:comment "TAI is a time standard the values of which are generated by calculating the weighted average of the measurements of more than 400 atomic clocks and is based on the International System of Units (SI) definition of one second equals the time it takes a Cesium-133 atom at the ground state to oscillate exactly 9,192,631,770 times. TAI is extremely precise, but does not perfectly synchronize with Earth times, which is why TAI and UT1 are both used to determine UTC. TAI serves as the main realization of TT."@en ;
-                rdfs:label "International Atomic Time"@en ;
-                cco:ont00001753 "TAI" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001591
-cco:ont00001591 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC-8"@en ;
-                rdfs:label "Uniform Time Zone"@en ;
-                cco:ont00001753 "U" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001597
-cco:ont00001597 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT+11"@en ;
-                skos:altLabel "SST"@en ,
-                              "Solomon Standard Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001599
-cco:ont00001599 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT+3:30"@en ;
-                skos:altLabel "Iran Standard Time"@en ,
-                              "Iran Time"@en ;
-                cco:ont00001753 "IRST" ,
-                                "IT" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001603
-cco:ont00001603 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC-1"@en ;
-                rdfs:label "November Time Zone"@en ;
-                cco:ont00001753 "N" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001607
-cco:ont00001607 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC-9"@en ;
-                rdfs:label "Victor Time Zone"@en ;
-                cco:ont00001753 "V" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001615
-cco:ont00001615 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT-7"@en ;
-                skos:altLabel "MST"@en ,
-                              "Mountain Standard Time"@en ,
-                              "PNT"@en ,
-                              "Phoenix Standard Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001624
-cco:ont00001624 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC+7"@en ;
-                rdfs:label "Golf Time Zone"@en ;
-                cco:ont00001753 "G" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001625
-cco:ont00001625 rdf:type owl:NamedIndividual ,
-                         cco:ont00000630 ;
-                rdfs:comment "UT0 is a variant of Universal Time that is measured by observing the diurnal motion of stars or extragalactic radio sources at a specific location on Earth. It does not take into consideration distorting factors, in particular polar motion, such that its value will differ based on the location it is measured at."@en ;
-                rdfs:label "Universal Time 0"@en ;
-                cco:ont00001753 "UT0" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001626
-cco:ont00001626 rdf:type owl:NamedIndividual ,
-                         cco:ont00000263 ;
-                rdfs:label "Twelve-Hour Clock Time System"@en ;
-                skos:altLabel "12-Hour Clock"@en ,
-                              "12-Hour Clock Time System"@en ,
-                              "Twelve Hour Clock"@en ,
-                              "Twelve Hour Clock Time System"@en ,
-                              "Twelve-Hour Clock"@en ;
-                skos:definition "A Clock Time System for keeping the Time of Day in which the Day runs from midnight to midnight and is divided into two intervals of 12 Hours each, where: the first interval begins at midnight, ends at noon, and is indicated by the suffix 'a.m.'; the second interval begins at noon, ends at midnight, and is indicated by the suffix 'p.m.'; and the midnight and noon Hours are numbered 12 with subsequent Hours numbered 1-11."@en ;
-                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=12-hour_clock&oldid=1057602523"^^xsd:anyURI ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001628
-cco:ont00001628 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC-12"@en ,
-                             "Yankee Time Zone is the same local time as Mike Time Zone, but is 1 Day (i.e. 24 Hours) behind Mike Time Zone as they are on opposite sides of the International Date Line."@en ;
-                rdfs:label "Yankee Time Zone"@en ;
-                cco:ont00001753 "Y" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001630
-cco:ont00001630 rdf:type owl:NamedIndividual ,
-                         cco:ont00000469 ;
-                rdfs:comment """\"WGS 84 is an Earth-centered, Earth-fixed terrestrial reference system and geodetic datum. WGS 84 is based on a consistent set of constants and model parameters that describe the Earth's size, shape, and gravity and geomagnetic fields. WGS 84 is the standard U.S. Department of Defense definition of a global reference system for geospatial information and is the reference system for the Global Positioning System (GPS). It is compatible with the International Terrestrial Reference System (ITRS).\"
-From: (http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf)"""@en ;
-                rdfs:label "World Geodetic System 1984"@en ;
-                cco:ont00001753 "WGS 84" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001634
-cco:ont00001634 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT-1"@en ;
-                skos:altLabel "CAT"@en ,
-                              "Central African Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001648
-cco:ont00001648 rdf:type owl:NamedIndividual ,
-                         cco:ont00000469 ,
-                         cco:ont00001351 ;
-                rdfs:label "Earth-Centered Earth-Fixed Coordinate System"@en ;
-                skos:altLabel "Conventional Terrestrial Coordinate System"@en ,
-                              "ECEF"@en ,
-                              "ECR"@en ,
-                              "Earth Centered Earth Fixed"@en ,
-                              "Earth Centered Rotational Coordinate System"@en ,
-                              "Earth-Centered Earth-Fixed"@en ,
-                              "Earth-Centered, Earth-Fixed"@en ;
-                skos:definition "A Geospatial and Cartesian Coordinate System that identifies positions using an x-axis, y-axis, and z-axis coordinate where the zero point is the center of the Earth, the z-Axis extends toward the North Pole but does not always coincide exactly with the Earth's Axis of Rotation, the x-Axis extends through the intersection of the Prime Meridian and the Equator, the y-Axis completes the right-handed system, and all three axes are fixed to the Earth such that they rotate along with the Earth."@en ;
-                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Earth-centered,_Earth-fixed_coordinate_system&oldid=1062678600"^^xsd:anyURI ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001658
-cco:ont00001658 rdf:type owl:NamedIndividual ,
-                         cco:ont00001328 ;
-                rdfs:comment "Teph (the 'eph' is written as subscript) is an ephemeris time argument developed and calculated at the Jet Propulsion Laboratory (JPL) and implemented in a series of numerically integrated Development Ephemerides (DE), including the currently used DE405. Teph is characterized as a relativistic coordinate time that is nearly equivalent to the IAU's definition of TCB, though Teph is not currently an IAU time standard. Teph is used by the JPL to generate the ephemerides it publishes to support spacecraft navigation and astronomy."@en ;
-                rdfs:label "Jet Propulsion Laboratory Ephemeris Time Argument"@en ;
-                skos:altLabel "JPL Ephemeris Time"@en ;
-                cco:ont00001753 "Teph" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001660
-cco:ont00001660 rdf:type owl:NamedIndividual ,
-                         cco:ont00000469 ;
-                rdfs:comment "This global main field model provides magnetic field values for any location on Earth, e.g. for  navigational purposes (declination) or as a standard for core field subtraction for aeromagnetic surveys. An updated version is adopted by International Association of Geomagnetism and Aeronomy (IAGA) every 5 years)."@en ;
-                rdfs:label "International Geomagnetic Reference Field"@en ;
-                cco:ont00001754 "Alken, P., Thébault, E., Beggan, C.D. et al. International Geomagnetic Reference Field: the thirteenth generation. Earth Planets Space 73, 49 (2021). https://doi.org/10.1186/s40623-020-01288-x , https://www.iaga-aiga.org/" .
-
-
-###  https://www.commoncoreontologies.org/ont00001661
-cco:ont00001661 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT+8"@en ;
-                skos:altLabel "CTT"@en ,
-                              "China Taiwan Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001666
-cco:ont00001666 rdf:type owl:NamedIndividual ,
-                         cco:ont00001328 ;
-                rdfs:comment """\"Barycentric Coordinate Time (TCB, from the French Temps-coordonnée barycentrique) is a coordinate time standard intended to be used as the independent variable of time for all calculations pertaining to orbits of planets, asteroids, comets, and interplanetary spacecraft in the Solar system. It is equivalent to the proper time experienced by a clock at rest in a coordinate frame co-moving with the barycenter of the Solar system: that is, a clock that performs exactly the same movements as the Solar system but is outside the system's gravity well. It is therefore not influenced by the gravitational time dilation caused by the Sun and the rest of the system.\"
-From: (https://en.wikipedia.org/wiki/Barycentric_Coordinate_Time)"""@en ;
-                rdfs:label "Barycentric Coordinate Time"@en ;
-                cco:ont00001753 "TCB" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001674
-cco:ont00001674 rdf:type owl:NamedIndividual ,
-                         cco:ont00000276 ;
-                rdfs:comment "The Gregorian Calendar was instituted by Pope Gregory XIII via papal bull on 24 February 1582 as a reform of the Julian Calendar to stop the drift of the calendar with respect to the equinoxes and solstices. The Gregorian Calendar is currently the most widely used civil Calendar System in the world and is 13 days ahead of the Julian Calendar Date."@en ;
-                rdfs:label "Gregorian Calendar"@en ;
-                skos:definition "A Solar Calendar System that has a regular Year of 365 24-Hour Days divided into 12 Months with a leap day added at the end of February every 4 Years except Years that are evenly divisible by 100 but not 400 such that there are 97 leap Years every 400 Years and the average length of a Gregorian Year is 365.2425 Days (365 Days 5 Hours 49 Minutes 12 Seconds)."@en ;
-                cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Gregorian_calendar&oldid=1062360692"^^xsd:anyURI ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001691
-cco:ont00001691 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT-6"@en ;
-                skos:altLabel "CST"@en ,
-                              "Central Standard Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001692
-cco:ont00001692 rdf:type owl:NamedIndividual ,
-                         cco:ont00001328 ;
-                rdfs:comment """Unix Time is a Temporal Reference System for describing a point in time, defined as the number of seconds that have elapsed since 00:00:00 Coordinated Universal Time (UTC) Thursday, 1 January 1970 minus the number of leap seconds that have taken place since then.
-(See: https://en.wikipedia.org/wiki/Unix_time)"""@en ;
-                rdfs:label "Unix Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001693
-cco:ont00001693 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC+0"@en ;
-                rdfs:label "Zulu Time Zone"@en ;
-                cco:ont00001753 "Z" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001695
-cco:ont00001695 rdf:type owl:NamedIndividual ,
-                         cco:ont00000630 ;
-                rdfs:comment "UT2 is a variant of Universal Time that smooths UT1 by accounting for both polar motion and variations in Earth's rotation due to seasonal factors, such as changes in vegetation and water or snow distribution."@en ;
-                rdfs:label "Universal Time 2"@en ;
-                cco:ont00001753 "UT2" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001700
-cco:ont00001700 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Juliet time is used as an indexical to refer to local time without otherwise specifying the time zone."@en ;
-                rdfs:label "Juliet Time Zone"@en ;
-                cco:ont00001753 "J" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001701
-cco:ont00001701 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT-3"@en ;
-                skos:altLabel "AGT"@en ,
-                              "Argentina Standard Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001702
-cco:ont00001702 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT+5:30"@en ;
-                skos:altLabel "Indian Standard Time"@en ,
-                              "Sri Lanka Standard Time"@en ;
-                cco:ont00001753 "IST" ,
-                                "SLST" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001704
-cco:ont00001704 rdf:type owl:NamedIndividual ,
-                         cco:ont00001352 ;
-                rdfs:label "GMT+3"@en ;
-                skos:altLabel "EAT"@en ,
-                              "Eastern African Time"@en ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001712
-cco:ont00001712 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC-5"@en ;
-                rdfs:label "Romeo Time Zone"@en ;
-                cco:ont00001753 "R" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001716
-cco:ont00001716 rdf:type owl:NamedIndividual ,
-                         cco:ont00000630 ;
-                rdfs:comment "UT1 is a derivation of UT0 that takes into account distortions caused by polar motion and is proportional to the rotation angle of the Earth with respect to distant quasars, specifically, the International Celestial Reference Frame (ICRF). UT1 is currently the most widely used variant of Universal Time and has the same value everywhere on Earth."@en ;
-                rdfs:label "Universal Time 1"@en ;
-                skos:altLabel "Astronomical Time"@en ;
-                cco:ont00001753 "UT1" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001723
-cco:ont00001723 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC+4"@en ;
-                rdfs:label "Delta Time Zone"@en ;
-                cco:ont00001753 "D" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001727
-cco:ont00001727 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC+10"@en ;
-                rdfs:label "Kilo Time Zone"@en ;
-                cco:ont00001753 "K" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001732
-cco:ont00001732 rdf:type owl:NamedIndividual ,
-                         cco:ont00001235 ;
-                rdfs:comment "Offset from Universal Coordinated Time = UTC+3"@en ;
-                rdfs:label "Charlie Time Zone"@en ;
-                cco:ont00001753 "C" ;
-                cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
-
-
-###  Generated by the OWL API (version 4.5.26.2023-07-17T20:34:13Z) https://github.com/owlcs/owlapi
+From: (https://www.iers.org/IERS/EN/Science/ITRS/ITRS.html)"""@en;
+  rdfs:label "International Terrestrial Reference System"@en;
+  cco:ont00001753 "ITRS";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001582 a owl:NamedIndividual, cco:ont00000469;
+  rdfs:label "Universal Transverse Mercator Reference System"@en;
+  cco:ont00001753 "UTM";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001584 a owl:NamedIndividual, cco:ont00000469;
+  rdfs:label "World Geographic Reference System"@en;
+  cco:ont00001753 "WGRS";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001588 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT+9"@en;
+  skos:altLabel "JST"@en, "Japan Standard Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001590 a owl:NamedIndividual, cco:ont00001328;
+  rdfs:comment "TAI is a time standard the values of which are generated by calculating the weighted average of the measurements of more than 400 atomic clocks and is based on the International System of Units (SI) definition of one second equals the time it takes a Cesium-133 atom at the ground state to oscillate exactly 9,192,631,770 times. TAI is extremely precise, but does not perfectly synchronize with Earth times, which is why TAI and UT1 are both used to determine UTC. TAI serves as the main realization of TT."@en;
+  rdfs:label "International Atomic Time"@en;
+  cco:ont00001753 "TAI";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001591 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC-8"@en;
+  rdfs:label "Uniform Time Zone"@en;
+  cco:ont00001753 "U";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001597 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT+11"@en;
+  skos:altLabel "SST"@en, "Solomon Standard Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001599 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT+3:30"@en;
+  skos:altLabel "Iran Standard Time"@en, "Iran Time"@en;
+  cco:ont00001753 "IRST", "IT";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001603 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC-1"@en;
+  rdfs:label "November Time Zone"@en;
+  cco:ont00001753 "N";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001607 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC-9"@en;
+  rdfs:label "Victor Time Zone"@en;
+  cco:ont00001753 "V";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001615 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT-7"@en;
+  skos:altLabel "MST"@en, "Mountain Standard Time"@en, "PNT"@en, "Phoenix Standard Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001624 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC+7"@en;
+  rdfs:label "Golf Time Zone"@en;
+  cco:ont00001753 "G";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001625 a owl:NamedIndividual, cco:ont00000630;
+  rdfs:comment "UT0 is a variant of Universal Time that is measured by observing the diurnal motion of stars or extragalactic radio sources at a specific location on Earth. It does not take into consideration distorting factors, in particular polar motion, such that its value will differ based on the location it is measured at."@en;
+  rdfs:label "Universal Time 0"@en;
+  cco:ont00001753 "UT0";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001626 a owl:NamedIndividual, cco:ont00000263;
+  rdfs:label "Twelve-Hour Clock Time System"@en;
+  skos:altLabel "12-Hour Clock"@en, "12-Hour Clock Time System"@en, "Twelve Hour Clock"@en,
+    "Twelve Hour Clock Time System"@en, "Twelve-Hour Clock"@en;
+  skos:definition "A Clock Time System for keeping the Time of Day in which the Day runs from midnight to midnight and is divided into two intervals of 12 Hours each, where: the first interval begins at midnight, ends at noon, and is indicated by the suffix 'a.m.'; the second interval begins at noon, ends at midnight, and is indicated by the suffix 'p.m.'; and the midnight and noon Hours are numbered 12 with subsequent Hours numbered 1-11."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=12-hour_clock&oldid=1057602523"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001628 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC-12"@en, "Yankee Time Zone is the same local time as Mike Time Zone, but is 1 Day (i.e. 24 Hours) behind Mike Time Zone as they are on opposite sides of the International Date Line."@en;
+  rdfs:label "Yankee Time Zone"@en;
+  cco:ont00001753 "Y";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001630 a owl:NamedIndividual, cco:ont00000469;
+  rdfs:comment """\"WGS 84 is an Earth-centered, Earth-fixed terrestrial reference system and geodetic datum. WGS 84 is based on a consistent set of constants and model parameters that describe the Earth's size, shape, and gravity and geomagnetic fields. WGS 84 is the standard U.S. Department of Defense definition of a global reference system for geospatial information and is the reference system for the Global Positioning System (GPS). It is compatible with the International Terrestrial Reference System (ITRS).\"
+From: (http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf)"""@en;
+  rdfs:label "World Geodetic System 1984"@en;
+  cco:ont00001753 "WGS 84";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001634 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT-1"@en;
+  skos:altLabel "CAT"@en, "Central African Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001648 a owl:NamedIndividual, cco:ont00000469, cco:ont00001351;
+  rdfs:label "Earth-Centered Earth-Fixed Coordinate System"@en;
+  skos:altLabel "Conventional Terrestrial Coordinate System"@en, "ECEF"@en, "ECR"@en,
+    "Earth Centered Earth Fixed"@en, "Earth Centered Rotational Coordinate System"@en,
+    "Earth-Centered Earth-Fixed"@en, "Earth-Centered, Earth-Fixed"@en;
+  skos:definition "A Geospatial and Cartesian Coordinate System that identifies positions using an x-axis, y-axis, and z-axis coordinate where the zero point is the center of the Earth, the z-Axis extends toward the North Pole but does not always coincide exactly with the Earth's Axis of Rotation, the x-Axis extends through the intersection of the Prime Meridian and the Equator, the y-Axis completes the right-handed system, and all three axes are fixed to the Earth such that they rotate along with the Earth."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Earth-centered,_Earth-fixed_coordinate_system&oldid=1062678600"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001658 a owl:NamedIndividual, cco:ont00001328;
+  rdfs:comment "Teph (the 'eph' is written as subscript) is an ephemeris time argument developed and calculated at the Jet Propulsion Laboratory (JPL) and implemented in a series of numerically integrated Development Ephemerides (DE), including the currently used DE405. Teph is characterized as a relativistic coordinate time that is nearly equivalent to the IAU's definition of TCB, though Teph is not currently an IAU time standard. Teph is used by the JPL to generate the ephemerides it publishes to support spacecraft navigation and astronomy."@en;
+  rdfs:label "Jet Propulsion Laboratory Ephemeris Time Argument"@en;
+  skos:altLabel "JPL Ephemeris Time"@en;
+  cco:ont00001753 "Teph";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001660 a owl:NamedIndividual, cco:ont00000469;
+  rdfs:comment "This global main field model provides magnetic field values for any location on Earth, e.g. for  navigational purposes (declination) or as a standard for core field subtraction for aeromagnetic surveys. An updated version is adopted by International Association of Geomagnetism and Aeronomy (IAGA) every 5 years)."@en;
+  rdfs:label "International Geomagnetic Reference Field"@en;
+  cco:ont00001754 "Alken, P., Thébault, E., Beggan, C.D. et al. International Geomagnetic Reference Field: the thirteenth generation. Earth Planets Space 73, 49 (2021). https://doi.org/10.1186/s40623-020-01288-x , https://www.iaga-aiga.org/" .
+
+cco:ont00001661 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT+8"@en;
+  skos:altLabel "CTT"@en, "China Taiwan Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001666 a owl:NamedIndividual, cco:ont00001328;
+  rdfs:comment """\"Barycentric Coordinate Time (TCB, from the French Temps-coordonnée barycentrique) is a coordinate time standard intended to be used as the independent variable of time for all calculations pertaining to orbits of planets, asteroids, comets, and interplanetary spacecraft in the Solar system. It is equivalent to the proper time experienced by a clock at rest in a coordinate frame co-moving with the barycenter of the Solar system: that is, a clock that performs exactly the same movements as the Solar system but is outside the system's gravity well. It is therefore not influenced by the gravitational time dilation caused by the Sun and the rest of the system.\"
+From: (https://en.wikipedia.org/wiki/Barycentric_Coordinate_Time)"""@en;
+  rdfs:label "Barycentric Coordinate Time"@en;
+  cco:ont00001753 "TCB";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001674 a owl:NamedIndividual, cco:ont00000276;
+  rdfs:comment "The Gregorian Calendar was instituted by Pope Gregory XIII via papal bull on 24 February 1582 as a reform of the Julian Calendar to stop the drift of the calendar with respect to the equinoxes and solstices. The Gregorian Calendar is currently the most widely used civil Calendar System in the world and is 13 days ahead of the Julian Calendar Date."@en;
+  rdfs:label "Gregorian Calendar"@en;
+  skos:definition "A Solar Calendar System that has a regular Year of 365 24-Hour Days divided into 12 Months with a leap day added at the end of February every 4 Years except Years that are evenly divisible by 100 but not 400 such that there are 97 leap Years every 400 Years and the average length of a Gregorian Year is 365.2425 Days (365 Days 5 Hours 49 Minutes 12 Seconds)."@en;
+  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Gregorian_calendar&oldid=1062360692"^^xsd:anyURI;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001691 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT-6"@en;
+  skos:altLabel "CST"@en, "Central Standard Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001692 a owl:NamedIndividual, cco:ont00001328;
+  rdfs:comment """Unix Time is a Temporal Reference System for describing a point in time, defined as the number of seconds that have elapsed since 00:00:00 Coordinated Universal Time (UTC) Thursday, 1 January 1970 minus the number of leap seconds that have taken place since then.
+(See: https://en.wikipedia.org/wiki/Unix_time)"""@en;
+  rdfs:label "Unix Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001693 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC+0"@en;
+  rdfs:label "Zulu Time Zone"@en;
+  cco:ont00001753 "Z";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001695 a owl:NamedIndividual, cco:ont00000630;
+  rdfs:comment "UT2 is a variant of Universal Time that smooths UT1 by accounting for both polar motion and variations in Earth's rotation due to seasonal factors, such as changes in vegetation and water or snow distribution."@en;
+  rdfs:label "Universal Time 2"@en;
+  cco:ont00001753 "UT2";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001700 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Juliet time is used as an indexical to refer to local time without otherwise specifying the time zone."@en;
+  rdfs:label "Juliet Time Zone"@en;
+  cco:ont00001753 "J";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001701 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT-3"@en;
+  skos:altLabel "AGT"@en, "Argentina Standard Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001702 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT+5:30"@en;
+  skos:altLabel "Indian Standard Time"@en, "Sri Lanka Standard Time"@en;
+  cco:ont00001753 "IST", "SLST";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001704 a owl:NamedIndividual, cco:ont00001352;
+  rdfs:label "GMT+3"@en;
+  skos:altLabel "EAT"@en, "Eastern African Time"@en;
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001712 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC-5"@en;
+  rdfs:label "Romeo Time Zone"@en;
+  cco:ont00001753 "R";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001716 a owl:NamedIndividual, cco:ont00000630;
+  rdfs:comment "UT1 is a derivation of UT0 that takes into account distortions caused by polar motion and is proportional to the rotation angle of the Earth with respect to distant quasars, specifically, the International Celestial Reference Frame (ICRF). UT1 is currently the most widely used variant of Universal Time and has the same value everywhere on Earth."@en;
+  rdfs:label "Universal Time 1"@en;
+  skos:altLabel "Astronomical Time"@en;
+  cco:ont00001753 "UT1";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001723 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC+4"@en;
+  rdfs:label "Delta Time Zone"@en;
+  cco:ont00001753 "D";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001727 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC+10"@en;
+  rdfs:label "Kilo Time Zone"@en;
+  cco:ont00001753 "K";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
+
+cco:ont00001732 a owl:NamedIndividual, cco:ont00001235;
+  rdfs:comment "Offset from Universal Coordinated Time = UTC+3"@en;
+  rdfs:label "Charlie Time Zone"@en;
+  cco:ont00001753 "C";
+  cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .

--- a/src/cco-modules/InformationEntityOntology.ttl
+++ b/src/cco-modules/InformationEntityOntology.ttl
@@ -1545,6 +1545,7 @@ cco:ont00001364 rdf:type owl:Class ;
 ###  https://www.commoncoreontologies.org/ont00002001
 cco:ont00002001 rdf:type owl:Class ;
                 rdfs:subClassOf cco:ont00000958 ;
+                rdfs:comment "By 'canonical', it is intended that the media format is of a commonly recognized format, such as mass media formats such as books, magazines, and journals, as well as digital media forms (e.g. ebooks), to include, too, file types, such as those recognized by the Internet Assigned Numbers Authority (IANA)'s Media Types standard [RFC2046]." ;
                 rdfs:label "Media Content Entity" ;
                 skos:definition "An information content entity presented in a canonical media format."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .


### PR DESCRIPTION
a.	For IBA and IBE, add the alternate labels ‘Information Carrying Artifact’ and ‘Information Carrying Entity’, respectively, and add the comment to IBE: ‘This class continues to use the work ‘bearing’ in its rdfs:label because of potential confusion with the acronym ‘ICE’, which is widely used for information content entity.’

b.	Add a similar comment for IBA that indicates by “bears” we mean that the IBA ‘is carrier of’ an ICE.

c.	IBA should get the comment: “This class continues to use the word ‘bearing’ in its rdfs:label for legacy reasons. It is understood that an IBA bears the concretization of an ICE and not the ICE directly.” 

d.	Update all rdfs:labels of subclasses of IBA to use prefix ‘Material Copy of’ and make their existing rdfs:label an alternative label. For instance, the class ‘Book’ will have the rdfs:label ‘Material Copy of a Book’ and the alternative label ‘Book. 

e.	Create a subclass of ‘Information Content Entity’ called ‘Media Content Entity’ with the definition ‘An information content entity presented in a canonical media format’. 

f.	Ensure the entire IBA subclass directory is then copied under ‘Media Content Entity’ such that, for example, the class ‘Book’ is now an ICE. 

g.	Add a subclass axiom on to each IBA classes which declares each ‘is carrier of’ some <corresponding media content entity>. For instance, every ‘Physical Copy of a Book’ is a carrier of some Book’. 
h.	In both the IBA and the ICE hierarchy, ensure that Book, Journal Article, and Spreadsheet (in both senses) are under ‘Document’ (again, in both senses).
 i.	Update the rdfs:label of ‘Document’ to ‘Document Content Entity’ 
j.	Rename ‘Document Form’ to ‘Form Document’
k.	Place ‘Document Field Content’ under ICE and add that is a continuant part of some Document. Add the alternative label ‘Document Field’. 
l.	Move ‘Document Field’ from under IBE and place under IBA. m.	Review all definitions of every class affected here to ensure the definitions clearly describe either ICEs or IBAs (e.g. a relationship like ‘is carrier of’ or ‘represents’ is not used inappropriately within one of these definitions).