### PR TITLE
adding MRO and release Suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,18 @@ bfo-diff: | $(config.TEMP_DIR)
 	@echo "Full diff written to $(BFO_DIFF_OUT)"
 
 # ---------------------------------------------------------------------------
+# release: Full release preparation pipeline (Steps 5–9 of CCO release process)
+# ---------------------------------------------------------------------------
+
+.PHONY: release
+release: $(ROBOT_FILE) | $(config.TEMP_DIR)
+	@if [ -z '$(VERSION)' ]; then \
+		echo 'ERROR: VERSION is required. Usage: make release VERSION=2.1 [DATE=YYYY-MM-DD]'; \
+		exit 1; \
+	fi
+	@VERSION='$(VERSION)' DATE='$(DATE)' bash scripts/release.sh
+
+# ---------------------------------------------------------------------------
 # T11 — stamp-version: Update owl:versionIRI and owl:versionInfo on all modules
 # ---------------------------------------------------------------------------
 
@@ -266,3 +278,59 @@ build-ccom: $(ROBOT_FILE) | $(config.TEMP_DIR)
 		--language-annotation owl:versionInfo "Depends on http://purl.obolibrary.org/obo/bfo/2020/bfo-core.ttl, obtained $(DATE)." en \
 		--output $(CCOM_MERGED)
 	@echo "build-ccom complete: $(CCOM_MERGED)"
+
+# ---------------------------------------------------------------------------
+# T13 — build-mro: Rebuild ModalRelationOntology.ttl via ROBOT + Python
+#
+# Steps:
+#   1. Merge all 11 CCO modules + BFO into one source file
+#   2. Extract OPs + DPs with ALL annotations, domain/range, blank-node class
+#      expressions (mro_extract.py — replaces robot filter which strips annotations)
+#   3. SPARQL query generates old→new namespace mapping CSV
+#   4. robot rename rewrites CCO + OBO namespaces to the MRO namespace
+#   5. Python post-processor: fixes curated-in, adds root property,
+#      wires top-level OPs, replaces ontology header
+#   6. Copy final file to src/cco-extensions/ModalRelationOntology.ttl
+#
+# Requires: python3 with rdflib (pip install rdflib)
+# Usage:    make build-mro VERSION=2.1 [DATE=YYYY-MM-DD]
+# ---------------------------------------------------------------------------
+MRO_OUT := src/cco-extensions/ModalRelationOntology.ttl
+
+.PHONY: build-mro
+build-mro: $(ROBOT_FILE) | $(config.TEMP_DIR)
+	@if [ -z '$(VERSION)' ]; then \
+		echo 'ERROR: VERSION is required. Usage: make build-mro VERSION=2.1 [DATE=YYYY-MM-DD]'; \
+		exit 1; \
+	fi
+	@echo "=== MRO Step 1: Merging 11 CCO modules + BFO + FRO + MRO additions ==="
+	java -jar $(ROBOT_FILE) merge \
+		$(foreach f,$(DEV_FILES),--input $(f)) \
+		--input $(BFO_LOCAL) \
+		--input src/cco-extensions/FamilialRelationsOntology.ttl \
+		--input src/cco-extensions/ModalRelationOntologyAdditions.ttl \
+		--catalog src/cco-modules/catalog-v001.xml \
+		--output $(config.TEMP_DIR)/mro-merged.ttl
+	@echo "=== MRO Step 2: Extracting ObjectProperties + DatatypeProperties with all annotations ==="
+	python3 scripts/mro_extract.py \
+		--input  $(config.TEMP_DIR)/mro-merged.ttl \
+		--output $(config.TEMP_DIR)/mro-filtered.ttl
+	@echo "=== MRO Step 3: Generating namespace rename mapping CSV ==="
+	java -jar $(ROBOT_FILE) query \
+		--input $(config.TEMP_DIR)/mro-filtered.ttl \
+		--query scripts/mro_rename.sparql \
+		$(config.TEMP_DIR)/mro-rename-map.csv
+	@echo "=== MRO Step 4: Applying namespace rename ==="
+	java -jar $(ROBOT_FILE) rename \
+		--input $(config.TEMP_DIR)/mro-filtered.ttl \
+		--mappings $(config.TEMP_DIR)/mro-rename-map.csv \
+		--output $(config.TEMP_DIR)/mro-renamed.ttl
+	@echo "=== MRO Step 5: Python post-processing ==="
+	python3 scripts/mro_postprocess.py \
+		--input   $(config.TEMP_DIR)/mro-renamed.ttl \
+		--output  $(config.TEMP_DIR)/mro-final.ttl \
+		--version $(VERSION) \
+		--date    $(DATE)
+	@echo "=== MRO Step 6: Copying to $(MRO_OUT) ==="
+	cp $(config.TEMP_DIR)/mro-final.ttl $(MRO_OUT)
+	@echo "build-mro complete: $(MRO_OUT)"

--- a/scripts/mro_extract.py
+++ b/scripts/mro_extract.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+mro_extract.py — Step 2 of the MRO build pipeline.
+
+Extracts all owl:ObjectProperty and owl:DatatypeProperty individuals from the
+merged CCO+BFO file, together with ALL their triples:
+
+  - Structural axioms: rdfs:subPropertyOf, owl:inverseOf, property characteristics
+  - Annotations:      rdfs:label, skos:definition, skos:altLabel, skos:example,
+                      skos:scopeNote, skos:editorialNote, dc:identifier, etc.
+  - Axioms:           rdfs:domain, rdfs:range (including complex blank-node
+                      class expressions such as owl:unionOf, owl:intersectionOf)
+
+Also includes rdf:type owl:AnnotationProperty declarations for every annotation
+predicate used on the extracted properties, matching the structure of the
+hand-built ModalRelationOntology.ttl.
+
+This replaces the `robot filter --select "object-properties data-properties"`
+step which strips annotation assertions even with --axioms all.
+
+Usage:
+    python3 scripts/mro_extract.py \\
+        --input  build/artifacts/mro-merged.ttl \\
+        --output build/artifacts/mro-filtered.ttl
+"""
+
+import argparse
+from rdflib import Graph, BNode, RDF, OWL
+
+
+def extract(merged_path: str, output_path: str) -> None:
+    src = Graph()
+    src.parse(merged_path, format="turtle")
+
+    out = Graph()
+    for prefix, ns in src.namespaces():
+        out.bind(prefix, ns)
+
+    # ── Collect every OP and DP subject ──────────────────────────────────────
+    prop_types = {OWL.ObjectProperty, OWL.DatatypeProperty}
+    subjects = {s for s, _, t in src.triples((None, RDF.type, None)) if t in prop_types}
+
+    # ── Recursively copy blank-node sub-graphs ────────────────────────────────
+    # Needed for complex domain/range class expressions:
+    #   e.g. rdfs:domain [ owl:unionOf ( obo:BFO_0000020 obo:BFO_0000031 ... ) ]
+    visited_bnodes: set = set()
+
+    def copy_bnode(node: BNode) -> None:
+        if node in visited_bnodes:
+            return
+        visited_bnodes.add(node)
+        for p, o in src.predicate_objects(node):
+            out.add((node, p, o))
+            if isinstance(o, BNode):
+                copy_bnode(o)
+
+    # ── Copy all triples for each extracted property ──────────────────────────
+    for s in subjects:
+        for p, o in src.predicate_objects(s):
+            out.add((s, p, o))
+            if isinstance(o, BNode):
+                copy_bnode(o)
+
+    # ── Add annotation property declarations for predicates in use ───────────
+    # The hand-built MRO declares every annotation property it uses
+    # (dc:identifier, skos:definition, skos:altLabel, etc.) so that OWL tools
+    # treat them properly rather than as bare URI predicates.
+    used_predicates = {p for _, p, _ in out}
+    for p in used_predicates:
+        if (p, RDF.type, OWL.AnnotationProperty) in src:
+            out.add((p, RDF.type, OWL.AnnotationProperty))
+
+    out.serialize(destination=output_path, format="turtle")
+    print(f"mro_extract: wrote {len(subjects)} properties to {output_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract OPs and DPs with all annotations from merged CCO+BFO."
+    )
+    parser.add_argument("--input",  required=True, help="Path to mro-merged.ttl")
+    parser.add_argument("--output", required=True, help="Path to write mro-filtered.ttl")
+    args = parser.parse_args()
+    extract(args.input, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mro_postprocess.py
+++ b/scripts/mro_postprocess.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""
+mro_postprocess.py — Post-process the ROBOT-renamed MRO Turtle file.
+
+Steps performed (matches build-mro pipeline Steps 5a–5d):
+
+  5a. Fix cco:ont00001760 (is curated in ontology) — replace all existing values
+      (whether IRI or xsd:anyURI literal) with the MRO ontology IRI.
+
+  5b. Add the mro:mro00000001 root ObjectProperty declaration with its label
+      and curated-in annotation (if it is not already present).
+
+  5c. Wire every top-level ObjectProperty (no rdfs:subPropertyOf asserted) as a
+      subPropertyOf mro:mro00000001.  DatatypeProperties are left as-is.
+
+  5d. Remove all existing owl:Ontology declarations and insert the canonical
+      MRO header with the supplied VERSION and DATE.
+
+Usage:
+    python3 scripts/mro_postprocess.py \\
+        --input  build/artifacts/mro-renamed.ttl \\
+        --output build/artifacts/mro-final.ttl \\
+        --version 2.1 \\
+        --date   2026-04-15
+"""
+
+import argparse
+from rdflib import Graph, URIRef, Literal, Namespace
+from rdflib.namespace import RDF, RDFS, OWL, XSD
+
+# ── Namespaces ────────────────────────────────────────────────────────────────
+CCO  = Namespace("https://www.commoncoreontologies.org/")
+MRO  = Namespace("https://www.commoncoreontologies.org/mro/")
+OBO  = Namespace("http://purl.obolibrary.org/obo/")
+SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
+DCT  = Namespace("http://purl.org/dc/terms/")
+DC   = Namespace("http://purl.org/dc/elements/1.1/")
+
+# ── Well-known IRIs ───────────────────────────────────────────────────────────
+MRO_ONTOLOGY_IRI = URIRef("https://www.commoncoreontologies.org/ModalRelationOntology")
+CURATED_IN       = CCO["ont00001760"]   # is curated in ontology
+MRO_ROOT         = MRO["mro00000001"]   # Modal Object Property (root)
+
+
+# ── Pre-step A: remove stray third-party properties ──────────────────────────
+MRO_NS  = "https://www.commoncoreontologies.org/mro/"
+
+def remove_non_mro_properties(g: Graph) -> None:
+    """Remove any OP/DP whose IRI does not start with the MRO namespace.
+
+    The extraction step (mro_extract.py) includes ALL OPs and DPs from the
+    merged ontology, some of which (e.g. geo:asWKT from GeoSPARQL) are
+    third-party properties pulled in via domain/range axioms. These have no
+    place in MRO and must be stripped before further processing.
+    """
+    for prop_type in (OWL.ObjectProperty, OWL.DatatypeProperty):
+        for s in list(g.subjects(RDF.type, prop_type)):
+            if not str(s).startswith(MRO_NS):
+                for p, o in list(g.predicate_objects(s)):
+                    g.remove((s, p, o))
+                g.remove((s, RDF.type, prop_type))
+
+
+# ── Pre-step B: remove spurious DatatypeProperty dual-typing ─────────────────
+def remove_dual_typed_dp(g: Graph) -> None:
+    """Remove rdf:type owl:DatatypeProperty from IRIs also typed as ObjectProperty.
+
+    ROBOT rename, via OWLAPI, sometimes generates ghost DatatypeProperty
+    declarations for ObjectProperties whose rdfs:range coincides with the
+    rdfs:domain class of an actual DatatypeProperty in the same ontology.
+    These phantom DP declarations must be stripped before further processing.
+    """
+    for s in list(g.subjects(RDF.type, OWL.DatatypeProperty)):
+        if (s, RDF.type, OWL.ObjectProperty) in g:
+            g.remove((s, RDF.type, OWL.DatatypeProperty))
+
+
+# ── Pre-step D: strip leading/trailing whitespace from string literals ────────
+def strip_annotation_whitespace(g: Graph) -> None:
+    """Strip leading/trailing whitespace from all string annotation literals.
+
+    Source modules occasionally have trailing spaces in definitions or labels
+    (e.g. mro:ont00001815). These trigger the annotation_whitespace QC query.
+    """
+    for s, p, o in list(g):
+        if isinstance(o, Literal) and o.datatype is None:
+            stripped = str(o).strip()
+            if stripped != str(o):
+                g.remove((s, p, o))
+                g.add((s, p, Literal(stripped, lang=o.language) if o.language
+                       else Literal(stripped)))
+
+
+# ── Step 5a ───────────────────────────────────────────────────────────────────
+def fix_curated_in(g: Graph) -> None:
+    """Ensure every OP and DP has exactly one curated-in pointing to MRO.
+
+    Source modules each set curated-in to their own ontology IRI. After the
+    rename step these values are stale (still pointing to AgentOntology,
+    ArtifactOntology, etc.). This function removes all existing curated-in
+    triples and re-adds the correct MRO ontology IRI for every property.
+    """
+    # Remove any stale curated-in triples that survived (edge case)
+    for s, _, o in list(g.triples((None, CURATED_IN, None))):
+        g.remove((s, CURATED_IN, o))
+    # Add the correct MRO curated-in to every OP and DP
+    for prop_type in (OWL.ObjectProperty, OWL.DatatypeProperty):
+        for s in g.subjects(RDF.type, prop_type):
+            g.add((s, CURATED_IN, MRO_ONTOLOGY_IRI))
+
+
+# ── Pre-step C: declare external classes used in domain/range ────────────────
+def declare_domain_range_classes(g: Graph) -> None:
+    """Add owl:Class declarations for every external class referenced in
+    rdfs:domain or rdfs:range of any property in the graph.
+
+    Without explicit declarations, the OWL API treats undeclared IRIs in
+    domain/range as ambiguous (class vs. datatype), which causes DL punning
+    violations for properties whose range coincides with another property's
+    domain. The old hand-built MRO had explicit cco:ont00000253 a owl:Class
+    declarations for exactly this reason.
+    """
+    XSD_NS = "http://www.w3.org/2001/XMLSchema#"
+    for pred in (RDFS.domain, RDFS.range):
+        for s, _, o in g.triples((None, pred, None)):
+            if not isinstance(o, URIRef):
+                continue
+            o_str = str(o)
+            # Skip XSD datatypes — they are not owl:Class
+            if o_str.startswith(XSD_NS):
+                continue
+            # Skip OWL/RDF/RDFS built-ins
+            if any(o_str.startswith(ns) for ns in (
+                "http://www.w3.org/2002/07/owl#",
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+                "http://www.w3.org/2000/01/rdf-schema#",
+            )):
+                continue
+            # Skip blank nodes already handled above
+            if (o, RDF.type, OWL.Class) not in g:
+                g.add((o, RDF.type, OWL.Class))
+
+
+# ── Step 5b ───────────────────────────────────────────────────────────────────
+def add_root_property(g: Graph) -> None:
+    """Add mro:mro00000001 'Modal Object Property' if not already present."""
+    if (MRO_ROOT, RDF.type, OWL.ObjectProperty) not in g:
+        g.add((MRO_ROOT, RDF.type,    OWL.ObjectProperty))
+        g.add((MRO_ROOT, RDFS.label,  Literal("Modal Object Property", lang="en")))
+        g.add((MRO_ROOT, CURATED_IN,  MRO_ONTOLOGY_IRI))
+
+
+# ── Step 5c ───────────────────────────────────────────────────────────────────
+def wire_orphans(g: Graph) -> None:
+    """Make every parentless ObjectProperty a subPropertyOf mro:mro00000001."""
+    for s in list(g.subjects(RDF.type, OWL.ObjectProperty)):
+        if s == MRO_ROOT:
+            continue
+        if not list(g.objects(s, RDFS.subPropertyOf)):
+            g.add((s, RDFS.subPropertyOf, MRO_ROOT))
+
+
+# ── Step 5d ───────────────────────────────────────────────────────────────────
+def replace_header(g: Graph, version: str, date: str) -> None:
+    """Remove all owl:Ontology nodes and insert the canonical MRO header."""
+    for s in list(g.subjects(RDF.type, OWL.Ontology)):
+        for p, o in list(g.predicate_objects(s)):
+            g.remove((s, p, o))
+        g.remove((s, RDF.type, OWL.Ontology))
+
+    version_iri = URIRef(
+        f"https://www.commoncoreontologies.org/{date}/ModalRelationOntology"
+    )
+    g.add((MRO_ONTOLOGY_IRI, RDF.type,       OWL.Ontology))
+    g.add((MRO_ONTOLOGY_IRI, OWL.versionIRI, version_iri))
+    g.add((MRO_ONTOLOGY_IRI, DCT.license,
+           Literal("BSD 3-Clause: https://github.com/CommonCoreOntology/"
+                   "CommonCoreOntologies/blob/master/LICENSE", lang="en")))
+    g.add((MRO_ONTOLOGY_IRI, DCT.rights,
+           Literal("CUBRC Inc., see full license.", lang="en")))
+    g.add((MRO_ONTOLOGY_IRI, RDFS.comment,
+           Literal("The modal counterparts to the object and data properties "
+                   "contained in CCO and BFO2020-core.")))
+    g.add((MRO_ONTOLOGY_IRI, RDFS.label,
+           Literal("Modal Relation Ontology")))
+    g.add((MRO_ONTOLOGY_IRI, OWL.versionInfo,
+           Literal(f"v{version}")))
+    # Declare header annotation properties so OWL 2 DL validators don't flag them
+    for ap in (DCT.license, DCT.rights):
+        if (ap, RDF.type, OWL.AnnotationProperty) not in g:
+            g.add((ap, RDF.type, OWL.AnnotationProperty))
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Post-process the ROBOT-renamed MRO Turtle file."
+    )
+    parser.add_argument("--input",   required=True, help="Path to mro-renamed.ttl")
+    parser.add_argument("--output",  required=True, help="Path to write mro-final.ttl")
+    parser.add_argument("--version", required=True, help="Version string, e.g. 2.1")
+    parser.add_argument("--date",    required=True, help="Release date YYYY-MM-DD")
+    args = parser.parse_args()
+
+    g = Graph()
+    g.parse(args.input, format="turtle")
+
+    remove_non_mro_properties(g)
+    remove_dual_typed_dp(g)
+    declare_domain_range_classes(g)
+    strip_annotation_whitespace(g)
+    fix_curated_in(g)
+    add_root_property(g)
+    wire_orphans(g)
+    replace_header(g, args.version, args.date)
+
+    # Bind prefixes for human-readable Turtle output
+    g.bind("",    MRO)
+    g.bind("cco", CCO)
+    g.bind("mro", MRO)
+    g.bind("obo", OBO)
+    g.bind("skos", SKOS)
+    g.bind("owl", OWL)
+    g.bind("rdf", RDF)
+    g.bind("rdfs", RDFS)
+    g.bind("xsd", XSD)
+    g.bind("dct", DCT)
+    g.bind("dc",  DC)
+
+    g.serialize(destination=args.output, format="turtle")
+    print(f"mro_postprocess: written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mro_rename.sparql
+++ b/scripts/mro_rename.sparql
@@ -1,0 +1,42 @@
+# Title:
+#     MRO Namespace Rename Mapping
+# Description:
+#     Generates a two-column CSV mapping each ObjectProperty and DatatypeProperty
+#     IRI to its MRO-namespace equivalent. Consumed by `robot rename --mappings`
+#     in the build-mro pipeline (Step 3 → Step 4).
+#
+#     Namespace remappings applied:
+#       https://www.commoncoreontologies.org/<LOCAL>
+#           -> https://www.commoncoreontologies.org/mro/<LOCAL>
+#       http://purl.obolibrary.org/obo/<LOCAL>
+#           -> https://www.commoncoreontologies.org/mro/<LOCAL>
+#
+#     IRIs that do not match either prefix are excluded (FILTER ?old != ?new).
+
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT DISTINCT ?old ?new
+WHERE {
+  { ?old rdf:type owl:ObjectProperty }
+  UNION
+  { ?old rdf:type owl:DatatypeProperty }
+
+  FILTER(isIRI(?old))
+
+  BIND(
+    IF(
+      STRSTARTS(STR(?old), "https://www.commoncoreontologies.org/"),
+      IRI(CONCAT("https://www.commoncoreontologies.org/mro/",
+            STRAFTER(STR(?old), "https://www.commoncoreontologies.org/"))),
+      IF(
+        STRSTARTS(STR(?old), "http://purl.obolibrary.org/obo/"),
+        IRI(CONCAT("https://www.commoncoreontologies.org/mro/",
+              STRAFTER(STR(?old), "http://purl.obolibrary.org/obo/"))),
+        ?old
+      )
+    ) AS ?new
+  )
+
+  FILTER(STR(?old) != STR(?new))
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# CCO Release Preparation Pipeline
+#
+# Automates steps 5–9 of the CCO release process:
+#   Phase 1 — BFO upstream diff
+#   Phase 2 — Module diff (develop vs master)
+#   Phase 3 — QC on 11 modules (consistency, OWL DL, SPARQL checks)
+#   Phase 4 — Build CCOM + MRO, validate both
+#   Phase 5 — Stamp version IRIs and versionInfo
+#
+# Manual steps after this script completes:
+#   - git add / commit / PR to master
+#   - Create GitHub release
+#
+# Usage:
+#   make release VERSION=2.1 [DATE=YYYY-MM-DD]
+
+set -euo pipefail
+
+VERSION="${VERSION:-}"
+DATE="${DATE:-$(date +%Y-%m-%d)}"
+ROBOT="java -jar build/lib/robot.jar"
+SPARQL_DIR=".github/deployment/sparql"
+ARTIFACTS="build/artifacts"
+
+# ── Validate inputs ───────────────────────────────────────────────────────────
+if [[ -z "$VERSION" ]]; then
+    echo "ERROR: VERSION is required.  Usage: make release VERSION=2.1 [DATE=YYYY-MM-DD]"
+    exit 1
+fi
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+phase() {
+    echo ""
+    printf '=%.0s' {1..62}; echo ""
+    echo "  $1"
+    printf '=%.0s' {1..62}; echo ""
+}
+
+pause() {
+    echo ""
+    echo "  REVIEW REQUIRED: $1"
+    echo ""
+    read -r -p "  Proceed? [y/N] " response
+    [[ "$response" =~ ^[Yy]$ ]] || { echo ""; echo "Release aborted by user."; exit 1; }
+}
+
+qc_summary() {
+    local input="$1"
+    local label="$2"
+    echo ""
+    echo "  QC violation summary — $label:"
+    for q in exactly_1_curated_in exactly_1_label curated_in_matches_ontology \
+              iri_format_check min_1_eng_def annotation_whitespace \
+              duplicate_label no_duplicate_declarations duplicate_iri_number; do
+        $ROBOT query \
+            --input "$input" \
+            --query "$SPARQL_DIR/${q}.sparql" \
+            "/tmp/rel_${q}.csv" 2>/dev/null
+        rows=$(wc -l < "/tmp/rel_${q}.csv")
+        printf "    %-40s %d violations\n" "${q}" "$((rows - 1))"
+    done
+}
+
+echo ""
+echo "  CCO Release Preparation — v${VERSION} / ${DATE}"
+echo "  -----------------------------------------------"
+
+# ── PHASE 1: BFO upstream diff ────────────────────────────────────────────────
+phase "PHASE 1 — BFO upstream diff"
+make bfo-diff
+pause "Review $ARTIFACTS/bfo-upstream-diff.txt and confirm BFO status is acceptable."
+
+# ── PHASE 2: Module diff (develop vs master) ──────────────────────────────────
+phase "PHASE 2 — Module diff (develop vs master)"
+echo "  Diff stats for each CCO module:"
+echo ""
+for f in \
+    src/cco-modules/AgentOntology.ttl \
+    src/cco-modules/ArtifactOntology.ttl \
+    src/cco-modules/CurrencyUnitOntology.ttl \
+    src/cco-modules/EventOntology.ttl \
+    src/cco-modules/ExtendedRelationOntology.ttl \
+    src/cco-modules/FacilityOntology.ttl \
+    src/cco-modules/GeospatialOntology.ttl \
+    src/cco-modules/QualityOntology.ttl \
+    src/cco-modules/UnitsOfMeasureOntology.ttl \
+    src/cco-modules/TimeOntology.ttl \
+    src/cco-modules/InformationEntityOntology.ttl; do
+    result=$(git diff --stat origin/master..HEAD -- "$f" 2>/dev/null || true)
+    if [[ -n "$result" ]]; then
+        echo "$result"
+    else
+        printf "    %-55s no changes\n" "$f"
+    fi
+done
+pause "Confirm all module changes match expected commits and draft release notes."
+
+# ── PHASE 3: QC on 11 modules ────────────────────────────────────────────────
+phase "PHASE 3 — QC checks on 11 modules"
+
+echo "  [3a] Consistency check (HermiT reasoner)..."
+make reason-individual
+
+echo ""
+echo "  [3b] OWL 2 DL profile validation..."
+make validate-profile-individual
+
+echo ""
+echo "  [3c] SPARQL quality checks..."
+make test-individual
+
+echo ""
+echo "  QC reports written to $ARTIFACTS/"
+echo "  NOTE: Reports contain results for the last processed file."
+echo "        Open individual CSVs to review per-file violations."
+pause "Review QC reports in $ARTIFACTS/ and confirm all issues are acceptable."
+
+# ── PHASE 4: Build CCOM + MRO and validate ───────────────────────────────────
+phase "PHASE 4 — Build CCOM and MRO"
+
+echo "  [4a] Building CCOM..."
+make build-ccom VERSION="$VERSION" DATE="$DATE"
+
+echo ""
+echo "  [4b] Building MRO..."
+make build-mro VERSION="$VERSION" DATE="$DATE"
+
+echo ""
+echo "  Diff stats (generated files vs HEAD):"
+git diff --stat src/cco-merged/CommonCoreOntologiesMerged.ttl 2>/dev/null || true
+git diff --stat src/cco-extensions/ModalRelationOntology.ttl  2>/dev/null || true
+
+echo ""
+echo "  [4c] OWL 2 DL profile — CCOM..."
+java -jar build/lib/robot.jar validate-profile \
+    --profile DL \
+    --input src/cco-merged/CommonCoreOntologiesMerged.ttl
+echo "  CCOM: OWL 2 DL PASS"
+
+echo ""
+echo "  [4d] OWL 2 DL profile — MRO..."
+java -jar build/lib/robot.jar validate-profile \
+    --profile DL \
+    --input src/cco-extensions/ModalRelationOntology.ttl
+echo "  MRO: OWL 2 DL PASS"
+
+echo ""
+echo "  [4e] Consistency check — CCOM..."
+make reason-combined
+
+qc_summary "src/cco-merged/CommonCoreOntologiesMerged.ttl" "CCOM"
+qc_summary "src/cco-extensions/ModalRelationOntology.ttl"  "MRO"
+
+pause "Review CCOM and MRO diffs and QC summaries above. Confirm builds are correct."
+
+# ── PHASE 5: Stamp version IRIs and versionInfo ───────────────────────────────
+phase "PHASE 5 — Stamp version IRIs and versionInfo (v${VERSION} / ${DATE})"
+make stamp-version VERSION="$VERSION" DATE="$DATE"
+
+echo ""
+echo "  Files stamped:"
+git diff --stat src/cco-modules/ \
+    src/cco-merged/CommonCoreOntologiesMerged.ttl \
+    src/cco-extensions/ModalRelationOntology.ttl 2>/dev/null || true
+
+pause "Confirm version stamping looks correct. This is the final state before commit."
+
+# ── Done ─────────────────────────────────────────────────────────────────────
+phase "RELEASE PREPARATION COMPLETE — v${VERSION} / ${DATE}"
+echo "  All automated checks passed."
+echo ""
+echo "  Manual steps remaining:"
+echo ""
+echo "    1. Review full diff:       git diff"
+echo "    2. Stage all changes:      git add -A"
+echo "    3. Commit:                 git commit -m 'Release v${VERSION} (${DATE})'"
+echo "    4. Open PR to master"
+echo "    5. Create GitHub release"
+echo "         Tag:    v${VERSION}"
+echo "         Title:  CCO v${VERSION}"
+echo "         Date:   ${DATE}  (must match version IRI)"
+echo ""

--- a/src/cco-extensions/ModalRelationOntologyAdditions.ttl
+++ b/src/cco-extensions/ModalRelationOntologyAdditions.ttl
@@ -1,0 +1,26 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix cco: <https://www.commoncoreontologies.org/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+
+<https://www.commoncoreontologies.org/ont00001861> a owl:ObjectProperty ;
+    owl:inverseOf <https://www.commoncoreontologies.org/ont00001991> ;
+    rdfs:domain obo:BFO_0000030 ;
+    rdfs:range obo:BFO_0000030 ;
+    rdfs:label "is material of"@en ;
+    skos:definition "An object m is material of an object o when m is the material of which o consists and that material does not undergo a change of kind during the creation of o"@en .
+
+<https://www.commoncoreontologies.org/ont00001953> a owl:ObjectProperty ;
+    rdfs:subPropertyOf <https://www.commoncoreontologies.org/ont00001865> ;
+    owl:inverseOf <https://www.commoncoreontologies.org/ont00001995> ;
+    rdfs:label "has parent"@en .
+
+<https://www.commoncoreontologies.org/ont00001991> a owl:ObjectProperty ;
+    owl:inverseOf <https://www.commoncoreontologies.org/ont00001861> ;
+    rdfs:domain obo:BFO_0000030 ;
+    rdfs:range obo:BFO_0000030 ;
+    rdfs:label "is made of"@en ;
+    skos:definition "An object o is made of an object m when m is the material that o consists of and that material does not undergo a change of kind during the creation of o"@en .


### PR DESCRIPTION
MRO Build Automation
Step 1 — Merge sources
Pulls together all 11 CCO modules, BFO, the Familial Relations Ontology, and a small stub file for 3 MRO-native properties that don't live in any module.

Step 2 — Extract OPs and DPs
We wrote a custom Python script (mro_extract.py) to pull out every Object Property and Data Property with everything attached — labels, definitions, domain/range, altLabels, blank-node class expressions. We couldn't use ROBOT's built-in filter here because it strips all annotations even when you ask it not to.

Step 3 & 4 — Rename into the mro: namespace
A SPARQL query generates a mapping of every old IRI → new MRO IRI. ROBOT then applies the rename across the entire file.

Step 5 — Post-process
Another Python script (mro_postprocess.py) cleans things up:

Adds explicit owl:Class declarations for external classes in domain/range
Fixes all curated-in annotations to point to MRO instead of source modules
Wires the full property hierarchy under the mro:mro00000001 root property
Stamps the ontology header with the correct version IRI, license, and rights
Step 6 — Done
Final file lands at ModalRelationOntology.ttl.

Release Suite Pipeline A single command — make release VERSION=2.1 DATE=2026-04-15 — that runs the entire pre-release pipeline interactively.

Phase 1 — BFO upstream diff
Fetches the latest BFO from upstream and diffs it against our pinned local copy. Writes the full diff to build/artifacts/bfo-upstream-diff.txt and pauses for review before continuing.

Phase 2 — Module diff (develop vs master)
Runs git diff --stat on each of the 11 CCO modules between develop and origin/master, so you can see exactly what changed before release. Pauses for confirmation.

Phase 3 — QC checks on 11 modules
Runs three checks on every individual module:

HermiT consistency check (make reason-individual)
OWL 2 DL profile validation (make validate-profile-individual)
All 19 SPARQL quality checks (make test-individual)
Pauses for review before continuing.

Phase 4 — Build CCOM + MRO and validate
Rebuilds both derivative files from scratch:

make build-ccom → CommonCoreOntologiesMerged.ttl
make build-mro → ModalRelationOntology.ttl

Phase 5 — Stamp version
Runs make stamp-version to write the release date into every version IRI and update the version number across all 11 modules, CCOM, and MRO