### PR TITLE
Drop Proposition Language Throughout

### DIFF
--- a/src/cco-modules/EventOntology.ttl
+++ b/src/cco-modules/EventOntology.ttl
@@ -889,7 +889,7 @@ cco:ont00000371 rdf:type owl:Class ;
 cco:ont00000379 rdf:type owl:Class ;
                 rdfs:subClassOf cco:ont00000402 ;
                 rdfs:label "Act of Representative Communication"@en ;
-                skos:definition "An Act of Communication that commits a speaker to the truth of the expressed proposition."@en ;
+                skos:definition "An Act of Communication that commits a speaker to the truth of the expressed content."@en ;
                 skos:scopeNote "Examples: affirming, alleging, announcing, answering, attributing, claiming, classifying, concurring, confirming, conjecturing, denying, disagreeing, disclosing, disputing, identifying, informing, insisting, predicting, ranking, reporting, stating, stipulating"@en ;
                 cco:ont00001754 "Derived (loosely) from: John Searle's Speech Acts: An Essay in the Philosophy of Language" ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .
@@ -3187,7 +3187,7 @@ cco:ont00001359 rdf:type owl:Class ;
 cco:ont00001374 rdf:type owl:Class ;
                 rdfs:subClassOf cco:ont00000402 ;
                 rdfs:label "Act of Declarative Communication"@en ;
-                skos:definition "An Act of Communication that changes the reality in accord with the proposition of the declaration."@en ;
+                skos:definition "An Act of Communication that changes the reality in accord with the content of the declaration."@en ;
                 skos:scopeNote "Examples: Baptism, Sentencing a person to imprisonment, Pronouncing a couple husband and wife, Declaring war"@en ;
                 cco:ont00001754 "Derived (loosely) from: John Searle's Speech Acts: An Essay in the Philosophy of Language" ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/EventOntology"^^xsd:anyURI .

--- a/src/cco-modules/InformationEntityOntology.ttl
+++ b/src/cco-modules/InformationEntityOntology.ttl
@@ -1243,7 +1243,7 @@ cco:ont00000965 rdf:type owl:Class ;
                 rdfs:subClassOf cco:ont00000958 ;
                 rdfs:label "Prescriptive Information Content Entity"@en ;
                 skos:altLabel "Directive ICE"@en ;
-                skos:definition "An Information Content Entity that prescribe some Entity."@en ;
+                skos:definition "An Information Content Entity that prescribes some Entity."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 

--- a/src/cco-modules/InformationEntityOntology.ttl
+++ b/src/cco-modules/InformationEntityOntology.ttl
@@ -1152,7 +1152,7 @@ cco:ont00000853 rdf:type owl:Class ;
                 owl:disjointWith cco:ont00000965 ;
                 rdfs:label "Descriptive Information Content Entity"@en ;
                 skos:altLabel "Descriptive ICE"@en ;
-                skos:definition "An Information Content Entity that consists of a set of propositions that describe some Entity."@en ;
+                skos:definition "An Information Content Entity that describes some Entity."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 
@@ -1243,7 +1243,7 @@ cco:ont00000965 rdf:type owl:Class ;
                 rdfs:subClassOf cco:ont00000958 ;
                 rdfs:label "Prescriptive Information Content Entity"@en ;
                 skos:altLabel "Directive ICE"@en ;
-                skos:definition "An Information Content Entity that consists of a set of propositions or images (as in the case of a blueprint) that prescribe some Entity."@en ;
+                skos:definition "An Information Content Entity that prescribe some Entity."@en ;
                 cco:ont00001760 "https://www.commoncoreontologies.org/InformationEntityOntology"^^xsd:anyURI .
 
 


### PR DESCRIPTION
Language existed in four definitions; dropped the clause referencing propositions and kept the remainder of the definitions. The definitions are no worse for losing reference to propositions. 

See discussion https://github.com/CommonCoreOntology/CommonCoreOntologies/issues/296