### PR TITLE
fix: add missing --catalog flag to test-combined (#732)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ reason-combined: $(combined-file) | $(ROBOT_FILE)
 	java -jar $(ROBOT_FILE) reason --input $(combined-file) --catalog src/cco-modules/catalog-v001.xml --reasoner HermiT
 
 test-combined: $(combined-file) | $(ROBOT_FILE)
-	java -jar $(ROBOT_FILE) verify --input $(combined-file) --output-dir $(config.REPORTS_DIR) --queries $(QUERIES) --fail-on-violation false || true
+	java -jar $(ROBOT_FILE) verify --input $(combined-file) --catalog src/cco-modules/catalog-v001.xml --output-dir $(config.REPORTS_DIR) --queries $(QUERIES) --fail-on-violation false || true
 
 .PHONY: report-edit
 report-edit: TEST_INPUT = $(EDITOR_BUILD_FILE)


### PR DESCRIPTION
test-combined was missing the --catalog flag, causing ROBOT to resolve imports over the internet instead of using local files. reason-combined already had it — this just aligns the two. Tested locally, runs clean.