### PR TITLE
redefine cargo transport in terms of payload

### DIFF
--- a/src/cco-modules/EventOntology.ttl
+++ b/src/cco-modules/EventOntology.ttl
@@ -1413,7 +1413,7 @@ cco:ont00000594 rdf:type owl:Class ;
 cco:ont00000595 rdf:type owl:Class ;
                  rdfs:subClassOf cco:ont00000065 ;
                  rdfs:label "Act of Cargo Transportation"@en ;
-                 skos:definition "An Act of Location Change involving the movement of manufactured goods through some Transportation Agent."@en ;
+                 skos:definition "An Act of Location Change wherein some Payload is moved from one location to another."@en ;
                  cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
 
 


### PR DESCRIPTION
Removed the reference to 'Transportation Agent' that is not found anywhere else in the ontologies.