### PR TITLE
remove geo:asWKT from cco:GeospatialOntology

### DIFF
--- a/.github/deployment/sparql/asserted-iri-only-in-cco-namespace.sparql
+++ b/.github/deployment/sparql/asserted-iri-only-in-cco-namespace.sparql
@@ -1,0 +1,32 @@
+# Title:
+#    Asserted IRI Subjects Must Be in the CCO Namespace
+# Constraint Description:
+#    Any IRI used as the subject of an asserted semantic statement must be in
+#    the CCO namespace. IRIs from dc, dcterms, and skos are ignored because
+#    ROBOT may generate metadata statements about those vocabularies.
+# Severity:
+#     Error
+# Author:
+#	 github.com/jonathanvajda
+
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT DISTINCT ?subject ?predicate ?object ?label ?error
+WHERE {
+  ?subject ?predicate ?object .
+
+  FILTER (isIRI(?subject))
+  FILTER (!STRSTARTS(STR(?subject), "https://www.commoncoreontologies.org/"))
+  FILTER (!STRSTARTS(STR(?subject), "http://purl.org/dc/elements/1.1/"))
+  FILTER (!STRSTARTS(STR(?subject), "http://purl.org/dc/terms/"))
+  FILTER (!STRSTARTS(STR(?subject), "http://www.w3.org/2004/02/skos/core#"))
+  FILTER (!STRSTARTS(STR(?subject), "http://purl.obolibrary.org/obo/BFO_"))
+
+  OPTIONAL { ?subject rdfs:label ?label }
+
+  BIND (CONCAT(
+    "ERROR: IRI subject <", STR(?subject),
+    "> is used in an asserted semantic statement but is not in the CCO namespace."
+  ) AS ?error)
+}
+ORDER BY ?subject ?predicate ?object

--- a/src/cco-modules/GeospatialOntology.ttl
+++ b/src/cco-modules/GeospatialOntology.ttl
@@ -187,15 +187,6 @@ cco:ont00001989 rdf:type owl:ObjectProperty ;
 #    Data properties
 #################################################################
 
-###  http://www.opengis.net/ont/geosparql#asWKT
-<http://www.opengis.net/ont/geosparql#asWKT> rdf:type owl:DatatypeProperty ;
-                                             skos:scopeNote "ISO 19162:2015"@en ;
-                                             rdfs:label "as WKT"@en ;
-                                             skos:definition "A Data Property that has as its range a string formated according to the Well-known text standardization for geometric objects."@en ;
-                                             skos:example "Polygon ((10 10, 10 20, 20 20, 20 15, 10 10))" ;
-                                             cco:ont00001760 "https://www.commoncoreontologies.org/GeospatialOntology"^^xsd:anyURI .
-
-
 ###  https://www.commoncoreontologies.org/ont00001763
 cco:ont00001763 rdf:type owl:DatatypeProperty ;
                  skos:scopeNote "Altitude values typically use kilometers as the Unit of Measurement."@en ;


### PR DESCRIPTION
Resolves an issue https://github.com/CommonCoreOntology/CommonCoreOntologies/issues/946 where an IRI, that is being maintained outside of CCO's namespace, is asserted with annotations and claims that it is curated in CCO GeospatialOntology.