### PR TITLE
reserve iri for Act of Refrain

### DIFF
--- a/documentation/contributing/iri-registry.csv
+++ b/documentation/contributing/iri-registry.csv
@@ -2090,3 +2090,4 @@ https://www.commoncoreontologies.org/ont00002076,Alexander Cox,03/31/26,https://
 https://www.commoncoreontologies.org/ont00002077,Alexander Cox,03/31/26,https://github.com/CommonCoreOntology/CommonCoreOntologies/issues/680
 https://www.commoncoreontologies.org/ont00002078,Alexander Cox,03/31/26,https://github.com/CommonCoreOntology/CommonCoreOntologies/issues/680
 https://www.commoncoreontologies.org/ont00002079,Alexander Cox,03/31/26,https://github.com/CommonCoreOntology/CommonCoreOntologies/issues/680
+https://www.commoncoreontologies.org/ont00002080,Shane Babcock,06/23/26,https://github.com/CommonCoreOntology/CommonCoreOntologies/issues/786


### PR DESCRIPTION
Reserving IRI for term Act of Refrain.

Term requested in: https://github.com/CommonCoreOntology/CommonCoreOntologies/issues/786

Discussed in: https://github.com/CommonCoreOntology/CommonCoreOntologies/discussions/843