### PR TITLE
Fix #885 Government Domain Border definition

### DIFF
--- a/src/cco-modules/AgentOntology.ttl
+++ b/src/cco-modules/AgentOntology.ttl
@@ -1166,7 +1166,7 @@ cco:ont00000666 rdf:type owl:Class ;
 cco:ont00000685 rdf:type owl:Class ;
                  rdfs:subClassOf cco:ont00000207 ;
                  rdfs:label "Government Domain Border"@en ;
-                 skos:definition "A Geospatial Boundary that is a boundary of some Government Domain."@en ;
+                 skos:definition "A One-Dimensional Geospatial Boundary that is a boundary of some Government Domain."@en ;
                  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Border&oldid=1061275162"^^xsd:anyURI ;
                  cco:ont00001760 "https://www.commoncoreontologies.org/AgentOntology"^^xsd:anyURI .
 

--- a/src/cco-modules/AgentOntology.ttl
+++ b/src/cco-modules/AgentOntology.ttl
@@ -1166,7 +1166,7 @@ cco:ont00000666 rdf:type owl:Class ;
 cco:ont00000685 rdf:type owl:Class ;
                  rdfs:subClassOf cco:ont00000207 ;
                  rdfs:label "Government Domain Border"@en ;
-                 skos:definition "A One-Dimensional Geospatial Boundary that is a boundary of some Government Domain."@en ;
+                 skos:definition "A One-Dimensional Geospatial Boundary of some Government Domain."@en ;
                  cco:ont00001754 "https://en.wikipedia.org/w/index.php?title=Border&oldid=1061275162"^^xsd:anyURI ;
                  cco:ont00001760 "https://www.commoncoreontologies.org/AgentOntology"^^xsd:anyURI .
 


### PR DESCRIPTION
## Summary

- Updates the `Government Domain Border` definition to use `One-Dimensional Geospatial Boundary` as its genus.
- Aligns the definition with the class's asserted parent, `cco:ont00000207`.

Fixes #885.

## Validation

- `git diff --check`
- `java -jar build\lib\robot.jar reason --input src\cco-modules\AgentOntology.ttl --catalog src\cco-modules\catalog-v001.xml --reasoner HermiT`

## Notes

`validate-profile` and the module-level SPARQL verify command report existing `develop` violations unrelated to this one-line definition change.