### PR TITLE
Adding two properties for "process has first/last instant"

### DIFF
--- a/src/cco-modules/TimeOntology.ttl
+++ b/src/cco-modules/TimeOntology.ttl
@@ -44,7 +44,7 @@ cco:ont00001760 rdf:type owl:AnnotationProperty .
 #################################################################
 
 ###  https://www.commoncoreontologies.org/ont00001779
-cco:ont00002079 rdf:type owl:ObjectProperty ,
+cco:ont00002080 rdf:type owl:ObjectProperty ,
                          owl:FunctionalProperty ;
                 owl:inverseOf cco:ont00001848 ;
                 rdfs:domain obo:BFO_0000015 ;
@@ -54,7 +54,7 @@ cco:ont00002079 rdf:type owl:ObjectProperty ,
                 cco:ont00001760 "https://www.commoncoreontologies.org/TimeOntology"^^xsd:anyURI .
 
 ###  https://www.commoncoreontologies.org/ont00001779
-cco:ont00002080 rdf:type owl:ObjectProperty ,
+cco:ont00002081 rdf:type owl:ObjectProperty ,
                          owl:FunctionalProperty ;
                 rdfs:domain obo:BFO_0000015 ;
                 rdfs:range obo:BFO_0000203 ;

--- a/src/cco-modules/TimeOntology.ttl
+++ b/src/cco-modules/TimeOntology.ttl
@@ -46,6 +46,25 @@ cco:ont00001760 rdf:type owl:AnnotationProperty .
 ###  https://www.commoncoreontologies.org/ont00001779
 cco:ont00001779 rdf:type owl:ObjectProperty ;
                 owl:inverseOf cco:ont00001848 ;
+                rdfs:domain obo:BFO_0000015 ;
+                rdfs:range obo:BFO_0000203 ;
+                rdfs:label "process has first instant"@en ;
+                skos:definition "x process_has_first_instant y iff x is an instance of Process and y is an instance of Temporal Instant and z is an instance of Temporal Region and y is first_instant_of z, and x occupies_temporal_region z."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/TimeOntology"^^xsd:anyURI .
+
+###  https://www.commoncoreontologies.org/ont00001779
+cco:ont00001779 rdf:type owl:ObjectProperty ;
+                owl:inverseOf cco:ont00001848 ;
+                rdfs:domain obo:BFO_0000015 ;
+                rdfs:range obo:BFO_0000203 ;
+                rdfs:label "process has last instant"@en ;
+                skos:definition "x has_last_instant y iff x is an instance of Process and y is an instance of Temporal Instant and z is an instance of Temporal Region and y is last_instant_of z, and x occupies_temporal_region z."@en ;
+                cco:ont00001760 "https://www.commoncoreontologies.org/TimeOntology"^^xsd:anyURI .
+
+
+###  https://www.commoncoreontologies.org/ont00001779
+cco:ont00001779 rdf:type owl:ObjectProperty ;
+                owl:inverseOf cco:ont00001848 ;
                 rdfs:domain obo:BFO_0000038 ;
                 rdfs:range obo:BFO_0000203 ;
                 rdfs:label "has inside instant"@en ;

--- a/src/cco-modules/TimeOntology.ttl
+++ b/src/cco-modules/TimeOntology.ttl
@@ -44,7 +44,7 @@ cco:ont00001760 rdf:type owl:AnnotationProperty .
 #################################################################
 
 ###  https://www.commoncoreontologies.org/ont00001779
-cco:ont00001779 rdf:type owl:ObjectProperty ;
+cco:ont00000000 rdf:type owl:ObjectProperty ;
                 owl:inverseOf cco:ont00001848 ;
                 rdfs:domain obo:BFO_0000015 ;
                 rdfs:range obo:BFO_0000203 ;
@@ -53,7 +53,7 @@ cco:ont00001779 rdf:type owl:ObjectProperty ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/TimeOntology"^^xsd:anyURI .
 
 ###  https://www.commoncoreontologies.org/ont00001779
-cco:ont00001779 rdf:type owl:ObjectProperty ;
+cco:ont00000000 rdf:type owl:ObjectProperty ;
                 owl:inverseOf cco:ont00001848 ;
                 rdfs:domain obo:BFO_0000015 ;
                 rdfs:range obo:BFO_0000203 ;

--- a/src/cco-modules/TimeOntology.ttl
+++ b/src/cco-modules/TimeOntology.ttl
@@ -44,7 +44,8 @@ cco:ont00001760 rdf:type owl:AnnotationProperty .
 #################################################################
 
 ###  https://www.commoncoreontologies.org/ont00001779
-cco:ont00000000 rdf:type owl:ObjectProperty ;
+cco:ont00002079 rdf:type owl:ObjectProperty ,
+                         owl:FunctionalProperty ;
                 owl:inverseOf cco:ont00001848 ;
                 rdfs:domain obo:BFO_0000015 ;
                 rdfs:range obo:BFO_0000203 ;
@@ -53,8 +54,8 @@ cco:ont00000000 rdf:type owl:ObjectProperty ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/TimeOntology"^^xsd:anyURI .
 
 ###  https://www.commoncoreontologies.org/ont00001779
-cco:ont00000000 rdf:type owl:ObjectProperty ;
-                owl:inverseOf cco:ont00001848 ;
+cco:ont00002080 rdf:type owl:ObjectProperty ,
+                         owl:FunctionalProperty ;
                 rdfs:domain obo:BFO_0000015 ;
                 rdfs:range obo:BFO_0000203 ;
                 rdfs:label "process has last instant"@en ;

--- a/src/cco-modules/TimeOntology.ttl
+++ b/src/cco-modules/TimeOntology.ttl
@@ -50,7 +50,7 @@ cco:ont00002080 rdf:type owl:ObjectProperty ,
                 rdfs:domain obo:BFO_0000015 ;
                 rdfs:range obo:BFO_0000203 ;
                 rdfs:label "process has first instant"@en ;
-                skos:definition "x process_has_first_instant y iff x is an instance of Process and y is an instance of Temporal Instant and z is an instance of Temporal Region and y is first_instant_of z, and x occupies_temporal_region z."@en ;
+                skos:definition "x process_has_first_instant y Def= x is a Process, y is a Temporal Instant, and there is some Temporal Region z such that y is first_instant_of z, and x occupies_temporal_region z"@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/TimeOntology"^^xsd:anyURI .
 
 ###  https://www.commoncoreontologies.org/ont00001779
@@ -59,7 +59,7 @@ cco:ont00002081 rdf:type owl:ObjectProperty ,
                 rdfs:domain obo:BFO_0000015 ;
                 rdfs:range obo:BFO_0000203 ;
                 rdfs:label "process has last instant"@en ;
-                skos:definition "x has_last_instant y iff x is an instance of Process and y is an instance of Temporal Instant and z is an instance of Temporal Region and y is last_instant_of z, and x occupies_temporal_region z."@en ;
+                skos:definition "x process_has_last_instant y Def= x is a Process, y is a Temporal Instant, and there is some Temporal Region z such that y is last_instant_of z, and x occupies_temporal_region z."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/TimeOntology"^^xsd:anyURI .
 
 


### PR DESCRIPTION
Solves #605 

I would appreciate some guidance on how to mint IRIs, I wasn't able to find any in the repo. Similarly to see if this is following other CCO contribution guidelines that I might not be aware of.

Regarding the two properties, I would also like to change the definition to says something along the lines of "x exactly occupies_temporal_region z", that is, to say that the temporal extent of process x is exactly the temporal extent of temporal region z. 

It also sounds reasonable to me that this relation should be functional.