### PR TITLE
PR to address issue #689

### DIFF
--- a/src/cco-modules/AgentOntology.ttl
+++ b/src/cco-modules/AgentOntology.ttl
@@ -58,6 +58,53 @@ cco:ont00001760 rdf:type owl:AnnotationProperty .
 #    Object Properties
 #################################################################
 
+
+### https://www.commoncoreontologies.org/ont00001852
+cco:ont00001852 rdf:type owl:ObjectProperty ;
+rdfs:subPropertyOf obo:BFO_0000056 ;
+owl:inverseOf cco:ont00001949 ;
+rdfs:domain cco:ont00001017 ;
+rdfs:range obo:BFO_0000015 ;
+rdfs:label "accessory in"@en ;
+skos:definition "x is_accessory_in y iff x is an instance of Agent and y is an instance of Process such that x assists another instance of Agent z in the commission of y, and x was not located at the location of y when y occurred, and x is not an agent_in y."@en ;
+cco:ont00001754 "http://en.wikipedia.org/wiki/Accessory_(legal_term)" ;
+cco:ont00001760 "https://www.commoncoreontologies.org/AgentOntology"^^xsd:anyURI .
+
+
+### https://www.commoncoreontologies.org/ont00001949
+cco:ont00001949 rdf:type owl:ObjectProperty ;
+rdfs:subPropertyOf obo:BFO_0000057 ;
+rdfs:domain obo:BFO_0000015 ;
+rdfs:range cco:ont00001017 ;
+rdfs:label "has accessory"@en ;
+skos:definition "x has_accessory y iff x is an instance of Process and y is an instance of Agent, such that y assists another agent in the commission of x, and y was not located at the location of x when x occurred, and y was not an agent_in x."@en ;
+cco:ont00001754 "http://en.wikipedia.org/wiki/Accessory_(legal_term)" ;
+cco:ont00001760 "https://www.commoncoreontologies.org/AgentOntology"^^xsd:anyURI .
+
+
+### https://www.commoncoreontologies.org/ont00001895
+cco:ont00001895 rdf:type owl:ObjectProperty ;
+rdfs:subPropertyOf obo:BFO_0000056 ;
+rdfs:domain cco:ont00001017;
+rdfs:range obo:BFO_0000015 ;
+rdfs:label "accomplice in"@en ;
+skos:definition "Agent x is accomplice_in Process y iff x assists in the commission of y, is located at the location of y, but is not agent_in y."@en ;
+cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Accomplice&oldid=1002047204"^^xsd:anyURI ;
+cco:ont00001760 "https://www.commoncoreontologies.org/AgentOntology"^^xsd:anyURI .
+
+
+### https://www.commoncoreontologies.org/ont00001830
+cco:ont00001830 rdf:type owl:ObjectProperty ;
+rdfs:subPropertyOf obo:BFO_0000057 ;
+owl:inverseOf cco:ont00001895 ;
+rdfs:domain obo:BFO_0000015 ;
+rdfs:range cco:ont00001017 ;
+rdfs:label "has accomplice"@en ;
+skos:definition "x has_accomplice y iff x is an instance of Process and y is an instance of Agent that assists in the commission of x, is located at the location of x, but is not agent_in x."@en ;
+cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Accomplice&oldid=1002047204"^^xsd:anyURI ;
+cco:ont00001760 "https://www.commoncoreontologies.org/AgentOntology"^^xsd:anyURI .
+
+
 ###  https://www.commoncoreontologies.org/ont00001774
 cco:ont00001774 rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf cco:ont00001902 ;

--- a/src/cco-modules/ExtendedRelationOntology.ttl
+++ b/src/cco-modules/ExtendedRelationOntology.ttl
@@ -338,18 +338,6 @@ cco:ont00001829 rdf:type owl:ObjectProperty ;
                  cco:ont00001760 "https://www.commoncoreontologies.org/ExtendedRelationOntology"^^xsd:anyURI .
 
 
-###  https://www.commoncoreontologies.org/ont00001830
-cco:ont00001830 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf obo:BFO_0000057 ;
-                 owl:inverseOf cco:ont00001895 ;
-                 rdfs:domain obo:BFO_0000015 ;
-                 rdfs:range cco:ont00001017 ;
-                 rdfs:label "has accomplice"@en ;
-                 skos:definition "x has_accomplice y iff x is an instance of Process and y is an instance of Agent that assists in the commission of x, is located at the location of x, but is not agent_in x."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Accomplice&oldid=1002047204"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ExtendedRelationOntology"^^xsd:anyURI .
-
-
 ###  https://www.commoncoreontologies.org/ont00001832
 cco:ont00001832 rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf owl:topObjectProperty ;
@@ -470,17 +458,6 @@ cco:ont00001888 rdf:type owl:ObjectProperty ;
                  cco:ont00001760 "https://www.commoncoreontologies.org/ExtendedRelationOntology"^^xsd:anyURI .
 
 
-###  https://www.commoncoreontologies.org/ont00001895
-cco:ont00001895 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf obo:BFO_0000056 ;
-                 rdfs:domain cco:ont00001017;
-                 rdfs:range obo:BFO_0000015 ;
-                 rdfs:label "accomplice in"@en ;
-                 skos:definition "Agent x is accomplice_in Process y iff x assists in the commission of y, is located at the location of y, but is not agent_in y."@en ;
-                 cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Accomplice&oldid=1002047204"^^xsd:anyURI ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ExtendedRelationOntology"^^xsd:anyURI .
-
-
 ###  https://www.commoncoreontologies.org/ont00001901
 cco:ont00001901 rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf cco:ont00001836 ;
@@ -561,17 +538,6 @@ cco:ont00001947 rdf:type owl:ObjectProperty ;
                  rdfs:range obo:BFO_0000027 ;
                  rdfs:label "quality of aggregate"@en ;
                  skos:definition "x quality_of_aggregate y iff y is an instance of Object Aggregate and x is an instance of Quality, and x inheres_in_aggregate y."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ExtendedRelationOntology"^^xsd:anyURI .
-
-
-###  https://www.commoncoreontologies.org/ont00001949
-cco:ont00001949 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf obo:BFO_0000057 ;
-                 rdfs:domain obo:BFO_0000015 ;
-                 rdfs:range cco:ont00001017 ;
-                 rdfs:label "has accessory"@en ;
-                 skos:definition "x has_accessory y iff x is an instance of Process and y is an instance of Agent, such that y assists another agent in the commission of x, and y was not located at the location of x when x occurred, and y was not an agent_in x."@en ;
-                 cco:ont00001754 "http://en.wikipedia.org/wiki/Accessory_(legal_term)" ;
                  cco:ont00001760 "https://www.commoncoreontologies.org/ExtendedRelationOntology"^^xsd:anyURI .
 
 

--- a/src/cco-modules/ExtendedRelationOntology.ttl
+++ b/src/cco-modules/ExtendedRelationOntology.ttl
@@ -416,10 +416,10 @@ cco:ont00001845 rdf:type owl:ObjectProperty ;
 cco:ont00001852 rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf obo:BFO_0000056 ;
                  owl:inverseOf cco:ont00001949 ;
-                 rdfs:domain obo:BFO_0000015 ;
-                 rdfs:range cco:ont00001017 ;
+                 rdfs:domain cco:ont00001017 ;
+                 rdfs:range obo:BFO_0000015 ;
                  rdfs:label "accessory in"@en ;
-                 skos:definition "y is_accessory_in x iff x is an instance of Process and y is an instance of Agent, such that y assists another agent in the commission of x, and y was not located at the location of x when x occurred, and y was not an agent_in x."@en ;
+                 skos:definition "x is_accessory_in y iff x is an instance of Agent and y is an instance of Process such that x assists another instance of Agent z in the commission of y, and x was not located at the location of y when y occurred, and x is not an agent_in y."@en ;
                  cco:ont00001754 "http://en.wikipedia.org/wiki/Accessory_(legal_term)" ;
                  cco:ont00001760 "https://www.commoncoreontologies.org/ExtendedRelationOntology"^^xsd:anyURI .
 

--- a/src/cco-modules/ExtendedRelationOntology.ttl
+++ b/src/cco-modules/ExtendedRelationOntology.ttl
@@ -485,7 +485,7 @@ cco:ont00001888 rdf:type owl:ObjectProperty ;
 ###  https://www.commoncoreontologies.org/ont00001895
 cco:ont00001895 rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf obo:BFO_0000056 ;
-                 rdfs:domain obo:BFO_0000040 ;
+                 rdfs:domain cco:ont00001017;
                  rdfs:range obo:BFO_0000015 ;
                  rdfs:label "accomplice in"@en ;
                  skos:definition "Agent x is accomplice_in Process y iff x assists in the commission of y, is located at the location of y, but is not agent_in y."@en ;

--- a/src/cco-modules/ExtendedRelationOntology.ttl
+++ b/src/cco-modules/ExtendedRelationOntology.ttl
@@ -343,7 +343,7 @@ cco:ont00001830 rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf obo:BFO_0000057 ;
                  owl:inverseOf cco:ont00001895 ;
                  rdfs:domain obo:BFO_0000015 ;
-                 rdfs:range obo:BFO_0000040 ;
+                 rdfs:range cco:ont00001017 ;
                  rdfs:label "has accomplice"@en ;
                  skos:definition "x has_accomplice y iff x is an instance of Process and y is an instance of Agent that assists in the commission of x, is located at the location of x, but is not agent_in x."@en ;
                  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Accomplice&oldid=1002047204"^^xsd:anyURI ;

--- a/src/cco-modules/ExtendedRelationOntology.ttl
+++ b/src/cco-modules/ExtendedRelationOntology.ttl
@@ -412,18 +412,6 @@ cco:ont00001845 rdf:type owl:ObjectProperty ;
                  cco:ont00001760 "https://www.commoncoreontologies.org/ExtendedRelationOntology"^^xsd:anyURI .
 
 
-###  https://www.commoncoreontologies.org/ont00001852
-cco:ont00001852 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf obo:BFO_0000056 ;
-                 owl:inverseOf cco:ont00001949 ;
-                 rdfs:domain cco:ont00001017 ;
-                 rdfs:range obo:BFO_0000015 ;
-                 rdfs:label "accessory in"@en ;
-                 skos:definition "x is_accessory_in y iff x is an instance of Agent and y is an instance of Process such that x assists another instance of Agent z in the commission of y, and x was not located at the location of y when y occurred, and x is not an agent_in y."@en ;
-                 cco:ont00001754 "http://en.wikipedia.org/wiki/Accessory_(legal_term)" ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/ExtendedRelationOntology"^^xsd:anyURI .
-
-
 ###  https://www.commoncoreontologies.org/ont00001857
 cco:ont00001857 rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf obo:BFO_0000132 ;


### PR DESCRIPTION
As @mark-jensen noted [here](https://github.com/CommonCoreOntology/CommonCoreOntologies/issues/689), the object property "accessory in" had mistakenly inverted domain and range axioms.
Additionally the issue points out that "accessory in", "has accessory", "accomplice in", and "has accomplice" are more relevant to the Common Core Agent Ontology, rather than the Extended Relation Ontology module.
This pull request changes those properties, the Agent Ontology, and the Extended Relation Ontology accordingly.