### PR TITLE
reclassified financial value

### DIFF
--- a/src/cco-modules/AgentOntology.ttl
+++ b/src/cco-modules/AgentOntology.ttl
@@ -1737,10 +1737,10 @@ cco:ont00000599 rdf:type owl:Class ;
 
 ###  https://www.commoncoreontologies.org/ont00000608
 cco:ont00000608 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000019 ;
-                 rdfs:label "Financial Value"@en ;
-                 skos:definition "A quality that inheres in an independent continuant to the degree that that independent continuant can serve as a medium of exchange in an economic system at a particular time."@en ;
-                 cco:ont00001760 "https://www.commoncoreontologies.org/AgentOntology"^^xsd:anyURI .
+                rdfs:subClassOf obo:BFO_0000023 ;
+                rdfs:label "Financial Value"@en ;
+                skos:definition "A role that inheres in an independent continuant that is realized in processes where that independent continuant is a medium of exchange in an economic system at a particular time."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/AgentOntology"^^xsd:anyURI .
 
 
 ###  https://www.commoncoreontologies.org/ont00000616


### PR DESCRIPTION
A relatively straight forward change that does not change the definition too much. It seems to be that financial value is externally grounded according to the original definition itself.